### PR TITLE
chore: add pull request ci workflow (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: python -m pip install -e .[dev]
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Mypy strict
+        run: mypy --strict --config-file mypy.ini src/abdp tests
+
+      - name: Pytest with coverage
+        run: pytest
+
+      - name: Mutmut
+        run: mutmut run
+
+      - name: Build package
+        run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,14 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.11",
 ]
+
+[tool.mutmut]
+paths_to_mutate = ["src/abdp/"]
+pytest_add_cli_args_test_selection = ["tests/unit/"]
+also_copy = ["pytest.ini"]
+do_not_mutate = [
+    "src/abdp/__init__.py",
+    "src/abdp/core/__init__.py",
+    "src/abdp/data/__init__.py",
+    "src/abdp/simulation/__init__.py",
+]

--- a/src/abdp/__init__.py
+++ b/src/abdp/__init__.py
@@ -1,1 +1,5 @@
 """"""
+
+from abdp.version import __version__, get_version
+
+__all__ = ["__version__", "get_version"]

--- a/src/abdp/version.py
+++ b/src/abdp/version.py
@@ -1,0 +1,5 @@
+def get_version() -> str:
+    return "0.1.0.dev0"
+
+
+__version__ = get_version()

--- a/tests/meta/test_ci_workflow.py
+++ b/tests/meta/test_ci_workflow.py
@@ -103,13 +103,25 @@ EXPECTED_STEP_BLOCKS = (
 )
 
 
+def _read_workflow_text() -> str:
+    assert WORKFLOW_PATH.is_file(), WORKFLOW_PATH
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
+    start = 0
+    for snippet in snippets:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
 def test_ci_workflow_file_exists() -> None:
     assert WORKFLOW_PATH.is_file()
 
 
 def test_ci_workflow_declares_expected_top_level_configuration() -> None:
-    assert WORKFLOW_PATH.is_file()
-    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow_text = _read_workflow_text()
 
     assert EXPECTED_WORKFLOW_HEADER in workflow_text
     assert EXPECTED_TRIGGER_BLOCK in workflow_text
@@ -119,11 +131,6 @@ def test_ci_workflow_declares_expected_top_level_configuration() -> None:
 
 
 def test_ci_workflow_declares_required_steps_in_order() -> None:
-    assert WORKFLOW_PATH.is_file()
-    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow_text = _read_workflow_text()
 
-    start = 0
-    for snippet in EXPECTED_STEP_BLOCKS:
-        index = workflow_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(workflow_text, EXPECTED_STEP_BLOCKS)

--- a/tests/meta/test_ci_workflow.py
+++ b/tests/meta/test_ci_workflow.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+EXPECTED_WORKFLOW_HEADER = "name: ci"
+
+EXPECTED_TRIGGER_BLOCK = "\n".join(
+    (
+        "on:",
+        "  push:",
+        "    branches:",
+        "      - main",
+        "  pull_request:",
+        "    branches:",
+        "      - main",
+    )
+)
+
+EXPECTED_PERMISSION_BLOCK = "\n".join(
+    (
+        "permissions:",
+        "  contents: read",
+    )
+)
+
+EXPECTED_CONCURRENCY_BLOCK = "\n".join(
+    (
+        "concurrency:",
+        "  group: ci-${{ github.workflow }}-${{ github.ref }}",
+        "  cancel-in-progress: true",
+    )
+)
+
+EXPECTED_JOB_BLOCK = "\n".join(
+    (
+        "jobs:",
+        "  ci:",
+        "    name: ci",
+        "    runs-on: ubuntu-latest",
+    )
+)
+
+EXPECTED_STEP_BLOCKS = (
+    "\n".join(
+        (
+            "      - name: Checkout repository",
+            "        uses: actions/checkout@v4",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Setup Python 3.12",
+            "        uses: actions/setup-python@v5",
+            "        with:",
+            '          python-version: "3.12"',
+            '          cache: "pip"',
+            "          cache-dependency-path: pyproject.toml",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Install dependencies",
+            "        run: python -m pip install -e .[dev]",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Ruff format check",
+            "        run: ruff format --check .",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Ruff check",
+            "        run: ruff check .",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Mypy strict",
+            "        run: mypy --strict --config-file mypy.ini src/abdp tests",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Pytest with coverage",
+            "        run: pytest",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Mutmut",
+            "        run: mutmut run",
+        )
+    ),
+    "\n".join(
+        (
+            "      - name: Build package",
+            "        run: python -m build",
+        )
+    ),
+)
+
+
+def test_ci_workflow_file_exists() -> None:
+    assert WORKFLOW_PATH.is_file()
+
+
+def test_ci_workflow_declares_expected_top_level_configuration() -> None:
+    assert WORKFLOW_PATH.is_file()
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert EXPECTED_WORKFLOW_HEADER in workflow_text
+    assert EXPECTED_TRIGGER_BLOCK in workflow_text
+    assert EXPECTED_PERMISSION_BLOCK in workflow_text
+    assert EXPECTED_CONCURRENCY_BLOCK in workflow_text
+    assert EXPECTED_JOB_BLOCK in workflow_text
+
+
+def test_ci_workflow_declares_required_steps_in_order() -> None:
+    assert WORKFLOW_PATH.is_file()
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    start = 0
+    for snippet in EXPECTED_STEP_BLOCKS:
+        index = workflow_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)

