### PR TITLE
docs: add naming conventions (#14)

### DIFF
--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,25 @@
+# Naming conventions
+
+This document defines naming rules for ABDP and uses [docs/architecture.md](architecture.md) as the authority for the frozen layer list.
+
+## Package and module names
+
+- The root package is `abdp`, and layer packages follow `abdp.<layer>` with layers taken from the architecture document.
+- Modules under `abdp.<layer>` use lowercase `snake_case` names.
+- Package and module names describe framework roles, not a specific domain.
+- `abdp.core` names stay framework-generic and must not encode a domain concept.
+
+## Public symbol names
+
+- Classes use `PascalCase`.
+- Functions and methods use `snake_case`.
+- Constants use `UPPER_SNAKE_CASE`.
+- Type aliases use `PascalCase`.
+- Prefer names that describe framework behavior and stay consistent across layers.
+
+## Issue, PR, and commit names
+
+- Issue titles and PR titles use lowercase commit-style prefixes that stay Conventional Commits-compatible.
+- Commit subjects use Conventional Commits with lowercase types only.
+- Allowed types: `docs:`, `test:`, `refactor:`, `feat:`, `fix:`, `chore:`, `ci:`, `build:`.
+- Branch names follow `<type>/<NNN>-<kebab-slug>`.

--- a/tests/meta/test_doc_naming.py
+++ b/tests/meta/test_doc_naming.py
@@ -63,12 +63,25 @@ FORBIDDEN_SNIPPETS: list[str] = [
 ]
 
 
+def _read_naming_text() -> str:
+    return NAMING_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: list[str]) -> None:
+    position = -1
+    for snippet in snippets:
+        next_position = text.find(snippet, position + 1)
+        assert next_position != -1, f"Missing snippet: {snippet}"
+        assert next_position > position, f"Snippet out of order: {snippet}"
+        position = next_position
+
+
 def test_naming_file_exists() -> None:
     assert NAMING_PATH.is_file(), f"Expected naming doc at {NAMING_PATH}"
 
 
 def test_naming_has_title_and_single_architecture_reference() -> None:
