### PR TITLE
docs: add agents workflow contract (#7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS
+
+## Oracle-first workflow
+
+1. Oracle consult before implementation is required.
+2. TDD strict: RED -> GREEN -> REFACTOR.
+3. Use three separate commits for RED, GREEN, and REFACTOR, and each commit message must reference the issue number.
+4. Oracle 100/100 before merge is required.
+
+## Engineering rules
+
+- Size each issue so it fits one focused pull request; if it spans unrelated concerns or cannot be finished in one RED -> GREEN -> REFACTOR cycle, split it first.
+- Write meaningful docstrings for public Python modules, classes, and functions, and preserve intentionally empty package docstrings where the repo tests require them.
+- No `Any` without justification.
+- No `# type: ignore`.
+
+## Standard v0.1 checklist
+
+- Oracle 100/100 before merge
+- all tests pass
+- mypy strict clean
+- ruff clean
+- 100% line coverage on new code

--- a/tests/meta/test_agents_file.py
+++ b/tests/meta/test_agents_file.py
@@ -48,39 +48,37 @@ EXPECTED_STANDARD_CHECKLIST = (
 )
 
 
+def _read_agents_text() -> str:
+    assert AGENTS_PATH.is_file(), AGENTS_PATH
+    return AGENTS_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
+    start = 0
+    for snippet in snippets:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
 def test_agents_file_exists() -> None:
     assert AGENTS_PATH.is_file()
 
 
 def test_agents_file_declares_required_sections() -> None:
-    assert AGENTS_PATH.is_file(), AGENTS_PATH
-    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+    agents_text = _read_agents_text()
 
     assert EXPECTED_TITLE in agents_text
-    start = 0
-    for snippet in EXPECTED_SECTION_HEADINGS:
-        index = agents_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(agents_text, EXPECTED_SECTION_HEADINGS)
 
 
 def test_agents_file_declares_oracle_first_rules_and_repo_constraints() -> None:
-    assert AGENTS_PATH.is_file(), AGENTS_PATH
-    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+    agents_text = _read_agents_text()
 
-    start = 0
-    for snippet in EXPECTED_RULE_SNIPPETS:
-        index = agents_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(agents_text, EXPECTED_RULE_SNIPPETS)
 
 
 def test_agents_file_declares_standard_v0_1_checklist() -> None:
-    assert AGENTS_PATH.is_file(), AGENTS_PATH
-    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+    agents_text = _read_agents_text()
 
-    start = 0
-    for snippet in EXPECTED_STANDARD_CHECKLIST:
-        index = agents_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(agents_text, EXPECTED_STANDARD_CHECKLIST)

--- a/tests/meta/test_agents_file.py
+++ b/tests/meta/test_agents_file.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_PATH = REPO_ROOT / "AGENTS.md"
+
+EXPECTED_TITLE = "# AGENTS"
+
+EXPECTED_SECTION_HEADINGS = (
+    "## Oracle-first workflow",
+    "## Engineering rules",
+    "## Standard v0.1 checklist",
+)
+
+EXPECTED_ORACLE_CONSULT_RULE = "Oracle consult before implementation is required."
+EXPECTED_TDD_RULE = "TDD strict: RED -> GREEN -> REFACTOR."
+EXPECTED_COMMIT_RULE = (
+    "Use three separate commits for RED, GREEN, and REFACTOR, and each commit message must reference the issue number."
+)
+EXPECTED_ORACLE_MERGE_RULE = "Oracle 100/100 before merge is required."
+EXPECTED_ISSUE_SIZING_RULE = (
+    "Size each issue so it fits one focused pull request; if it spans unrelated concerns "
+    "or cannot be finished in one RED -> GREEN -> REFACTOR cycle, split it first."
+)
+EXPECTED_DOCSTRING_RULE = (
+    "Write meaningful docstrings for public Python modules, classes, and functions, and "
+    "preserve intentionally empty package docstrings where the repo tests require them."
+)
+EXPECTED_NO_ANY_RULE = "No `Any` without justification."
+EXPECTED_NO_TYPE_IGNORE_RULE = "No `# type: ignore`."
+
+EXPECTED_RULE_SNIPPETS = (
+    EXPECTED_ORACLE_CONSULT_RULE,
+    EXPECTED_TDD_RULE,
+    EXPECTED_COMMIT_RULE,
+    EXPECTED_ORACLE_MERGE_RULE,
+    EXPECTED_ISSUE_SIZING_RULE,
+    EXPECTED_DOCSTRING_RULE,
+    EXPECTED_NO_ANY_RULE,
+    EXPECTED_NO_TYPE_IGNORE_RULE,
+)
+
+EXPECTED_STANDARD_CHECKLIST = (
+    "- Oracle 100/100 before merge",
+    "- all tests pass",
+    "- mypy strict clean",
+    "- ruff clean",
+    "- 100% line coverage on new code",
+)
+
+
+def test_agents_file_exists() -> None:
+    assert AGENTS_PATH.is_file()
+
+
+def test_agents_file_declares_required_sections() -> None:
+    assert AGENTS_PATH.is_file(), AGENTS_PATH
+    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+
+    assert EXPECTED_TITLE in agents_text
+    start = 0
+    for snippet in EXPECTED_SECTION_HEADINGS:
+        index = agents_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
+def test_agents_file_declares_oracle_first_rules_and_repo_constraints() -> None:
+    assert AGENTS_PATH.is_file(), AGENTS_PATH
+    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+
+    start = 0
+    for snippet in EXPECTED_RULE_SNIPPETS:
+        index = agents_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
+def test_agents_file_declares_standard_v0_1_checklist() -> None:
+    assert AGENTS_PATH.is_file(), AGENTS_PATH
+    agents_text = AGENTS_PATH.read_text(encoding="utf-8")
+
+    start = 0
+    for snippet in EXPECTED_STANDARD_CHECKLIST:
+        index = agents_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)


