### PR TITLE
chore: add minimal pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "abdp"
+version = "0.1.0.dev0"
+description = "A Python framework for reproducible agent-based decision simulation"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { file = "LICENSE" }
+dependencies = []

--- a/tests/meta/test_pyproject_metadata.py
+++ b/tests/meta/test_pyproject_metadata.py
@@ -3,40 +3,52 @@ from typing import Any
 import tomllib
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+EXPECTED_PROJECT_NAME = "abdp"
+EXPECTED_PROJECT_VERSION = "0.1.0.dev0"
+EXPECTED_PROJECT_DESCRIPTION = (
+    "A Python framework for reproducible agent-based decision simulation"
+)
+EXPECTED_PROJECT_README = "README.md"
+EXPECTED_PROJECT_REQUIRES_PYTHON = ">=3.12"
+EXPECTED_PROJECT_LICENSE = {"file": "LICENSE"}
+EXPECTED_PROJECT_DEPENDENCIES: list[str] = []
+
+EXPECTED_BUILD_SYSTEM_REQUIRES = ["setuptools>=61"]
+EXPECTED_BUILD_BACKEND = "setuptools.build_meta"
+
+
 def _load_pyproject() -> dict[str, Any]:
-    repo_root = Path(__file__).resolve().parents[2]
-    pyproject_path = repo_root / "pyproject.toml"
+    assert PYPROJECT_PATH.is_file()
 
-    assert pyproject_path.is_file()
-
-    with pyproject_path.open("rb") as pyproject_file:
+    with PYPROJECT_PATH.open("rb") as pyproject_file:
         return tomllib.load(pyproject_file)
 
 
 def test_pyproject_declares_required_project_metadata() -> None:
     project = _load_pyproject()["project"]
 
-    assert project["name"] == "abdp"
-    assert project["version"] == "0.1.0.dev0"
-    assert project["description"] == "A Python framework for reproducible agent-based decision simulation"
-    assert project["readme"] == "README.md"
-    assert project["requires-python"] == ">=3.12"
-    assert project["license"] == {"file": "LICENSE"}
-    assert project["dependencies"] == []
+    assert project["name"] == EXPECTED_PROJECT_NAME
+    assert project["version"] == EXPECTED_PROJECT_VERSION
+    assert project["description"] == EXPECTED_PROJECT_DESCRIPTION
+    assert project["readme"] == EXPECTED_PROJECT_README
+    assert project["requires-python"] == EXPECTED_PROJECT_REQUIRES_PYTHON
+    assert project["license"] == EXPECTED_PROJECT_LICENSE
+    assert project["dependencies"] == EXPECTED_PROJECT_DEPENDENCIES
 
 
 def test_pyproject_uses_setuptools_build_backend() -> None:
     build_system = _load_pyproject()["build-system"]
 
-    assert build_system["requires"] == ["setuptools>=61"]
-    assert build_system["build-backend"] == "setuptools.build_meta"
+    assert build_system["requires"] == EXPECTED_BUILD_SYSTEM_REQUIRES
+    assert build_system["build-backend"] == EXPECTED_BUILD_BACKEND
 
 
 def test_project_name_matches_src_layout_package_directory() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    project = _load_pyproject()["project"]
-    package_root = repo_root / "src" / project["name"]
+    package_root = REPO_ROOT / "src" / EXPECTED_PROJECT_NAME
 
-    assert project["name"] == package_root.name
+    assert _load_pyproject()["project"]["name"] == package_root.name
     assert package_root.is_dir()
     assert (package_root / "__init__.py").is_file()

--- a/tests/meta/test_pyproject_metadata.py
+++ b/tests/meta/test_pyproject_metadata.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import Any
+import tomllib
+
+
+def _load_pyproject() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    pyproject_path = repo_root / "pyproject.toml"
+
+    assert pyproject_path.is_file()
+
+    with pyproject_path.open("rb") as pyproject_file:
+        return tomllib.load(pyproject_file)
+
+
+def test_pyproject_declares_required_project_metadata() -> None:
+    project = _load_pyproject()["project"]
+
+    assert project["name"] == "abdp"
+    assert project["version"] == "0.1.0.dev0"
+    assert project["description"] == "A Python framework for reproducible agent-based decision simulation"
+    assert project["readme"] == "README.md"
+    assert project["requires-python"] == ">=3.12"
+    assert project["license"] == {"file": "LICENSE"}
+    assert project["dependencies"] == []
+
+
+def test_pyproject_uses_setuptools_build_backend() -> None:
+    build_system = _load_pyproject()["build-system"]
+
+    assert build_system["requires"] == ["setuptools>=61"]
+    assert build_system["build-backend"] == "setuptools.build_meta"
+
+
+def test_project_name_matches_src_layout_package_directory() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    project = _load_pyproject()["project"]
+    package_root = repo_root / "src" / project["name"]
+
+    assert project["name"] == package_root.name
+    assert package_root.is_dir()
+    assert (package_root / "__init__.py").is_file()


### PR DESCRIPTION
Closes #4

## Summary
- Add minimal PEP 621 project metadata in `pyproject.toml` (name=abdp, version=0.1.0.dev0, description=tagline, readme=README.md, requires-python=>=3.12, license={file=LICENSE}, dependencies=[]).
- Use setuptools as the PEP 517 build backend; rely on implicit `src/` package auto-discovery for `abdp` (no `[tool.*]` sections — explicitly out of scope per issue).
- Add 3 meta tests locking metadata, build backend, and src-layout discovery preconditions.

## TDD evidence
| Stage | Commit | Evidence |
| --- | --- | --- |
| RED | `d5079d5` | `tests/meta/test_pyproject_metadata.py` fails — `pyproject.toml` missing |
| GREEN | `766f5ba` | minimal `pyproject.toml` makes all 3 tests pass |
| REFACTOR | `06dbe34` | extract constants + `_load_pyproject()` helper to module scope; behavior preserved |

## Manual verification

```
$ PYTHONPATH=src python -m pytest -q
9 passed in 0.05s

$ python -m coverage erase && PYTHONPATH=src python -m coverage run --branch -m pytest tests/meta/test_pyproject_metadata.py -q
3 passed in 0.02s

$ python -m coverage report --include='tests/meta/test_pyproject_metadata.py' --fail-under=100 -m
Name                                    Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------------
tests/meta/test_pyproject_metadata.py      36      0      0      0   100%

$ PYTHONPATH=src python -m mypy --strict tests/meta/test_pyproject_metadata.py
Success: no issues found in 1 source file

$ python -m ruff check tests/meta/test_pyproject_metadata.py
All checks passed!

$ python -m ruff format --check tests/meta/test_pyproject_metadata.py
1 file already formatted
```

## pyproject.toml (exact)
```toml
[build-system]
requires = ["setuptools>=61"]
build-backend = "setuptools.build_meta"

[project]
name = "abdp"
version = "0.1.0.dev0"
description = "A Python framework for reproducible agent-based decision simulation"
readme = "README.md"
requires-python = ">=3.12"
license = { file = "LICENSE" }
dependencies = []
```

## Out of scope
- `[tool.*]` config sections (deferred to #5)
- CI commands (#6)
- authors / classifiers / keywords / URLs
- `python -m build` / install / wheel smoke tests
- SPDX license expression (PEP 639) — using legacy `{file = "LICENSE"}` for tooling compat