### PR TITLE
docs: add docs directory scaffold (#10)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Docs
+
+This index is intentionally minimal. Detailed expansion is deferred to #044.
+
+- [Development](development/README.md) — Contributor process and v0.1 issue queue.
+- [Models](models/README.md) — Conceptual model documentation for abdp.
+- [Examples](examples/README.md) — Worked examples and tutorials.
+- [ADRs](adr/README.md) — Architecture decision records and template.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# ADRs
+
+Architecture decision records live here.
+Start from [0000-template.md](0000-template.md) when writing a new ADR.
+Directory index details are deferred to #044.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,4 @@
+# Development
+
+Placeholder only. Contributor process and v0.1 issue queue live here.
+Detailed expansion is deferred to #044.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,4 @@
+# Examples
+
+Placeholder only. Worked examples and tutorials live here.
+Detailed expansion is deferred to #044.

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -1,0 +1,4 @@
+# Models
+
+Placeholder only. Conceptual model documentation for abdp lives here.
+Detailed expansion is deferred to #044.

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
+DEVELOPMENT_README_PATH = REPO_ROOT / "docs" / "development" / "README.md"
+MODELS_README_PATH = REPO_ROOT / "docs" / "models" / "README.md"
+EXAMPLES_README_PATH = REPO_ROOT / "docs" / "examples" / "README.md"
+ADR_README_PATH = REPO_ROOT / "docs" / "adr" / "README.md"
+
+README_PATHS: tuple[Path, ...] = (
+    DOCS_INDEX_PATH,
+    DEVELOPMENT_README_PATH,
+    MODELS_README_PATH,
+    EXAMPLES_README_PATH,
+    ADR_README_PATH,
+)
+
+MAX_README_LINES = 10
+
+EXPECTED_DOCS_INDEX_SNIPPETS = (
+    "# Docs",
+    "This index is intentionally minimal. Detailed expansion is deferred to #044.",
+    "- [Development](development/README.md) — Contributor process and v0.1 issue queue.",
+    "- [Models](models/README.md) — Conceptual model documentation for abdp.",
+    "- [Examples](examples/README.md) — Worked examples and tutorials.",
+    "- [ADRs](adr/README.md) — Architecture decision records and template.",
+)
+
+EXPECTED_SUBSECTION_TITLES: tuple[tuple[Path, str], ...] = (
+    (DEVELOPMENT_README_PATH, "# Development"),
+    (MODELS_README_PATH, "# Models"),
+    (EXAMPLES_README_PATH, "# Examples"),
+    (ADR_README_PATH, "# ADRs"),
+)
+
+EXPECTED_SUBSECTION_README_SNIPPETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+    (
+        DEVELOPMENT_README_PATH,
+        (
+            "# Development",
+            "Placeholder only. Contributor process and v0.1 issue queue live here.",
+            "Detailed expansion is deferred to #044.",
+        ),
+    ),
+    (
+        MODELS_README_PATH,
+        (
+            "# Models",
+            "Placeholder only. Conceptual model documentation for abdp lives here.",
+            "Detailed expansion is deferred to #044.",
+        ),
+    ),
+    (
+        EXAMPLES_README_PATH,
+        (
+            "# Examples",
+            "Placeholder only. Worked examples and tutorials live here.",
+            "Detailed expansion is deferred to #044.",
+        ),
+    ),
+    (
+        ADR_README_PATH,
+        (
+            "# ADRs",
+            "Architecture decision records live here.",
+            "Start from [0000-template.md](0000-template.md) when writing a new ADR.",
+            "Directory index details are deferred to #044.",
+        ),
+    ),
+)
+
+EXPECTED_ADR_TEMPLATE_POINTER = "Start from [0000-template.md](0000-template.md) when writing a new ADR."
+
+
+def test_docs_scaffold_files_exist() -> None:
+    for path in README_PATHS:
+        assert path.is_file(), path
+
+
+def test_docs_index_declares_expected_navigation_and_stays_short() -> None:
+    assert DOCS_INDEX_PATH.is_file(), DOCS_INDEX_PATH
+    docs_index_text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
+
+    start = 0
+    for snippet in EXPECTED_DOCS_INDEX_SNIPPETS:
+        index = docs_index_text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+    assert len(docs_index_text.splitlines()) < MAX_README_LINES
+
+
+def test_subsection_readmes_declare_expected_titles() -> None:
+    for path, expected_title in EXPECTED_SUBSECTION_TITLES:
+        assert path.is_file(), path
+        readme_text = path.read_text(encoding="utf-8")
+
+        assert expected_title in readme_text
+
+
+def test_subsection_readmes_remain_placeholders_and_stay_short() -> None:
+    for path, expected_snippets in EXPECTED_SUBSECTION_README_SNIPPETS:
+        assert path.is_file(), path
+        readme_text = path.read_text(encoding="utf-8")
+
+        start = 0
+        for snippet in expected_snippets:
+            index = readme_text.find(snippet, start)
+            assert index >= 0, snippet
+            start = index + len(snippet)
+
+        assert len(readme_text.splitlines()) < MAX_README_LINES
+
+
+def test_adr_readme_references_template() -> None:
+    assert ADR_README_PATH.is_file(), ADR_README_PATH
+    adr_readme_text = ADR_README_PATH.read_text(encoding="utf-8")
+
+    assert EXPECTED_ADR_TEMPLATE_POINTER in adr_readme_text

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -72,48 +72,47 @@ EXPECTED_SUBSECTION_README_SNIPPETS: tuple[tuple[Path, tuple[str, ...]], ...] = 
 EXPECTED_ADR_TEMPLATE_POINTER = "Start from [0000-template.md](0000-template.md) when writing a new ADR."
 
 
