### PR TITLE
docs: add product requirements (#12)

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,41 @@
+# Product requirements (v0.1)
+
+This document defines the minimum product boundary for v0.1 of ABDP and continues the scope set in [docs/vision.md](vision.md).
+
+## Primary user and job
+
+The primary user is a developer or researcher who needs a reproducible way to model and replay agent-based decisions.
+Their job is to define inputs, run a simulation, and inspect stable outputs that can be compared across runs.
+
+## Core use cases
+
+- Create structured input data for a decision simulation.
+- Run a deterministic simulation through the v0.1 core.
+- Inspect outputs that can be replayed and compared for the same inputs.
+- Use the resulting contracts as the acceptance boundary for later issues.
+
+## Success criteria
+
+- Every issue proposed for v0.1 can be accepted or rejected by checking it against this document.
+- Every merged v0.1 PR satisfies the Standard v0.1 checklist.
+- The tagged v0.1.0 release contains only layers 1-3 = core, data, simulation.
+- Every public v0.1 contract in src/abdp/ is exercised by at least one automated test.
+
+## v0.1 in-scope
+
+- A minimal runnable framework boundary for layers 1-3 = core, data, simulation.
+- Public contracts that let users supply inputs, execute a simulation, and observe stable outputs.
+- Tests that prove the supported v0.1 behavior of those contracts.
+- Documentation that states the boundary clearly enough to judge issue fit.
+
+## v0.1 out-of-scope
+
+- Work beyond layers 1-3.
+- Layered architecture detail beyond naming layers 1-3 = core, data, simulation.
+- Contributor workflow guidance.
+- Product promises outside the stated v0.1 boundary.
+
+## v0.1 milestone
+
+The v0.1 milestone is "core skeleton".
+It is complete when the tagged v0.1.0 release provides tested contracts for layers 1-3 and contains only core, data, and simulation.

--- a/tests/meta/test_doc_prd.py
+++ b/tests/meta/test_doc_prd.py
@@ -60,30 +60,38 @@ FORBIDDEN_SNIPPETS: list[str] = [
 ]
 
 
+def _read_prd_text() -> str:
+    return PRD_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: list[str]) -> None:
+    position = -1
+    for snippet in snippets:
+        next_position = text.find(snippet, position + 1)
+        assert next_position != -1, f"Missing snippet: {snippet}"
+        assert next_position > position, f"Snippet out of order: {snippet}"
+        position = next_position
+
+
 def test_prd_file_exists() -> None:
     assert PRD_PATH.is_file(), f"Expected PRD file at {PRD_PATH}"
 
 
 def test_prd_has_title_and_single_vision_reference() -> None:
-    text = PRD_PATH.read_text(encoding="utf-8")
+    text = _read_prd_text()
 
     assert text.startswith(f"{TITLE}\n")
     assert text.count(VISION_REFERENCE) == 1
 
 
 def test_prd_has_required_section_headings_in_order() -> None:
-    text = PRD_PATH.read_text(encoding="utf-8")
+    text = _read_prd_text()
 
-    position = -1
-    for heading in REQUIRED_HEADINGS:
-        next_position = text.find(heading, position + 1)
-        assert next_position != -1, f"Missing heading: {heading}"
-        assert next_position > position, f"Heading out of order: {heading}"
-        position = next_position
+    _assert_snippets_in_order(text, REQUIRED_HEADINGS)
 
 
 def test_prd_sections_include_expected_anchors() -> None:
-    text = PRD_PATH.read_text(encoding="utf-8")
+    text = _read_prd_text()
 
     for index, heading in enumerate(REQUIRED_HEADINGS):
         start = text.index(heading)
@@ -97,7 +105,7 @@ def test_prd_sections_include_expected_anchors() -> None:
 
 
 def test_prd_includes_required_phrases_and_omits_forbidden_snippets() -> None:
-    text = PRD_PATH.read_text(encoding="utf-8")
+    text = _read_prd_text()
 
     for phrase in REQUIRED_PHRASES:
         assert phrase in text, f"Missing required phrase: {phrase}"
@@ -107,6 +115,6 @@ def test_prd_includes_required_phrases_and_omits_forbidden_snippets() -> None:
 
 
 def test_prd_stays_within_line_budget() -> None:
-    text = PRD_PATH.read_text(encoding="utf-8")
+    text = _read_prd_text()
 
     assert len(text.splitlines()) <= MAX_LINE_COUNT