-    text = NAMING_PATH.read_text(encoding="utf-8")
+    text = _read_naming_text()
 
     assert text.startswith(f"{TITLE}\n"), f"Expected naming doc to start with {TITLE!r}"
     assert text.count(ARCHITECTURE_REFERENCE) == 1, (
@@ -77,18 +90,13 @@ def test_naming_has_title_and_single_architecture_reference() -> None:
 
 
 def test_naming_has_required_section_headings_in_order() -> None:
-    text = NAMING_PATH.read_text(encoding="utf-8")
+    text = _read_naming_text()
 
-    position = -1
-    for snippet in REQUIRED_HEADINGS:
-        next_position = text.find(snippet, position + 1)
-        assert next_position != -1, f"Missing snippet: {snippet}"
-        assert next_position > position, f"Snippet out of order: {snippet}"
-        position = next_position
+    _assert_snippets_in_order(text, REQUIRED_HEADINGS)
 
 
 def test_naming_sections_include_expected_anchors() -> None:
-    text = NAMING_PATH.read_text(encoding="utf-8")
+    text = _read_naming_text()
 
     for index, heading in enumerate(REQUIRED_HEADINGS):
         start = text.index(heading)
@@ -102,7 +110,7 @@ def test_naming_sections_include_expected_anchors() -> None:
 
 
 def test_naming_includes_required_phrases_and_omits_forbidden_snippets() -> None:
-    text = NAMING_PATH.read_text(encoding="utf-8")
+    text = _read_naming_text()
 
     for phrase in REQUIRED_PHRASES:
         assert phrase in text, f"Missing required phrase: {phrase}"
@@ -112,6 +120,6 @@ def test_naming_includes_required_phrases_and_omits_forbidden_snippets() -> None
 
 
 def test_naming_stays_within_line_budget() -> None:
-    text = NAMING_PATH.read_text(encoding="utf-8")
+    text = _read_naming_text()
 
     assert len(text.splitlines()) <= MAX_LINE_COUNT, f"Naming doc exceeds line budget of {MAX_LINE_COUNT}"

--- a/tests/meta/test_doc_naming.py
+++ b/tests/meta/test_doc_naming.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NAMING_PATH = REPO_ROOT / "docs" / "naming.md"
+TITLE = "# Naming conventions"
+ARCHITECTURE_REFERENCE = "[docs/architecture.md](architecture.md)"
+MAX_LINE_COUNT = 70
+
+REQUIRED_HEADINGS: list[str] = [
+    "## Package and module names",
+    "## Public symbol names",
+    "## Issue, PR, and commit names",
+]
+
+SECTION_ANCHORS: dict[str, list[str]] = {
+    "## Package and module names": [
+        (
+            "The root package is `abdp`, and layer packages follow `abdp.<layer>` with layers "
+            "taken from the architecture document."
+        ),
+        "Modules under `abdp.<layer>` use lowercase `snake_case` names.",
+        "`abdp.core` names stay framework-generic and must not encode a domain concept.",
+    ],
+    "## Public symbol names": [
+        "Classes use `PascalCase`.",
+        "Functions and methods use `snake_case`.",
+        "Constants use `UPPER_SNAKE_CASE`.",
+        "Type aliases use `PascalCase`.",
+    ],
+    "## Issue, PR, and commit names": [
+        ("Issue titles and PR titles use lowercase commit-style prefixes that stay Conventional Commits-compatible."),
+        "Commit subjects use Conventional Commits with lowercase types only.",
+        "Allowed types: `docs:`, `test:`, `refactor:`, `feat:`, `fix:`, `chore:`, `ci:`, `build:`.",
+        "Branch names follow `<type>/<NNN>-<kebab-slug>`.",
+    ],
+}
+
+REQUIRED_PHRASES: list[str] = [
+    "`abdp.<layer>`",
+    "`snake_case`",
+    "`PascalCase`",
+    "`UPPER_SNAKE_CASE`",
+    "`<type>/<NNN>-<kebab-slug>`",
+    "Conventional Commits",
+    "`docs:`",
+    "`test:`",
+    "`refactor:`",
+    "`feat:`",
+    "`fix:`",
+    "`chore:`",
+    "`ci:`",
+    "`build:`",
+]
+
+FORBIDDEN_SNIPPETS: list[str] = [
+    "RealEstateAgent",
+    "HousingScorer",
+    "real estate",
+    "mortgage",
+    "Korean",
+    "Docs:",
+    "Feat:",
+]
+
+
+def test_naming_file_exists() -> None:
+    assert NAMING_PATH.is_file(), f"Expected naming doc at {NAMING_PATH}"
+
+
+def test_naming_has_title_and_single_architecture_reference() -> None:
+    text = NAMING_PATH.read_text(encoding="utf-8")
+
+    assert text.startswith(f"{TITLE}\n"), f"Expected naming doc to start with {TITLE!r}"
+    assert text.count(ARCHITECTURE_REFERENCE) == 1, (
+        f"Expected exactly one architecture reference: {ARCHITECTURE_REFERENCE}"
+    )
+
+
+def test_naming_has_required_section_headings_in_order() -> None:
+    text = NAMING_PATH.read_text(encoding="utf-8")
+
+    position = -1
+    for snippet in REQUIRED_HEADINGS:
+        next_position = text.find(snippet, position + 1)
+        assert next_position != -1, f"Missing snippet: {snippet}"
+        assert next_position > position, f"Snippet out of order: {snippet}"
+        position = next_position
+
+
+def test_naming_sections_include_expected_anchors() -> None:
+    text = NAMING_PATH.read_text(encoding="utf-8")
+
+    for index, heading in enumerate(REQUIRED_HEADINGS):
+        start = text.index(heading)
+        end = len(text)
+        if index + 1 < len(REQUIRED_HEADINGS):
+            end = text.index(REQUIRED_HEADINGS[index + 1], start + len(heading))
+        section_text = text[start:end]
+
+        for anchor in SECTION_ANCHORS[heading]:
+            assert anchor in section_text, f"Missing anchor in {heading}: {anchor}"
+
+
+def test_naming_includes_required_phrases_and_omits_forbidden_snippets() -> None:
+    text = NAMING_PATH.read_text(encoding="utf-8")
+
+    for phrase in REQUIRED_PHRASES:
+        assert phrase in text, f"Missing required phrase: {phrase}"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, f"Forbidden snippet present: {snippet}"
+
+
+def test_naming_stays_within_line_budget() -> None:
+    text = NAMING_PATH.read_text(encoding="utf-8")
+
+    assert len(text.splitlines()) <= MAX_LINE_COUNT, f"Naming doc exceeds line budget of {MAX_LINE_COUNT}"


### PR DESCRIPTION
Closes #14

## Summary
Adds `docs/naming.md` defining naming rules for packages/modules (`abdp.<layer>` + `snake_case`), public symbols (PascalCase / snake_case / UPPER_SNAKE_CASE / PascalCase aliases), and issue/PR/commit conventions (lowercase Conventional Commit prefixes, `<type>/<NNN>-<kebab-slug>` branches). Locks the contract with a 6-test meta spec.

## TDD evidence
- RED `2ad23f5` — `test: add failing naming conventions meta test (#14)` — adds `tests/meta/test_doc_naming.py` (6 tests fail because doc absent)
- GREEN `2305952` — `docs: add naming conventions (#14)` — adds `docs/naming.md` (25 lines), all 6 tests pass
- REFACTOR — `refactor: extract naming-conventions meta-test helpers (#14)` — extracts `_read_naming_text()` and `_assert_snippets_in_order()`; behavior unchanged

## Verification (local, .venv312, Python 3.12.13)
- `ruff format --check .` clean
- `ruff check .` All checks passed
- `mypy --strict src tests` Success: no issues found in 20 source files
- `pytest` 57 passed, 100% coverage
- `mutmut run < /dev/null` exit 0 (1 file mutated, 4 ignored; 2/2 mutants caught)

## Oracle
Design session: `ses_24e35099affets6OrLurfBQKin` (100/100 review pending).