### PR TITLE
docs: add contributing bootstrap guide (#8)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+This guide is intentionally short; detailed expansion is deferred to #044.
+
+## Small issues only
+
+- One issue -> one focused pull request.
+- If work spans unrelated concerns or cannot be finished in one RED -> GREEN -> REFACTOR cycle, split it first.
+
+## Commit prefixes
+
+- Use Conventional Commits prefixes: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`, `build`, `perf`.
+
+## Oracle gate
+
+- See `AGENTS.md` for the Oracle-first workflow and TDD strict: RED -> GREEN -> REFACTOR.
+- Before merge, satisfy the Standard v0.1 checklist:
+  - Oracle 100/100 before merge
+  - all tests pass
+  - mypy strict clean
+  - ruff clean
+  - 100% line coverage on new code

--- a/tests/meta/test_contributing_bootstrap.py
+++ b/tests/meta/test_contributing_bootstrap.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRIBUTING_PATH = REPO_ROOT / "CONTRIBUTING.md"
+
+MAX_GUIDE_LINES = 50
+
+EXPECTED_TITLE = "# Contributing"
+EXPECTED_SHORT_GUIDE_NOTE = "This guide is intentionally short; detailed expansion is deferred to #044."
+
+EXPECTED_SECTION_HEADINGS = (
+    "## Small issues only",
+    "## Commit prefixes",
+    "## Oracle gate",
+)
+
+EXPECTED_SMALL_ISSUE_POLICY = "One issue -> one focused pull request."
+EXPECTED_SMALL_ISSUE_SPLIT_RULE = (
+    "If work spans unrelated concerns or cannot be finished in one RED -> GREEN -> REFACTOR cycle, split it first."
+)
+
+EXPECTED_COMMIT_PREFIX_RULE = (
+    "Use Conventional Commits prefixes: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`, `build`, `perf`."
+)
+
+EXPECTED_ORACLE_GUIDE_POINTER = (
+    "See `AGENTS.md` for the Oracle-first workflow and TDD strict: RED -> GREEN -> REFACTOR."
+)
+EXPECTED_STANDARD_CHECKLIST_INTRO = "Before merge, satisfy the Standard v0.1 checklist:"
+EXPECTED_STANDARD_CHECKLIST = (
+    "- Oracle 100/100 before merge",
+    "- all tests pass",
+    "- mypy strict clean",
+    "- ruff clean",
+    "- 100% line coverage on new code",
+)
+
+
+def test_contributing_file_exists() -> None:
+    assert CONTRIBUTING_PATH.is_file()
+
+
+def test_contributing_file_declares_expected_sections_and_stays_short() -> None:
+    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
+    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+
+    assert EXPECTED_TITLE in contributing_text
+    assert EXPECTED_SHORT_GUIDE_NOTE in contributing_text
+
+    start = 0
+    for snippet in EXPECTED_SECTION_HEADINGS:
+        index = contributing_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+    assert len(contributing_text.splitlines()) < MAX_GUIDE_LINES
+
+
+def test_contributing_file_declares_small_issue_policy_and_commit_prefixes() -> None:
+    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
+    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+
+    snippets = (
+        EXPECTED_SMALL_ISSUE_POLICY,
+        EXPECTED_SMALL_ISSUE_SPLIT_RULE,
+        EXPECTED_COMMIT_PREFIX_RULE,
+    )
+    start = 0
+    for snippet in snippets:
+        index = contributing_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
+def test_contributing_file_declares_oracle_gate_and_standard_v0_1_checklist() -> None:
+    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
+    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+
+    snippets = (
+        EXPECTED_ORACLE_GUIDE_POINTER,
+        EXPECTED_STANDARD_CHECKLIST_INTRO,
+        *EXPECTED_STANDARD_CHECKLIST,
+    )
+    start = 0
+    for snippet in snippets:
+        index = contributing_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)