--- a/tests/meta/test_doc_prd.py
+++ b/tests/meta/test_doc_prd.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRD_PATH = REPO_ROOT / "docs" / "prd.md"
+TITLE = "# Product requirements (v0.1)"
+VISION_REFERENCE = "[docs/vision.md](vision.md)"
+MAX_LINE_COUNT = 80
+
+REQUIRED_HEADINGS: list[str] = [
+    "## Primary user and job",
+    "## Core use cases",
+    "## Success criteria",
+    "## v0.1 in-scope",
+    "## v0.1 out-of-scope",
+    "## v0.1 milestone",
+]
+
+SECTION_ANCHORS: dict[str, list[str]] = {
+    "## Primary user and job": [
+        (
+            "The primary user is a developer or researcher who needs a reproducible way to model "
+            "and replay agent-based decisions."
+        ),
+    ],
+    "## Core use cases": [
+        "- Create structured input data for a decision simulation.",
+    ],
+    "## Success criteria": [
+        "- Every merged v0.1 PR satisfies the Standard v0.1 checklist.",
+    ],
+    "## v0.1 in-scope": [
+        "- A minimal runnable framework boundary for layers 1-3 = core, data, simulation.",
+    ],
+    "## v0.1 out-of-scope": [
+        "- Work beyond layers 1-3.",
+    ],
+    "## v0.1 milestone": [
+        'The v0.1 milestone is "core skeleton".',
+        (
+            "It is complete when the tagged v0.1.0 release provides tested contracts for layers "
+            "1-3 and contains only core, data, and simulation."
+        ),
+    ],
+}
+
+REQUIRED_PHRASES: list[str] = [
+    "core skeleton",
+    "tested contracts for layers 1-3",
+]
+
+FORBIDDEN_SNIPPETS: list[str] = [
+    "agents layer",
+    "evaluation layer",
+    "reporting layer",
+    "scenario layer",
+    "evidence layer",
+    "domains layer",
+    "pull request",
+    "Conventional Commits",
+]
+
+
+def test_prd_file_exists() -> None:
+    assert PRD_PATH.is_file(), f"Expected PRD file at {PRD_PATH}"
+
+
+def test_prd_has_title_and_single_vision_reference() -> None:
+    text = PRD_PATH.read_text(encoding="utf-8")
+
+    assert text.startswith(f"{TITLE}\n")
+    assert text.count(VISION_REFERENCE) == 1
+
+
+def test_prd_has_required_section_headings_in_order() -> None:
+    text = PRD_PATH.read_text(encoding="utf-8")
+
+    position = -1
+    for heading in REQUIRED_HEADINGS:
+        next_position = text.find(heading, position + 1)
+        assert next_position != -1, f"Missing heading: {heading}"
+        assert next_position > position, f"Heading out of order: {heading}"
+        position = next_position
+
+
+def test_prd_sections_include_expected_anchors() -> None:
+    text = PRD_PATH.read_text(encoding="utf-8")
+
+    for index, heading in enumerate(REQUIRED_HEADINGS):
+        start = text.index(heading)
+        end = len(text)
+        if index + 1 < len(REQUIRED_HEADINGS):
+            end = text.index(REQUIRED_HEADINGS[index + 1], start + len(heading))
+        section_text = text[start:end]
+
+        for anchor in SECTION_ANCHORS[heading]:
+            assert anchor in section_text, f"Missing anchor in {heading}: {anchor}"
+
+
+def test_prd_includes_required_phrases_and_omits_forbidden_snippets() -> None:
+    text = PRD_PATH.read_text(encoding="utf-8")
+
+    for phrase in REQUIRED_PHRASES:
+        assert phrase in text, f"Missing required phrase: {phrase}"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, f"Forbidden snippet present: {snippet}"
+
+
+def test_prd_stays_within_line_budget() -> None:
+    text = PRD_PATH.read_text(encoding="utf-8")
+
+    assert len(text.splitlines()) <= MAX_LINE_COUNT


### PR DESCRIPTION
Closes #12

## Summary
Adds `docs/prd.md` defining the v0.1 product requirements (primary user, core use cases, success criteria, in-scope/out-of-scope, milestone) and a meta test that locks the document's required structure, headings, anchors, phrases, forbidden snippets, and line budget.

## TDD evidence
- RED `15b11bc` — `test: add failing product requirements meta test (#12)` — adds `tests/meta/test_doc_prd.py` (6 tests, fails because PRD does not exist).
- GREEN `4896d6a` — `docs: add product requirements (#12)` — adds `docs/prd.md` (41 lines), all 6 tests pass.
- REFACTOR `f3e2124` — `refactor: extract product-requirements meta-test helpers (#12)` — extracts `_read_prd_text()` and `_assert_snippets_in_order()` helpers; behavior unchanged.

## Verification (local, .venv312, Python 3.12.13)
- `ruff format --check .` → clean
- `ruff check .` → All checks passed
- `mypy --strict src tests` → Success: no issues found in 18 source files
- `pytest` → 45 passed, 100% coverage
- `mutmut run < /dev/null` → exit 0 (1 file mutated, 4 ignored, 0 unmodified; 2/2 mutants caught)

## Oracle
Design + same-session 100/100 review session: `ses_24e453d57ffeMLTCbp4Ux2BAGa`