### PR TITLE
chore: add python package gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python cache
+__pycache__/
+
+# Virtual environments
+.venv/
+
+# Tool caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage data
+.coverage
+
+# Build artifacts
+build/
+dist/

--- a/tests/meta/test_gitignore_rules.py
+++ b/tests/meta/test_gitignore_rules.py
@@ -1,46 +1,53 @@
 from pathlib import Path
 
 
-def _read_active_gitignore_lines() -> tuple[str, ...]:
-    repo_root = Path(__file__).resolve().parents[2]
-    gitignore_path = repo_root / ".gitignore"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITIGNORE_PATH = REPO_ROOT / ".gitignore"
 
-    assert gitignore_path.is_file()
+REQUIRED_PATTERNS = (
+    "__pycache__/",
+    ".venv/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    ".coverage",
+    "build/",
+    "dist/",
+)
+
+FORBIDDEN_PATTERNS = (
+    "/",
+    "*",
+    "/*",
+    "**",
+    "/**",
+    "src/",
+    "/src/",
+    "tests/",
+    "/tests/",
+    "*.py",
+)
+
+
+def _read_active_gitignore_lines() -> tuple[str, ...]:
+    assert GITIGNORE_PATH.is_file()
 
     return tuple(
-        line for line in gitignore_path.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")
+        line
+        for line in GITIGNORE_PATH.read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#")
     )
 
 
 def test_gitignore_contains_required_python_package_rules() -> None:
     active_lines = _read_active_gitignore_lines()
 
-    for pattern in (
-        "__pycache__/",
-        ".venv/",
-        ".pytest_cache/",
-        ".mypy_cache/",
-        ".ruff_cache/",
-        ".coverage",
-        "build/",
-        "dist/",
-    ):
+    for pattern in REQUIRED_PATTERNS:
         assert pattern in active_lines, pattern
 
 
 def test_gitignore_does_not_contain_overly_broad_repository_rules() -> None:
     active_lines = _read_active_gitignore_lines()
 
-    for pattern in (
-        "/",
-        "*",
-        "/*",
-        "**",
-        "/**",
-        "src/",
-        "/src/",
-        "tests/",
-        "/tests/",
-        "*.py",
-    ):
+    for pattern in FORBIDDEN_PATTERNS:
         assert pattern not in active_lines, pattern

--- a/tests/meta/test_gitignore_rules.py
+++ b/tests/meta/test_gitignore_rules.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+def _read_active_gitignore_lines() -> tuple[str, ...]:
+    repo_root = Path(__file__).resolve().parents[2]
+    gitignore_path = repo_root / ".gitignore"
+
+    assert gitignore_path.is_file()
+
+    return tuple(
+        line for line in gitignore_path.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")
+    )
+
+
+def test_gitignore_contains_required_python_package_rules() -> None:
+    active_lines = _read_active_gitignore_lines()
+
+    for pattern in (
+        "__pycache__/",
+        ".venv/",
+        ".pytest_cache/",
+        ".mypy_cache/",
+        ".ruff_cache/",
+        ".coverage",
+        "build/",
+        "dist/",
+    ):
+        assert pattern in active_lines, pattern
+
+
+def test_gitignore_does_not_contain_overly_broad_repository_rules() -> None:
+    active_lines = _read_active_gitignore_lines()
+
+    for pattern in (
+        "/",
+        "*",
+        "/*",
+        "**",
+        "/**",
+        "src/",
+        "/src/",
+        "tests/",
+        "/tests/",
+        "*.py",
+    ):
+        assert pattern not in active_lines, pattern


### PR DESCRIPTION
Closes #3

## Summary
- Add a minimal Python-only `.gitignore` covering the 8 required cache, venv, coverage, and build patterns.
- Add meta tests that lock the required ignore entries and forbid overly broad patterns that could hide `src/` or `tests/`.

## TDD evidence
| Stage | Commit | Evidence |
| --- | --- | --- |
| RED | `54945d9` | `tests/meta/test_gitignore_rules.py` fails — `.gitignore` missing |
| GREEN | `c778f70` | minimal `.gitignore` makes both tests pass |
| REFACTOR | `a88e3bb` | extract `REQUIRED_PATTERNS`, `FORBIDDEN_PATTERNS`, helper to module scope; behavior preserved |

## Manual verification

```
$ PYTHONPATH=src python -m pytest -q
6 passed in 0.05s

$ python -m coverage erase && PYTHONPATH=src python -m coverage run --branch -m pytest tests/meta/test_gitignore_rules.py -q
2 passed in 0.03s

$ python -m coverage report --include='tests/meta/test_gitignore_rules.py' --fail-under=100 -m
Name                                 Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------------
tests/meta/test_gitignore_rules.py      16      0      4      0   100%

$ PYTHONPATH=src python -m mypy --strict tests/meta/test_gitignore_rules.py
Success: no issues found in 1 source file

$ python -m ruff check tests/meta/test_gitignore_rules.py
All checks passed!

$ python -m ruff format --check tests/meta/test_gitignore_rules.py
1 file already formatted
```

## .gitignore contents (exact)
```
# Python cache
__pycache__/

# Virtual environments
.venv/

# Tool caches
.pytest_cache/
.mypy_cache/
.ruff_cache/

# Coverage data
.coverage

# Build artifacts
build/
dist/
```

UTF-8, LF only, single trailing LF. Order frozen per design contract.

## Out of scope
- OS / editor / per-developer local overrides (`.DS_Store`, `.vscode/`, `.idea/`, etc.)
- pyproject.toml (#4)
- tooling configs (#5)
- CI workflow (#6)
- Speculative future-tool ignores (`htmlcov/`, `.hypothesis/`, `*.egg-info/`, etc.) — open separately if needed

## Note on coverage flag
Oracle's contract suggested `--cov-include` (does not exist in pytest-cov). Substituted the equivalent `coverage report --include=...` recipe used in PR #48 (GH#2). Same gate semantics: 100% on the new test file only.