--- a/tests/meta/test_contributing_bootstrap.py
+++ b/tests/meta/test_contributing_bootstrap.py
@@ -36,53 +36,54 @@ EXPECTED_STANDARD_CHECKLIST = (
 )
 
 
+def _read_contributing_text() -> str:
+    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
+    return CONTRIBUTING_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
+    start = 0
+    for snippet in snippets:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
 def test_contributing_file_exists() -> None:
     assert CONTRIBUTING_PATH.is_file()
 
 
 def test_contributing_file_declares_expected_sections_and_stays_short() -> None:
-    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
-    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+    contributing_text = _read_contributing_text()
 
     assert EXPECTED_TITLE in contributing_text
     assert EXPECTED_SHORT_GUIDE_NOTE in contributing_text
-
-    start = 0
-    for snippet in EXPECTED_SECTION_HEADINGS:
-        index = contributing_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(contributing_text, EXPECTED_SECTION_HEADINGS)
 
     assert len(contributing_text.splitlines()) < MAX_GUIDE_LINES
 
 
 def test_contributing_file_declares_small_issue_policy_and_commit_prefixes() -> None:
-    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
-    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+    contributing_text = _read_contributing_text()
 
-    snippets = (
-        EXPECTED_SMALL_ISSUE_POLICY,
-        EXPECTED_SMALL_ISSUE_SPLIT_RULE,
-        EXPECTED_COMMIT_PREFIX_RULE,
+    _assert_snippets_in_order(
+        contributing_text,
+        (
+            EXPECTED_SMALL_ISSUE_POLICY,
+            EXPECTED_SMALL_ISSUE_SPLIT_RULE,
+            EXPECTED_COMMIT_PREFIX_RULE,
+        ),
     )
-    start = 0
-    for snippet in snippets:
-        index = contributing_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
 
 
 def test_contributing_file_declares_oracle_gate_and_standard_v0_1_checklist() -> None:
-    assert CONTRIBUTING_PATH.is_file(), CONTRIBUTING_PATH
-    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+    contributing_text = _read_contributing_text()
 
-    snippets = (
-        EXPECTED_ORACLE_GUIDE_POINTER,
-        EXPECTED_STANDARD_CHECKLIST_INTRO,
-        *EXPECTED_STANDARD_CHECKLIST,
+    _assert_snippets_in_order(
+        contributing_text,
+        (
+            EXPECTED_ORACLE_GUIDE_POINTER,
+            EXPECTED_STANDARD_CHECKLIST_INTRO,
+            *EXPECTED_STANDARD_CHECKLIST,
+        ),
     )
-    start = 0
-    for snippet in snippets:
-        index = contributing_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)


### PR DESCRIPTION
Closes #8.

## Summary
Adds a short bootstrap `CONTRIBUTING.md` with the small-issue policy, Conventional Commits prefixes, and a pointer to `AGENTS.md` for the Oracle-first workflow plus the Standard v0.1 checklist. Detailed expansion is deferred to #044.

## TDD evidence (3 commits)
- **RED** `6c7d29a` — `test: add failing contributing bootstrap meta test (#8)` — adds `tests/meta/test_contributing_bootstrap.py` (4 tests). Fails because `CONTRIBUTING.md` does not yet exist.
- **GREEN** `1fe27f8` — `docs: add contributing bootstrap guide (#8)` — adds `CONTRIBUTING.md`. Tests pass.
- **REFACTOR** `fdcab23` — `refactor: extract contributing-bootstrap meta-test helpers (#8)` — extracts `_read_contributing_text()` and `_assert_snippets_in_order()` mirroring `tests/meta/test_agents_file.py`.

## Local verification (Python 3.12.13, .venv312)
- `ruff format --check .` — clean
- `ruff check .` — clean
- `mypy --strict src tests` — clean
- `pytest` — 27 passed, **100% coverage** on `src/`
- `mutmut run < /dev/null` — exit **0**, 2/2 mutants killed

## Oracle session
Design contract from oracle session `ses_24e61112bffePlmpwdlcGl4xg4`. Will resume the same session for the 100/100 review.