### PR TITLE
docs: add project vision (#11)

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,29 @@
+# Project vision
+
+A Python framework for reproducible agent-based decision simulation
+
+## Problem statement
+Teams that study or compare decision strategies often rebuild one-off simulations that are hard to rerun, inspect, and compare.
+abdp exists to provide a shared Python framework for defining agent-based decision simulations whose assumptions, inputs, randomness, and outputs can be reproduced and reviewed.
+Architecture details are deferred to separate docs.
+
+## Target users
+abdp serves researchers, analysts, and product or policy teams who need repeatable decision simulations instead of ad hoc scripts.
+It is for people who want to model choices made by agents, rerun the same experiment with controlled randomness, and compare results with evidence they can explain to others.
+
+## Non-goals
+- Not a real-time simulation engine for live operational systems.
+- Not a domain library with built-in business, policy, scientific, or game rules.
+- Not an autonomous decision-making service that replaces human accountability.
+- Not a generic workflow orchestrator for unrelated automation tasks.
+- Not a promise of integrations or capabilities beyond the documented v0.1 scope.
+
+## v0.1 promise
+In v0.1, abdp will provide a clear, narrow foundation for reproducible agent-based decision simulation in Python.
+It will define what the framework is for, who it serves, and the boundaries it intentionally keeps so the public API can stay aligned with that scope.
+The v0.1 checklist is simple:
+- state the problem abdp is for
+- name the target users
+- state the non-goals
+- keep commitments limited to v0.1
+This document sets scope, not implementation commitments beyond v0.1.

--- a/tests/meta/test_doc_vision.py
+++ b/tests/meta/test_doc_vision.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VISION_PATH = REPO_ROOT / "docs" / "vision.md"
+
+TAGLINE = "A Python framework for reproducible agent-based decision simulation"
+
+SECTION_HEADINGS: tuple[str, ...] = (
+    "## Problem statement",
+    "## Target users",
+    "## Non-goals",
+    "## v0.1 promise",
+)
+
+SECTION_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "## Problem statement",
+        (
+            "study or compare decision strategies",
+            "assumptions, inputs, randomness, and outputs can be reproduced and reviewed.",
+        ),
+    ),
+    (
+        "## Target users",
+        (
+            "researchers, analysts, and product or policy teams",
+            "rerun the same experiment with controlled randomness",
+        ),
+    ),
+    (
+        "## Non-goals",
+        (
+            "Not a real-time simulation engine for live operational systems.",
+            "Not a domain library with built-in business, policy, scientific, or game rules.",
+            "Not an autonomous decision-making service that replaces human accountability.",
+        ),
+    ),
+    (
+        "## v0.1 promise",
+        (
+            "public API can stay aligned with that scope.",
+            "The v0.1 checklist is simple:",
+            "This document sets scope, not implementation commitments beyond v0.1.",
+        ),
+    ),
+)
+
+FORBIDDEN_SNIPPETS: tuple[str, ...] = (
+    "core/data/simulation/agents/scenario/evaluation/evidence/reporting/domains",
+    "9 architectural layers",
+    "milestone sequencing",
+    "v0.2",
+    "v1.0",
+)
+
+MAX_VISION_LINES = 60
+
+
+def test_vision_file_exists() -> None:
+    assert VISION_PATH.is_file(), VISION_PATH
+
+
+def test_vision_includes_tagline_and_required_sections_in_order() -> None:
+    assert VISION_PATH.is_file(), VISION_PATH
+    text = VISION_PATH.read_text(encoding="utf-8")
+
+    assert TAGLINE in text
+
+    start = 0
+    for snippet in SECTION_HEADINGS:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
+def test_each_section_contains_expected_snippets() -> None:
+    assert VISION_PATH.is_file(), VISION_PATH
+    text = VISION_PATH.read_text(encoding="utf-8")
+
+    for index, (heading, snippets) in enumerate(SECTION_SNIPPETS):
+        section_start = text.index(heading)
+        if index + 1 < len(SECTION_SNIPPETS):
+            next_heading = SECTION_SNIPPETS[index + 1][0]
+            section_end = text.index(next_heading, section_start + len(heading))
+        else:
+            section_end = len(text)
+
+        section_text = text[section_start:section_end]
+        for snippet in snippets:
+            assert snippet in section_text, f"{heading}: {snippet}"
+
+
+def test_vision_avoids_forbidden_scope_and_stays_within_line_budget() -> None:
+    assert VISION_PATH.is_file(), VISION_PATH
+    text = VISION_PATH.read_text(encoding="utf-8")
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, snippet
+
+    assert len(text.splitlines()) <= MAX_VISION_LINES