--- a/tests/meta/test_gitignore_rules.py
+++ b/tests/meta/test_gitignore_rules.py
@@ -33,9 +33,7 @@ def _read_active_gitignore_lines() -> tuple[str, ...]:
     assert GITIGNORE_PATH.is_file()
 
     return tuple(
-        line
-        for line in GITIGNORE_PATH.read_text(encoding="utf-8").splitlines()
-        if line and not line.startswith("#")
+        line for line in GITIGNORE_PATH.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")
     )
 
 

--- a/tests/meta/test_pyproject_metadata.py
+++ b/tests/meta/test_pyproject_metadata.py
@@ -8,9 +8,7 @@ PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 
 EXPECTED_PROJECT_NAME = "abdp"
 EXPECTED_PROJECT_VERSION = "0.1.0.dev0"
-EXPECTED_PROJECT_DESCRIPTION = (
-    "A Python framework for reproducible agent-based decision simulation"
-)
+EXPECTED_PROJECT_DESCRIPTION = "A Python framework for reproducible agent-based decision simulation"
 EXPECTED_PROJECT_README = "README.md"
 EXPECTED_PROJECT_REQUIRES_PYTHON = ">=3.12"
 EXPECTED_PROJECT_LICENSE = {"file": "LICENSE"}

--- a/tests/meta/test_repo_scaffold.py
+++ b/tests/meta/test_repo_scaffold.py
@@ -5,7 +5,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 EXPECTED_README_TEXT = (
-    "# agent-based-decision-pipeline\n\n" "A Python framework for reproducible agent-based decision simulation"
+    "# agent-based-decision-pipeline\n\nA Python framework for reproducible agent-based decision simulation"
 )
 
 REQUIRED_SCAFFOLD_PATHS = (

--- a/tests/unit/test_package_version.py
+++ b/tests/unit/test_package_version.py
@@ -1,0 +1,11 @@
+def test_abdp_has_expected_version() -> None:
+    from abdp import __version__
+
+    assert __version__ == "0.1.0.dev0"
+
+
+def test_get_version_returns_public_version() -> None:
+    from abdp import __version__, get_version
+
+    assert get_version() == "0.1.0.dev0"
+    assert get_version() == __version__


### PR DESCRIPTION
Closes #6

## Summary

Adds `.github/workflows/ci.yml` so every push to `main` and every pull
request runs the full quality gate matrix: ruff format, ruff lint,
mypy --strict, pytest (100% branch coverage), mutmut, and `python -m build`.

Also wires the minimum configuration/source needed to make the workflow
honest:

- `[tool.mutmut]` block scoping mutation tests to `src/abdp/` with
  `tests/unit/` as the test selection, and `pytest.ini` in `also_copy`.
- `abdp.__version__` + `get_version()` giving mutmut a killable mutant
  (module-level constants alone yield zero killable mutants in mutmut
  3.5.0).
- New `tests/unit/` tree for code-under-test unit tests, keeping
  repo-structure meta tests isolated in `tests/meta/` so mutmut's
  sandbox does not try to execute them.
- Cosmetic `ruff format` fixes to three pre-existing meta tests so that
  `ruff format --check .` is green repo-wide.

## TDD Evidence

| Commit | Purpose |
|---|---|
| `d524156` test: add failing ci workflow meta test (#6) | RED — `tests/meta/test_ci_workflow.py` fails because `.github/workflows/ci.yml` does not exist |
| `26de56e` chore: add pull request ci workflow (#6) | GREEN — adds ci.yml, mutmut config, `__version__` + `get_version`, unit test, and ruff-format fixes so every gate passes |
| `2dc07dd` refactor: extract ci workflow meta-test helpers (#6) | REFACTOR — extract `_read_workflow_text()` and `_assert_snippets_in_order()` helpers, no behavior change |

## Local Verification

\`\`\`
ruff format --check .   → 11 files already formatted
ruff check .            → All checks passed!
mypy --strict .         → Success: no issues found in 11 source files
pytest -q               → 19 passed, total coverage 100%
mutmut run              → 4 files mutated, MUTMUT_EXIT=0
\`\`\`

Per-file branch coverage of every `src/abdp/**/__init__.py` reaches
100% via the \`COVERAGE_RCFILE=/dev/null coverage run --branch --include=<file>\` recipe.

## Design Notes

Four rounds of oracle design review in session \`ses_24f30e9daffen3pj0Q5F0Iol0k\` shaped this PR:

1. Meta tests that inspect the repo layout cannot live inside mutmut's
   sandbox → split into `tests/meta/` vs `tests/unit/`, scoped mutmut
   to `tests/unit/`.
2. Mutmut 3.5.0 mutates function/method bodies only; a bare
   `__version__ = "..."` yields 0 killable mutants, so a trivial
   `get_version()` function was added together with a test that
   invokes it.
3. `also_copy = ["pytest.ini"]` is required so the mutmut sandbox
   honors pytest configuration.
4. `ruff format --check .` covers the whole repo, so the three legacy
   meta tests had to be reformatted in the GREEN commit rather than
   left to drift.