### PR TITLE
docs: add adr template (#9)

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,19 @@
+# 0000 - ADR template
+
+Template only. Copy this file to a new numbered ADR and replace every placeholder before use.
+
+## Status
+
+TBD
+
+## Context
+
+<describe the problem, constraints, and forces>
+
+## Decision
+
+<describe the chosen option>
+
+## Consequences
+
+<describe expected benefits, trade-offs, and follow-up work>

--- a/tests/meta/test_adr_template.py
+++ b/tests/meta/test_adr_template.py
@@ -28,35 +28,37 @@ FORBIDDEN_REPO_SPECIFIC_SNIPPETS = (
 )
 
 
+def _read_template_text() -> str:
+    assert TEMPLATE_PATH.is_file(), TEMPLATE_PATH
+    return TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
+    start = 0
+    for snippet in snippets:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
 def test_adr_template_file_exists() -> None:
     assert TEMPLATE_PATH.is_file()
 
 
 def test_adr_template_file_declares_expected_sections_and_stays_short() -> None:
-    assert TEMPLATE_PATH.is_file(), TEMPLATE_PATH
-    template_text = TEMPLATE_PATH.read_text(encoding="utf-8")
+    template_text = _read_template_text()
 
     assert EXPECTED_TITLE in template_text
     assert EXPECTED_TEMPLATE_NOTE in template_text
-
-    start = 0
-    for snippet in EXPECTED_SECTION_HEADINGS:
-        index = template_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(template_text, EXPECTED_SECTION_HEADINGS)
 
     assert len(template_text.splitlines()) < MAX_TEMPLATE_LINES
 
 
 def test_adr_template_file_is_generic_and_contains_only_placeholder_content() -> None:
-    assert TEMPLATE_PATH.is_file(), TEMPLATE_PATH
-    template_text = TEMPLATE_PATH.read_text(encoding="utf-8")
+    template_text = _read_template_text()
 
-    start = 0
-    for snippet in EXPECTED_PLACEHOLDER_SNIPPETS:
-        index = template_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(template_text, EXPECTED_PLACEHOLDER_SNIPPETS)
 
     lowered_template_text = template_text.lower()
     for snippet in FORBIDDEN_REPO_SPECIFIC_SNIPPETS:

--- a/tests/meta/test_adr_template.py
+++ b/tests/meta/test_adr_template.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_PATH = REPO_ROOT / "docs" / "adr" / "0000-template.md"
+
+MAX_TEMPLATE_LINES = 20
+
+EXPECTED_TITLE = "# 0000 - ADR template"
+EXPECTED_TEMPLATE_NOTE = "Template only. Copy this file to a new numbered ADR and replace every placeholder before use."
+
+EXPECTED_SECTION_HEADINGS = (
+    "## Status",
+    "## Context",
+    "## Decision",
+    "## Consequences",
+)
+
+EXPECTED_PLACEHOLDER_SNIPPETS = (
+    "TBD",
+    "<describe the problem, constraints, and forces>",
+    "<describe the chosen option>",
+    "<describe expected benefits, trade-offs, and follow-up work>",
+)
+
+FORBIDDEN_REPO_SPECIFIC_SNIPPETS = (
+    "agent-based-decision-pipeline",
+    "abdp",
+)
+
+
+def test_adr_template_file_exists() -> None:
+    assert TEMPLATE_PATH.is_file()
+
+
+def test_adr_template_file_declares_expected_sections_and_stays_short() -> None:
+    assert TEMPLATE_PATH.is_file(), TEMPLATE_PATH
+    template_text = TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert EXPECTED_TITLE in template_text
+    assert EXPECTED_TEMPLATE_NOTE in template_text
+
+    start = 0
+    for snippet in EXPECTED_SECTION_HEADINGS:
+        index = template_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+    assert len(template_text.splitlines()) < MAX_TEMPLATE_LINES
+
+
+def test_adr_template_file_is_generic_and_contains_only_placeholder_content() -> None:
+    assert TEMPLATE_PATH.is_file(), TEMPLATE_PATH
+    template_text = TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    start = 0
+    for snippet in EXPECTED_PLACEHOLDER_SNIPPETS:
+        index = template_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+    lowered_template_text = template_text.lower()
+    for snippet in FORBIDDEN_REPO_SPECIFIC_SNIPPETS:
+        assert snippet not in lowered_template_text


### PR DESCRIPTION
Closes #9.

## Summary
Adds `docs/adr/0000-template.md` with `Status`, `Context`, `Decision`, and `Consequences` sections plus placeholder content. Template only; copy to a new numbered ADR before recording an actual decision.

## TDD evidence (3 commits)
- **RED** `00c2fd2` — `test: add failing adr template meta test (#9)` — adds `tests/meta/test_adr_template.py` (3 tests). Fails because the template does not yet exist.
- **GREEN** `35e2650` — `docs: add adr template (#9)` — adds `docs/adr/0000-template.md`. Tests pass.
- **REFACTOR** — `refactor: extract adr-template meta-test helpers (#9)` — extracts `_read_template_text()` and `_assert_snippets_in_order()` mirroring `tests/meta/test_contributing_bootstrap.py`.

## Local verification (Python 3.12.13, .venv312)
- `ruff format --check .` — clean
- `ruff check .` — clean
- `mypy --strict src tests` — clean
- `pytest` — 30 passed, **100% coverage** on `src/`
- `mutmut run < /dev/null` — exit **0**, 2/2 mutants killed

## Oracle session
Design contract from oracle session `ses_24e5869a2ffeLYazYBGzWMkSWq`. Will resume the same session for the 100/100 review.