### PR DESCRIPTION
Closes #7

## Summary

Adds `AGENTS.md` as the single normative source for the repo's
human/AI working rules so every later issue can point to one stable
contract.

## TDD Evidence

| Commit | Purpose |
|---|---|
| `f502537` test: add failing agents workflow contract meta test (#7) | RED — `tests/meta/test_agents_file.py` fails because `AGENTS.md` does not exist |
| `8ad6d92` docs: add agents workflow contract (#7) | GREEN — adds `AGENTS.md` with three required sections and all enforced phrases |
| `ab412e7` refactor: extract agents-file meta-test helpers (#7) | REFACTOR — extracts `_read_agents_text()` and `_assert_snippets_in_order()` helpers, no behavior change |

## Local Verification (Python 3.12, no-TTY)

\`\`\`
ruff format --check .   → 13 files already formatted
ruff check .            → All checks passed!
mypy --strict .         → Success: no issues found in 13 source files
pytest -q               → 23 passed, total coverage 100%
mutmut run < /dev/null  → MUTMUT_EXIT=0 (2 mutants killed)
\`\`\`

## Acceptance Criteria

- [x] Standard v0.1 checklist applied (oracle 100/100, all tests pass, mypy strict clean, ruff clean, 100% line coverage on new code)
- [x] `AGENTS.md` explicitly states "Oracle consult before implementation is required." AND "Oracle 100/100 before merge is required."
- [x] `AGENTS.md` explicitly states "No \`Any\` without justification." AND "No \`# type: ignore\`."

## Design Notes

Per oracle session \`ses_24e68c2beffeHIQDCq57iVeNTJ\`:
- Three minimal sections: Oracle-first workflow, Engineering rules, Standard v0.1 checklist.
- Docstring rule explicitly preserves the empty `src/abdp/__init__.py` docstring requirement.
- Test enforces controlled brittleness on backticked phrases (`Any`, `# type: ignore`) so future drift is caught.
- No mutmut implications: only adds `AGENTS.md` and a meta test; mutmut still finds 2 killable mutants in `src/abdp/version.py`.