--- a/tests/meta/test_doc_vision.py
+++ b/tests/meta/test_doc_vision.py
@@ -56,26 +56,32 @@ FORBIDDEN_SNIPPETS: tuple[str, ...] = (
 MAX_VISION_LINES = 60
 
 
-def test_vision_file_exists() -> None:
+def _read_vision_text() -> str:
     assert VISION_PATH.is_file(), VISION_PATH
+    return VISION_PATH.read_text(encoding="utf-8")
 
 
-def test_vision_includes_tagline_and_required_sections_in_order() -> None:
-    assert VISION_PATH.is_file(), VISION_PATH
-    text = VISION_PATH.read_text(encoding="utf-8")
-
-    assert TAGLINE in text
-
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
     start = 0
-    for snippet in SECTION_HEADINGS:
+    for snippet in snippets:
         index = text.find(snippet, start)
         assert index >= 0, snippet
         start = index + len(snippet)
 
 
+def test_vision_file_exists() -> None:
+    assert VISION_PATH.is_file()
+
+
+def test_vision_includes_tagline_and_required_sections_in_order() -> None:
+    text = _read_vision_text()
+
+    assert TAGLINE in text
+    _assert_snippets_in_order(text, SECTION_HEADINGS)
+
+
 def test_each_section_contains_expected_snippets() -> None:
-    assert VISION_PATH.is_file(), VISION_PATH
-    text = VISION_PATH.read_text(encoding="utf-8")
+    text = _read_vision_text()
 
     for index, (heading, snippets) in enumerate(SECTION_SNIPPETS):
         section_start = text.index(heading)
@@ -91,8 +97,7 @@ def test_each_section_contains_expected_snippets() -> None:
 
 
 def test_vision_avoids_forbidden_scope_and_stays_within_line_budget() -> None:
-    assert VISION_PATH.is_file(), VISION_PATH
-    text = VISION_PATH.read_text(encoding="utf-8")
+    text = _read_vision_text()
 
     for snippet in FORBIDDEN_SNIPPETS:
         assert snippet not in text, snippet


### PR DESCRIPTION
Closes #11.

## Summary
Adds `docs/vision.md` freezing the problem statement, target users, non-goals, and the v0.1 promise. Includes the frozen tagline verbatim. Architecture details and milestone sequencing are explicitly deferred.

## TDD evidence (3 commits)
- **RED** `12f14ea` — `test: add failing project vision meta test (#11)` — adds `tests/meta/test_doc_vision.py` (4 tests). Fails because `docs/vision.md` does not yet exist.
- **GREEN** `4de9f23` — `docs: add project vision (#11)` — adds `docs/vision.md`. Tests pass.
- **REFACTOR** — `refactor: extract project-vision meta-test helpers (#11)` — extracts `_read_vision_text()` and `_assert_snippets_in_order()` mirroring prior meta tests.

## Local verification (Python 3.12.13, .venv312)
- `ruff format --check .` — clean
- `ruff check .` — clean
- `mypy --strict src tests` — clean
- `pytest` — 39 passed, **100% coverage** on `src/`
- `mutmut run < /dev/null` — exit **0**, 2/2 mutants killed

## Notes vs. oracle design
- Adopted `REPO_ROOT = Path(__file__).resolve().parents[2]` path constant pattern instead of relative `Path("docs/vision.md")` — matches the four prior meta-test files (`test_agents_file.py`, `test_contributing_bootstrap.py`, `test_adr_template.py`, `test_docs_scaffold.py`) for consistency. Document bytes match A1 verbatim.

## Oracle session
Design contract from oracle session `ses_24e4be0a2ffegakeo63TEewhHT`. Will resume same session for 100/100 review.