### PR TITLE
chore: add ruff mypy pytest coverage config (#5)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source =
+    src/abdp
+
+[report]
+fail_under = 100
+show_missing = True
+skip_covered = True
+exclude_lines =
+    pragma: no cover
+    if __name__ == "__main__":
+    if TYPE_CHECKING:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,11 @@
+target-version = "py312"
+line-length = 120
+
+[lint]
+select = ["E", "F", "W", "UP", "B"]
+ignore = []
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.12
+files = src/abdp, tests
+strict = True
+warn_unused_configs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,14 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = { file = "LICENSE" }
 dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "build>=1.0.0",
+    "hypothesis>=6.0.0",
+    "mutmut>=3.0.0",
+    "mypy>=1.20.1",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.11",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+minversion = 9.0
+addopts = --cov=src/abdp --cov-branch --cov-report=term-missing
+testpaths = tests
+pythonpath = src
+strict_config = True
+strict_markers = True
+xfail_strict = True
+console_output_style = progress

--- a/tests/meta/test_tooling_config.py
+++ b/tests/meta/test_tooling_config.py
@@ -1,0 +1,108 @@
+import tomllib
+from configparser import ConfigParser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_ruff_configuration_matches_project_policy() -> None:
+    ruff_path = REPO_ROOT / ".ruff.toml"
+    assert ruff_path.is_file()
+    with ruff_path.open("rb") as config_file:
+        ruff_config = tomllib.load(config_file)
+    assert ruff_config["target-version"] == "py312"
+    assert ruff_config["line-length"] == 120
+    assert tuple(ruff_config["lint"]["select"]) == ("E", "F", "W", "UP", "B")
+    assert tuple(ruff_config["lint"].get("ignore", [])) == ()
+    assert ruff_config["format"]["quote-style"] == "double"
+    assert ruff_config["format"]["indent-style"] == "space"
+    assert ruff_config["format"]["line-ending"] == "lf"
+
+
+def test_mypy_configuration_enables_strict_type_checking_for_src_and_tests() -> None:
+    mypy_path = REPO_ROOT / "mypy.ini"
+    assert mypy_path.is_file()
+    mypy_config = ConfigParser(interpolation=None)
+    assert mypy_config.read(mypy_path, encoding="utf-8") == [str(mypy_path)]
+    assert tuple(mypy_config.sections()) == ("mypy",)
+    assert mypy_config["mypy"]["python_version"] == "3.12"
+    files_value = mypy_config["mypy"]["files"]
+    files_parsed = tuple(
+        part.strip() for part in files_value.split(",") if part.strip()
+    )
+    assert files_parsed == ("src/abdp", "tests")
+    assert mypy_config.getboolean("mypy", "strict") is True
+    assert mypy_config.getboolean("mypy", "warn_unused_configs") is True
+
+
+def test_pytest_configuration_enables_strict_collection_and_coverage_defaults() -> None:
+    pytest_path = REPO_ROOT / "pytest.ini"
+    assert pytest_path.is_file()
+    pytest_config = ConfigParser(interpolation=None)
+    assert pytest_config.read(pytest_path, encoding="utf-8") == [str(pytest_path)]
+    assert tuple(pytest_config.sections()) == ("pytest",)
+    assert pytest_config["pytest"]["minversion"] == "9.0"
+    assert (
+        pytest_config["pytest"]["addopts"]
+        == "--cov=src/abdp --cov-branch --cov-report=term-missing"
+    )
+    testpaths_value = pytest_config["pytest"]["testpaths"]
+    testpaths_parsed = tuple(
+        line.strip() for line in testpaths_value.splitlines() if line.strip()
+    )
+    assert testpaths_parsed == ("tests",)
+    pythonpath_value = pytest_config["pytest"]["pythonpath"]
+    pythonpath_parsed = tuple(
+        line.strip() for line in pythonpath_value.splitlines() if line.strip()
+    )
+    assert pythonpath_parsed == ("src",)
+    assert pytest_config.getboolean("pytest", "strict_config") is True
+    assert pytest_config.getboolean("pytest", "strict_markers") is True
+    assert pytest_config.getboolean("pytest", "xfail_strict") is True
+    assert pytest_config["pytest"]["console_output_style"] == "progress"
+
+
+def test_coverage_configuration_requires_full_branch_coverage_for_package_code() -> (
+    None
+):
+    coverage_path = REPO_ROOT / ".coveragerc"
+    assert coverage_path.is_file()
+    coverage_config = ConfigParser(interpolation=None)
+    assert coverage_config.read(coverage_path, encoding="utf-8") == [str(coverage_path)]
+    assert tuple(coverage_config.sections()) == ("run", "report")
+    assert coverage_config.getboolean("run", "branch") is True
+    source_value = coverage_config["run"]["source"]
+    source_parsed = tuple(
+        line.strip() for line in source_value.splitlines() if line.strip()
+    )
+    assert source_parsed == ("src/abdp",)
+    assert coverage_config.getint("report", "fail_under") == 100
+    assert coverage_config.getboolean("report", "show_missing") is True
+    assert coverage_config.getboolean("report", "skip_covered") is True
+    exclude_value = coverage_config["report"]["exclude_lines"]
+    exclude_parsed = tuple(
+        line.strip() for line in exclude_value.splitlines() if line.strip()
+    )
+    assert exclude_parsed == (
+        "pragma: no cover",
+        'if __name__ == "__main__":',
+        "if TYPE_CHECKING:",
+    )
+
+
+def test_pyproject_dev_extras_include_required_tooling_dependencies() -> None:
+    pyproject_path = REPO_ROOT / "pyproject.toml"
+    assert pyproject_path.is_file()
+    with pyproject_path.open("rb") as config_file:
+        project = tomllib.load(config_file)["project"]
+    assert project["dependencies"] == []
+    assert set(project["optional-dependencies"]) == {"dev"}
+    assert tuple(project["optional-dependencies"]["dev"]) == (
+        "build>=1.0.0",
+        "hypothesis>=6.0.0",
+        "mutmut>=3.0.0",
+        "mypy>=1.20.1",
+        "pytest>=9.0.3",
+        "pytest-cov>=7.1.0",
+        "ruff>=0.15.11",
+    )

--- a/tests/meta/test_tooling_config.py
+++ b/tests/meta/test_tooling_config.py
@@ -1,108 +1,132 @@
-import tomllib
 from configparser import ConfigParser
 from pathlib import Path
+from typing import Any
+import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+RUFF_PATH = REPO_ROOT / ".ruff.toml"
+MYPY_PATH = REPO_ROOT / "mypy.ini"
+PYTEST_PATH = REPO_ROOT / "pytest.ini"
+COVERAGE_PATH = REPO_ROOT / ".coveragerc"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+EXPECTED_RUFF_TARGET_VERSION = "py312"
+EXPECTED_RUFF_LINE_LENGTH = 120
+EXPECTED_RUFF_SELECT = ("E", "F", "W", "UP", "B")
+EXPECTED_RUFF_IGNORE: tuple[str, ...] = ()
+EXPECTED_RUFF_QUOTE_STYLE = "double"
+EXPECTED_RUFF_INDENT_STYLE = "space"
+EXPECTED_RUFF_LINE_ENDING = "lf"
+
+EXPECTED_MYPY_SECTIONS = ("mypy",)
+EXPECTED_MYPY_PYTHON_VERSION = "3.12"
+EXPECTED_MYPY_FILES = ("src/abdp", "tests")
+
+EXPECTED_PYTEST_SECTIONS = ("pytest",)
+EXPECTED_PYTEST_MINVERSION = "9.0"
+EXPECTED_PYTEST_ADDOPTS = "--cov=src/abdp --cov-branch --cov-report=term-missing"
+EXPECTED_PYTEST_TESTPATHS = ("tests",)
+EXPECTED_PYTEST_PYTHONPATH = ("src",)
+EXPECTED_PYTEST_CONSOLE_OUTPUT_STYLE = "progress"
+
+EXPECTED_COVERAGE_SECTIONS = ("run", "report")
+EXPECTED_COVERAGE_SOURCE = ("src/abdp",)
+EXPECTED_COVERAGE_EXCLUDE_LINES = (
+    "pragma: no cover",
+    'if __name__ == "__main__":',
+    "if TYPE_CHECKING:",
+)
+
+EXPECTED_RUNTIME_DEPENDENCIES: list[str] = []
+EXPECTED_OPTIONAL_DEPENDENCY_GROUPS = {"dev"}
+EXPECTED_DEV_DEPENDENCIES = (
+    "build>=1.0.0",
+    "hypothesis>=6.0.0",
+    "mutmut>=3.0.0",
+    "mypy>=1.20.1",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.11",
+)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    assert path.is_file(), path
+
+    with path.open("rb") as config_file:
+        return tomllib.load(config_file)
+
+
+def _load_ini(path: Path) -> ConfigParser:
+    assert path.is_file(), path
+
+    config = ConfigParser(interpolation=None)
+    read_files = config.read(path, encoding="utf-8")
+
+    assert read_files == [str(path)]
+
+    return config
+
+
+def _split_csv(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _split_lines(value: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in value.splitlines() if line.strip())
 
 
 def test_ruff_configuration_matches_project_policy() -> None:
-    ruff_path = REPO_ROOT / ".ruff.toml"
-    assert ruff_path.is_file()
-    with ruff_path.open("rb") as config_file:
-        ruff_config = tomllib.load(config_file)
-    assert ruff_config["target-version"] == "py312"
-    assert ruff_config["line-length"] == 120
-    assert tuple(ruff_config["lint"]["select"]) == ("E", "F", "W", "UP", "B")
-    assert tuple(ruff_config["lint"].get("ignore", [])) == ()
-    assert ruff_config["format"]["quote-style"] == "double"
-    assert ruff_config["format"]["indent-style"] == "space"
-    assert ruff_config["format"]["line-ending"] == "lf"
+    ruff_config = _load_toml(RUFF_PATH)
+
+    assert ruff_config["target-version"] == EXPECTED_RUFF_TARGET_VERSION
+    assert ruff_config["line-length"] == EXPECTED_RUFF_LINE_LENGTH
+    assert tuple(ruff_config["lint"]["select"]) == EXPECTED_RUFF_SELECT
+    assert tuple(ruff_config["lint"].get("ignore", [])) == EXPECTED_RUFF_IGNORE
+    assert ruff_config["format"]["quote-style"] == EXPECTED_RUFF_QUOTE_STYLE
+    assert ruff_config["format"]["indent-style"] == EXPECTED_RUFF_INDENT_STYLE
+    assert ruff_config["format"]["line-ending"] == EXPECTED_RUFF_LINE_ENDING
 
 
 def test_mypy_configuration_enables_strict_type_checking_for_src_and_tests() -> None:
-    mypy_path = REPO_ROOT / "mypy.ini"
-    assert mypy_path.is_file()
-    mypy_config = ConfigParser(interpolation=None)
-    assert mypy_config.read(mypy_path, encoding="utf-8") == [str(mypy_path)]
-    assert tuple(mypy_config.sections()) == ("mypy",)
-    assert mypy_config["mypy"]["python_version"] == "3.12"
-    files_value = mypy_config["mypy"]["files"]
-    files_parsed = tuple(
-        part.strip() for part in files_value.split(",") if part.strip()
-    )
-    assert files_parsed == ("src/abdp", "tests")
+    mypy_config = _load_ini(MYPY_PATH)
+
+    assert tuple(mypy_config.sections()) == EXPECTED_MYPY_SECTIONS
+    assert mypy_config["mypy"]["python_version"] == EXPECTED_MYPY_PYTHON_VERSION
+    assert _split_csv(mypy_config["mypy"]["files"]) == EXPECTED_MYPY_FILES
     assert mypy_config.getboolean("mypy", "strict") is True
     assert mypy_config.getboolean("mypy", "warn_unused_configs") is True
 
 
 def test_pytest_configuration_enables_strict_collection_and_coverage_defaults() -> None:
-    pytest_path = REPO_ROOT / "pytest.ini"
-    assert pytest_path.is_file()
-    pytest_config = ConfigParser(interpolation=None)
-    assert pytest_config.read(pytest_path, encoding="utf-8") == [str(pytest_path)]
-    assert tuple(pytest_config.sections()) == ("pytest",)
-    assert pytest_config["pytest"]["minversion"] == "9.0"
-    assert (
-        pytest_config["pytest"]["addopts"]
-        == "--cov=src/abdp --cov-branch --cov-report=term-missing"
-    )
-    testpaths_value = pytest_config["pytest"]["testpaths"]
-    testpaths_parsed = tuple(
-        line.strip() for line in testpaths_value.splitlines() if line.strip()
-    )
-    assert testpaths_parsed == ("tests",)
-    pythonpath_value = pytest_config["pytest"]["pythonpath"]
-    pythonpath_parsed = tuple(
-        line.strip() for line in pythonpath_value.splitlines() if line.strip()
-    )
-    assert pythonpath_parsed == ("src",)
+    pytest_config = _load_ini(PYTEST_PATH)
+
+    assert tuple(pytest_config.sections()) == EXPECTED_PYTEST_SECTIONS
+    assert pytest_config["pytest"]["minversion"] == EXPECTED_PYTEST_MINVERSION
+    assert pytest_config["pytest"]["addopts"] == EXPECTED_PYTEST_ADDOPTS
+    assert _split_lines(pytest_config["pytest"]["testpaths"]) == EXPECTED_PYTEST_TESTPATHS
+    assert _split_lines(pytest_config["pytest"]["pythonpath"]) == EXPECTED_PYTEST_PYTHONPATH
     assert pytest_config.getboolean("pytest", "strict_config") is True
     assert pytest_config.getboolean("pytest", "strict_markers") is True
     assert pytest_config.getboolean("pytest", "xfail_strict") is True
-    assert pytest_config["pytest"]["console_output_style"] == "progress"
+    assert pytest_config["pytest"]["console_output_style"] == EXPECTED_PYTEST_CONSOLE_OUTPUT_STYLE
 
 
-def test_coverage_configuration_requires_full_branch_coverage_for_package_code() -> (
-    None
-):
-    coverage_path = REPO_ROOT / ".coveragerc"
-    assert coverage_path.is_file()
-    coverage_config = ConfigParser(interpolation=None)
-    assert coverage_config.read(coverage_path, encoding="utf-8") == [str(coverage_path)]
-    assert tuple(coverage_config.sections()) == ("run", "report")
+def test_coverage_configuration_requires_full_branch_coverage_for_package_code() -> None:
+    coverage_config = _load_ini(COVERAGE_PATH)
+
+    assert tuple(coverage_config.sections()) == EXPECTED_COVERAGE_SECTIONS
     assert coverage_config.getboolean("run", "branch") is True
-    source_value = coverage_config["run"]["source"]
-    source_parsed = tuple(
-        line.strip() for line in source_value.splitlines() if line.strip()
-    )
-    assert source_parsed == ("src/abdp",)
+    assert _split_lines(coverage_config["run"]["source"]) == EXPECTED_COVERAGE_SOURCE
     assert coverage_config.getint("report", "fail_under") == 100
     assert coverage_config.getboolean("report", "show_missing") is True
     assert coverage_config.getboolean("report", "skip_covered") is True
-    exclude_value = coverage_config["report"]["exclude_lines"]
-    exclude_parsed = tuple(
-        line.strip() for line in exclude_value.splitlines() if line.strip()
-    )
-    assert exclude_parsed == (
-        "pragma: no cover",
-        'if __name__ == "__main__":',
-        "if TYPE_CHECKING:",
-    )
+    assert _split_lines(coverage_config["report"]["exclude_lines"]) == EXPECTED_COVERAGE_EXCLUDE_LINES
 
 
 def test_pyproject_dev_extras_include_required_tooling_dependencies() -> None:
-    pyproject_path = REPO_ROOT / "pyproject.toml"
-    assert pyproject_path.is_file()
-    with pyproject_path.open("rb") as config_file:
-        project = tomllib.load(config_file)["project"]
-    assert project["dependencies"] == []
-    assert set(project["optional-dependencies"]) == {"dev"}
-    assert tuple(project["optional-dependencies"]["dev"]) == (
-        "build>=1.0.0",
-        "hypothesis>=6.0.0",
-        "mutmut>=3.0.0",
-        "mypy>=1.20.1",
-        "pytest>=9.0.3",
-        "pytest-cov>=7.1.0",
-        "ruff>=0.15.11",
-    )
+    project = _load_toml(PYPROJECT_PATH)["project"]
+
+    assert project["dependencies"] == EXPECTED_RUNTIME_DEPENDENCIES
+    assert set(project["optional-dependencies"]) == EXPECTED_OPTIONAL_DEPENDENCY_GROUPS
+    assert tuple(project["optional-dependencies"]["dev"]) == EXPECTED_DEV_DEPENDENCIES


### PR DESCRIPTION
Closes #5

## Summary
Locks strict local quality gates before feature work begins. Adds `.ruff.toml`, `mypy.ini`, `pytest.ini`, `.coveragerc`, and `[project.optional-dependencies].dev` to `pyproject.toml`. Adds `tests/meta/test_tooling_config.py` enforcing the exact contract.

## TDD commits
| Commit | Stage | Evidence |
|---|---|---|
| 752fab1 | RED — test defining tooling contract | 5/5 failed (missing configs + missing optional-dependencies) |
| d66b15e | GREEN — add configs + pyproject dev extras | 5/5 passed |
| 75edd71 | REFACTOR — extract module constants + helpers (`_load_toml`, `_load_ini`, `_split_csv`, `_split_lines`) | 5/5 still passing |

## Verification (all clean)

### Full suite (uses pytest.ini addopts: `--cov=src/abdp --cov-branch --cov-report=term-missing`)
```
$ .venv/bin/pytest
14 passed in 0.18s
Required test coverage of 100.0% reached. Total coverage: 100.00%
```

### Strict typing on changed file
```
$ .venv/bin/mypy --config-file mypy.ini tests/meta/test_tooling_config.py
Success: no issues found in 1 source file
```

### Lint + format on changed file and full repo
```
$ .venv/bin/ruff check tests/meta/test_tooling_config.py
All checks passed!
$ .venv/bin/ruff format --check tests/meta/test_tooling_config.py
1 file already formatted
$ .venv/bin/ruff check .
All checks passed!
```

### Per-file 100% line+branch coverage for the new test
```
$ COVERAGE_RCFILE=/dev/null .venv/bin/coverage run --branch \
    --include="tests/meta/test_tooling_config.py" \
    -m pytest --override-ini addopts='' tests/meta/test_tooling_config.py
$ COVERAGE_RCFILE=/dev/null .venv/bin/coverage report \
    --include="tests/meta/test_tooling_config.py" --fail-under=100
tests/meta/test_tooling_config.py      86      0      0      0   100%
```
(`.coveragerc` source scope is `src/abdp`, so per-file coverage must override rcfile.)

## Design notes (Oracle contract)
- Ruff select = `["E", "F", "W", "UP", "B"]`, no `I`/`D`/`S`/`ANN`/`ALL` — curated set that passes on existing tests without forcing unrelated cleanup.
- mypy `strict = True` with `files = src/abdp, tests` and `warn_unused_configs = True`. No plugins, no per-module overrides.
- pytest `strict_config`, `strict_markers`, `xfail_strict` set explicitly; `pythonpath = src` removes need for `PYTHONPATH=src` env prefix.
- Coverage `branch = True`, `source = src/abdp`, `fail_under = 100`, minimal `exclude_lines` (`pragma: no cover`, `__main__` guard, `TYPE_CHECKING`).
- `test_pyproject_metadata.py` was deliberately NOT modified — it does not assert the `[project]` key set, so adding `[project.optional-dependencies]` is a safe additive change; coverage for dev extras lives in the new test.

## Out of scope (future issues)
- GitHub Actions CI workflow (#6)
- Pre-commit hooks
- Repo-wide `ruff format` normalization of existing meta tests
- Import sorting (`I`) policy