### PR TITLE
docs: add layered architecture (#13)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,43 @@
+# Layered architecture
+
+This document defines the frozen layer model for ABDP and continues the v0.1 boundary set in [docs/prd.md](prd.md).
+
+## Layer responsibilities
+
+Layers 1-3 = `core`, `data`, `simulation`; they are the only v0.1 implementation target.
+
+1. `core` — Stable framework contracts, shared types, and invariants with no domain-specific concepts.
+2. `data` — Structured inputs, outputs, repositories, and serialization that move data into and out of simulations.
+3. `simulation` — Deterministic execution flow, runtime control, and orchestration for running a simulation.
+4. `agents` — Agent contracts and behavior composition used inside a simulation run.
+5. `scenario` — Scenario assembly that binds agents, inputs, and conditions into a runnable case.
+6. `evaluation` — Metrics and judgments applied to simulation results.
+7. `evidence` — Traces, observations, and supporting artifacts collected from execution and evaluation.
+8. `reporting` — Presentation-ready summaries and exports derived from evidence and evaluation.
+9. `domains` — Optional domain plugins that adapt the framework to a specific field without changing the core framework.
+
+## Allowed dependency direction
+
+The frozen order is `core <- data <- simulation <- agents <- scenario <- evaluation <- evidence <- reporting <- domains`.
+An ABDP layer may import only itself and layers to its left in that order.
+
+- `abdp.core` imports no sibling layer, no `domains` package, and no domain package directly.
+- `abdp.core` public types and contracts must stay free of domain-specific concepts.
+- `data` may import only `core`.
+- `simulation` may import only `data` and `core`.
+- `agents` may import only `simulation`, `data`, and `core`.
+- `scenario` may import only `agents`, `simulation`, `data`, and `core`.
+- `evaluation` may import only `scenario`, `agents`, `simulation`, `data`, and `core`.
+- `evidence` may import only `evaluation`, `scenario`, `agents`, `simulation`, `data`, and `core`.
+- `reporting` may import only `evidence`, `evaluation`, `scenario`, `agents`, `simulation`, `data`, and `core`.
+- `domains` may import any lower layer, but no lower layer may import `domains`.
+
+Review rule: if an import points rightward in the frozen order, it is disallowed.
+
+## Hard rules
+
+- "core framework must not contain domain-specific concepts"
+- "core must not import domain packages directly"
+- "plugins must depend on the core contracts"
+- "abstractions should be justified by at least two domains"
+- "If randomness is introduced, it must be seed-aware"

--- a/tests/meta/test_doc_architecture.py
+++ b/tests/meta/test_doc_architecture.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
+TITLE = "# Layered architecture"
+PRD_REFERENCE = "[docs/prd.md](prd.md)"
+MAX_LINE_COUNT = 90
+
+REQUIRED_HEADINGS: list[str] = [
+    "## Layer responsibilities",
+    "## Allowed dependency direction",
+    "## Hard rules",
+]
+
+SECTION_ANCHORS: dict[str, list[str]] = {
+    "## Layer responsibilities": [
+        "Layers 1-3 = `core`, `data`, `simulation`; they are the only v0.1 implementation target.",
+        "1. `core` — Stable framework contracts, shared types, and invariants with no domain-specific concepts.",
+        "9. `domains` — Optional domain plugins that adapt the framework to a specific field without changing the core framework.",
+    ],
+    "## Allowed dependency direction": [
+        "The frozen order is `core <- data <- simulation <- agents <- scenario <- evaluation <- evidence <- reporting <- domains`.",
+        "An ABDP layer may import only itself and layers to its left in that order.",
+        "- `abdp.core` imports no sibling layer, no `domains` package, and no domain package directly.",
+        "- `domains` may import any lower layer, but no lower layer may import `domains`.",
+        "Review rule: if an import points rightward in the frozen order, it is disallowed.",
+    ],
+    "## Hard rules": [
+        '"core framework must not contain domain-specific concepts"',
+        '"core must not import domain packages directly"',
+        '"plugins must depend on the core contracts"',
+        '"abstractions should be justified by at least two domains"',
+        '"If randomness is introduced, it must be seed-aware"',
+    ],
+}
+
+REQUIRED_PHRASES: list[str] = [
+    "`core`",
+    "`data`",
+    "`simulation`",
+    "`agents`",
+    "`scenario`",
+    "`evaluation`",
+    "`evidence`",
+    "`reporting`",
+    "`domains`",
+    "`abdp.core`",
+    "at least two domains",
+    "seed-aware",
+]
+
+FORBIDDEN_SNIPPETS: list[str] = [
+    "real estate",
+    "housing",
+    "mortgage",
+    "insurance",
+    "retail",
+    "korean",
+    "south korea",
+]
+
+
+def test_architecture_file_exists() -> None:
+    assert ARCHITECTURE_PATH.is_file(), f"Expected architecture doc at {ARCHITECTURE_PATH}"
+
+
+def test_architecture_has_title_and_single_prd_reference() -> None:
+    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+    assert text.startswith(f"{TITLE}\n"), f"Expected architecture doc to start with {TITLE!r}"
+    assert text.count(PRD_REFERENCE) == 1, f"Expected exactly one PRD reference: {PRD_REFERENCE}"
+
+
+def test_architecture_has_required_section_headings_in_order() -> None:
+    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+    position = -1
+    for heading in REQUIRED_HEADINGS:
+        next_position = text.find(heading, position + 1)
+        assert next_position != -1, f"Missing heading: {heading}"
+        assert next_position > position, f"Heading out of order: {heading}"
+        position = next_position
+
+
+def test_architecture_sections_include_expected_anchors() -> None:
+    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+    for index, heading in enumerate(REQUIRED_HEADINGS):
+        start = text.index(heading)
+        end = len(text)
+        if index + 1 < len(REQUIRED_HEADINGS):
+            end = text.index(REQUIRED_HEADINGS[index + 1], start + len(heading))
+        section_text = text[start:end]
+
+        for anchor in SECTION_ANCHORS[heading]:
+            assert anchor in section_text, f"Missing anchor in {heading}: {anchor}"
+
+
+def test_architecture_includes_required_phrases_and_omits_forbidden_snippets() -> None:
+    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+    for phrase in REQUIRED_PHRASES:
+        assert phrase in text, f"Missing required phrase: {phrase}"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, f"Forbidden snippet present: {snippet}"
+
+
+def test_architecture_stays_within_line_budget() -> None:
+    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+    assert len(text.splitlines()) <= MAX_LINE_COUNT, f"Architecture doc exceeds line budget of {MAX_LINE_COUNT}"

--- a/tests/meta/test_doc_architecture.py
+++ b/tests/meta/test_doc_architecture.py
@@ -16,10 +16,16 @@ SECTION_ANCHORS: dict[str, list[str]] = {
     "## Layer responsibilities": [
         "Layers 1-3 = `core`, `data`, `simulation`; they are the only v0.1 implementation target.",
         "1. `core` — Stable framework contracts, shared types, and invariants with no domain-specific concepts.",
-        "9. `domains` — Optional domain plugins that adapt the framework to a specific field without changing the core framework.",
+        (
+            "9. `domains` — Optional domain plugins that adapt the framework to a specific field "
+            "without changing the core framework."
+        ),
     ],
     "## Allowed dependency direction": [
-        "The frozen order is `core <- data <- simulation <- agents <- scenario <- evaluation <- evidence <- reporting <- domains`.",
+        (
+            "The frozen order is `core <- data <- simulation <- agents <- scenario <- "
+            "evaluation <- evidence <- reporting <- domains`."
+        ),
         "An ABDP layer may import only itself and layers to its left in that order.",
         "- `abdp.core` imports no sibling layer, no `domains` package, and no domain package directly.",
         "- `domains` may import any lower layer, but no lower layer may import `domains`.",
@@ -60,30 +66,38 @@ FORBIDDEN_SNIPPETS: list[str] = [
 ]
 
 
+def _read_architecture_text() -> str:
+    return ARCHITECTURE_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: list[str]) -> None:
+    position = -1
+    for snippet in snippets:
+        next_position = text.find(snippet, position + 1)
+        assert next_position != -1, f"Missing snippet: {snippet}"
+        assert next_position > position, f"Snippet out of order: {snippet}"
+        position = next_position
+
+
 def test_architecture_file_exists() -> None:
     assert ARCHITECTURE_PATH.is_file(), f"Expected architecture doc at {ARCHITECTURE_PATH}"
 
 
 def test_architecture_has_title_and_single_prd_reference() -> None:
-    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+    text = _read_architecture_text()
 
     assert text.startswith(f"{TITLE}\n"), f"Expected architecture doc to start with {TITLE!r}"
     assert text.count(PRD_REFERENCE) == 1, f"Expected exactly one PRD reference: {PRD_REFERENCE}"
 
 
 def test_architecture_has_required_section_headings_in_order() -> None:
-    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+    text = _read_architecture_text()
 
-    position = -1
-    for heading in REQUIRED_HEADINGS:
-        next_position = text.find(heading, position + 1)
-        assert next_position != -1, f"Missing heading: {heading}"
-        assert next_position > position, f"Heading out of order: {heading}"
-        position = next_position
+    _assert_snippets_in_order(text, REQUIRED_HEADINGS)
 
 
 def test_architecture_sections_include_expected_anchors() -> None:
-    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+    text = _read_architecture_text()
 
     for index, heading in enumerate(REQUIRED_HEADINGS):
         start = text.index(heading)
@@ -97,7 +111,7 @@ def test_architecture_sections_include_expected_anchors() -> None:
 
 
 def test_architecture_includes_required_phrases_and_omits_forbidden_snippets() -> None:
-    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+    text = _read_architecture_text()
 
     for phrase in REQUIRED_PHRASES:
         assert phrase in text, f"Missing required phrase: {phrase}"
@@ -107,6 +121,6 @@ def test_architecture_includes_required_phrases_and_omits_forbidden_snippets() -
 
 
 def test_architecture_stays_within_line_budget() -> None:
-    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+    text = _read_architecture_text()
 
     assert len(text.splitlines()) <= MAX_LINE_COUNT, f"Architecture doc exceeds line budget of {MAX_LINE_COUNT}"


### PR DESCRIPTION
Closes #13

## Summary
Adds `docs/architecture.md` enumerating the nine frozen layers (`core`, `data`, `simulation`, `agents`, `scenario`, `evaluation`, `evidence`, `reporting`, `domains`), the allowed dependency direction (left-to-right; rightward imports are disallowed), and the verbatim hard rules (no domain leakage into `core`, seed-aware randomness, ≥2-domain justification). Locks the contract with a 6-test meta spec.

## TDD evidence
- RED `25cb4ef` — `test: add failing layered architecture meta test (#13)` — adds `tests/meta/test_doc_architecture.py` (6 tests, fail because doc absent).
- GREEN `e480edf` — `docs: add layered architecture (#13)` — adds `docs/architecture.md` (43 lines), all 6 tests pass.
- REFACTOR — `refactor: extract layered-architecture meta-test helpers (#13)` — extracts `_read_architecture_text()` and `_assert_snippets_in_order()` helpers; behavior unchanged.

## Verification (local, .venv312, Python 3.12.13)
- `ruff format --check .` clean
- `ruff check .` All checks passed
- `mypy --strict src tests` Success: no issues found in 19 source files
- `pytest` 51 passed, 100% coverage
- `mutmut run < /dev/null` exit 0 (1 file mutated, 4 ignored; 2/2 mutants caught)

## Oracle
Design session: `ses_24e3c5d95ffewPHXbtGdTBlkbU` (100/100 review pending).