+def _read_text(path: Path) -> str:
+    assert path.is_file(), path
+    return path.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
+    start = 0
+    for snippet in snippets:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
 def test_docs_scaffold_files_exist() -> None:
     for path in README_PATHS:
         assert path.is_file(), path
 
 
 def test_docs_index_declares_expected_navigation_and_stays_short() -> None:
-    assert DOCS_INDEX_PATH.is_file(), DOCS_INDEX_PATH
-    docs_index_text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
+    docs_index_text = _read_text(DOCS_INDEX_PATH)
 
-    start = 0
-    for snippet in EXPECTED_DOCS_INDEX_SNIPPETS:
-        index = docs_index_text.find(snippet, start)
-        assert index >= 0, snippet
-        start = index + len(snippet)
+    _assert_snippets_in_order(docs_index_text, EXPECTED_DOCS_INDEX_SNIPPETS)
 
     assert len(docs_index_text.splitlines()) < MAX_README_LINES
 
 
 def test_subsection_readmes_declare_expected_titles() -> None:
     for path, expected_title in EXPECTED_SUBSECTION_TITLES:
-        assert path.is_file(), path
-        readme_text = path.read_text(encoding="utf-8")
-
-        assert expected_title in readme_text
+        assert expected_title in _read_text(path)
 
 
 def test_subsection_readmes_remain_placeholders_and_stay_short() -> None:
     for path, expected_snippets in EXPECTED_SUBSECTION_README_SNIPPETS:
-        assert path.is_file(), path
-        readme_text = path.read_text(encoding="utf-8")
+        readme_text = _read_text(path)
 
-        start = 0
-        for snippet in expected_snippets:
-            index = readme_text.find(snippet, start)
-            assert index >= 0, snippet
-            start = index + len(snippet)
+        _assert_snippets_in_order(readme_text, expected_snippets)
 
         assert len(readme_text.splitlines()) < MAX_README_LINES
 
 
 def test_adr_readme_references_template() -> None:
-    assert ADR_README_PATH.is_file(), ADR_README_PATH
-    adr_readme_text = ADR_README_PATH.read_text(encoding="utf-8")
+    adr_readme_text = _read_text(ADR_README_PATH)
 
     assert EXPECTED_ADR_TEMPLATE_POINTER in adr_readme_text


### PR DESCRIPTION
Closes #10.

## Summary
Adds `docs/README.md` plus placeholder READMEs for `docs/development`, `docs/models`, `docs/examples`, and `docs/adr`. Top-level index links to each subsection; `docs/adr/README.md` points to the existing `0000-template.md`.

## TDD evidence (3 commits)
- **RED** `bc6da7a` — `test: add failing docs scaffold meta test (#10)` — adds `tests/meta/test_docs_scaffold.py` (5 tests). Fails because the scaffold READMEs do not yet exist.
- **GREEN** `e5898bd` — `docs: add docs directory scaffold (#10)` — adds the 5 README files. Tests pass.
- **REFACTOR** — `refactor: extract docs-scaffold meta-test helpers (#10)` — extracts `_read_text()` and `_assert_snippets_in_order()` mirroring the prior meta tests.

## Local verification (Python 3.12.13, .venv312)
- `ruff format --check .` — clean
- `ruff check .` — clean
- `mypy --strict src tests` — clean
- `pytest` — 35 passed, **100% coverage** on `src/`
- `mutmut run < /dev/null` — exit **0**, 2/2 mutants killed

## Oracle session
Design contract from oracle session `ses_24e53603cffefMA3sR7IDteoXk`. Will resume the same session for the 100/100 review.