### PR TITLE
docs: add repository structure guide (#15)

### DIFF
--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -1,0 +1,52 @@
+# Repository structure
+
+This guide fixes the repository layout for ABDP. [docs/architecture.md](architecture.md) is the authority for layer names; `docs/naming.md` and `docs/prd.md` stay authoritative for naming rules and the v0.1 scope boundary.
+
+## Current top-level tree
+
+```text
+.github/workflows/ci.yml
+AGENTS.md
+CONTRIBUTING.md
+LICENSE
+README.md
+docs/
+  README.md
+  adr/
+  architecture.md
+  development/
+  examples/
+  models/
+  naming.md
+  prd.md
+  vision.md
+mypy.ini
+pyproject.toml
+pytest.ini
+src/
+  abdp/
+    __init__.py
+    core/
+    data/
+    py.typed
+    simulation/
+    version.py
+tests/
+  meta/
+  unit/
+```
+
+## Placement rules
+
+- `src/abdp/` holds framework source code, with layer packages such as `abdp.core`, `abdp.data`, and `abdp.simulation`.
+- New layer code follows `src/abdp/<layer>/`, and layer names come from the architecture document.
+- `tests/meta/` holds repository and documentation contract tests.
+- `tests/unit/` holds unit tests for code under `src/abdp/`.
+- `docs/` holds framework documentation only and does not hold executable framework code.
+
+## Reserved domains layer
+
+- `abdp.domains` stays reserved as the framework layer name.
+- Real domain plugins ship as separate Python packages, not under `src/abdp/domains/`.
+- Example domain plugins follow the same rule and stay outside the `src/abdp/` tree.
+- Do not add domain-specific package names anywhere under `src/abdp/`.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -1,6 +1,8 @@
 # Repository structure
 
-This guide fixes the repository layout for ABDP. [docs/architecture.md](architecture.md) is the authority for layer names; `docs/naming.md` and `docs/prd.md` stay authoritative for naming rules and the v0.1 scope boundary.
+This guide fixes the repository layout for ABDP.
+[docs/architecture.md](architecture.md) is the authority for layer names;
+`docs/naming.md` and `docs/prd.md` stay authoritative for naming rules and the v0.1 scope boundary.
 
 ## Current top-level tree
 

--- a/tests/meta/test_doc_repository_structure.py
+++ b/tests/meta/test_doc_repository_structure.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY_STRUCTURE_PATH = REPO_ROOT / "docs" / "repository-structure.md"
+TITLE = "# Repository structure"
+ARCHITECTURE_REFERENCE = "[docs/architecture.md](architecture.md)"
+MAX_LINE_COUNT = 70
+
+REQUIRED_HEADINGS: list[str] = [
+    "## Current top-level tree",
+    "## Placement rules",
+    "## Reserved domains layer",
+]
+
+SECTION_ANCHORS: dict[str, list[str]] = {
+    "## Current top-level tree": [
+        ".github/workflows/ci.yml",
+        "docs/",
+        "src/",
+        "tests/",
+    ],
+    "## Placement rules": [
+        (
+            "`src/abdp/` holds framework source code, with layer packages such as "
+            "`abdp.core`, `abdp.data`, and `abdp.simulation`."
+        ),
+        "New layer code follows `src/abdp/<layer>/`, and layer names come from the architecture document.",
+        "`tests/meta/` holds repository and documentation contract tests.",
+        "`tests/unit/` holds unit tests for code under `src/abdp/`.",
+        "`docs/` holds framework documentation only and does not hold executable framework code.",
+    ],
+    "## Reserved domains layer": [
+        "`abdp.domains` stays reserved as the framework layer name.",
+        "Real domain plugins ship as separate Python packages, not under `src/abdp/domains/`.",
+        "Example domain plugins follow the same rule and stay outside the `src/abdp/` tree.",
+        "Do not add domain-specific package names anywhere under `src/abdp/`.",
+    ],
+}
+
+REQUIRED_PHRASES: list[str] = [
+    "`src/abdp/`",
+    "`src/abdp/<layer>/`",
+    "`tests/meta/`",
+    "`tests/unit/`",
+    "`docs/`",
+    "`abdp.domains`",
+    "`abdp.core`",
+    "`abdp.data`",
+    "`abdp.simulation`",
+    "`docs/naming.md`",
+    "`docs/prd.md`",
+    "separate Python packages",
+]
+
+FORBIDDEN_SNIPPETS: list[str] = [
+    "abdp/realestate/",
+    "abdp/housing/",
+    "RealEstateAgent",
+    "Korean",
+    "mortgage",
+]
+
+
+def test_repository_structure_file_exists() -> None:
+    assert REPOSITORY_STRUCTURE_PATH.is_file(), f"Expected repository structure doc at {REPOSITORY_STRUCTURE_PATH}"
+
+
+def test_repository_structure_has_title_and_single_architecture_reference() -> None:
+    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+
+    assert text.startswith(f"{TITLE}\n"), f"Expected repository structure doc to start with {TITLE!r}"
+    assert text.count(ARCHITECTURE_REFERENCE) == 1, (
+        f"Expected exactly one architecture reference: {ARCHITECTURE_REFERENCE}"
+    )
+
+
+def test_repository_structure_has_required_section_headings_in_order() -> None:
+    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+
+    position = -1
+    for snippet in REQUIRED_HEADINGS:
+        next_position = text.find(snippet, position + 1)
+        assert next_position != -1, f"Missing snippet: {snippet}"
+        assert next_position > position, f"Snippet out of order: {snippet}"
+        position = next_position
+
+
+def test_repository_structure_sections_include_expected_anchors() -> None:
+    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+
+    for index, heading in enumerate(REQUIRED_HEADINGS):
+        start = text.index(heading)
+        end = len(text)
+        if index + 1 < len(REQUIRED_HEADINGS):
+            end = text.index(REQUIRED_HEADINGS[index + 1], start + len(heading))
+        section_text = text[start:end]
+
+        for anchor in SECTION_ANCHORS[heading]:
+            assert anchor in section_text, f"Missing anchor in {heading}: {anchor}"
+
+
+def test_repository_structure_includes_required_phrases_and_omits_forbidden_snippets() -> None:
+    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+
+    for phrase in REQUIRED_PHRASES:
+        assert phrase in text, f"Missing required phrase: {phrase}"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, f"Forbidden snippet present: {snippet}"
+
+
+def test_repository_structure_stays_within_line_budget() -> None:
+    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+
+    assert len(text.splitlines()) <= MAX_LINE_COUNT, f"Repository structure doc exceeds line budget of {MAX_LINE_COUNT}"

--- a/tests/meta/test_doc_repository_structure.py
+++ b/tests/meta/test_doc_repository_structure.py
@@ -61,12 +61,25 @@ FORBIDDEN_SNIPPETS: list[str] = [
 ]
 
 
+def _read_repository_structure_text() -> str:
+    return REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: list[str]) -> None:
+    position = -1
+    for snippet in snippets:
+        next_position = text.find(snippet, position + 1)
+        assert next_position != -1, f"Missing snippet: {snippet}"
+        assert next_position > position, f"Snippet out of order: {snippet}"
+        position = next_position
+
+
 def test_repository_structure_file_exists() -> None:
     assert REPOSITORY_STRUCTURE_PATH.is_file(), f"Expected repository structure doc at {REPOSITORY_STRUCTURE_PATH}"
 
 
 def test_repository_structure_has_title_and_single_architecture_reference() -> None:
-    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+    text = _read_repository_structure_text()
 
     assert text.startswith(f"{TITLE}\n"), f"Expected repository structure doc to start with {TITLE!r}"
     assert text.count(ARCHITECTURE_REFERENCE) == 1, (
@@ -75,18 +88,13 @@ def test_repository_structure_has_title_and_single_architecture_reference() -> N
 
 
 def test_repository_structure_has_required_section_headings_in_order() -> None:
-    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+    text = _read_repository_structure_text()
 
-    position = -1
-    for snippet in REQUIRED_HEADINGS:
-        next_position = text.find(snippet, position + 1)
-        assert next_position != -1, f"Missing snippet: {snippet}"
-        assert next_position > position, f"Snippet out of order: {snippet}"
-        position = next_position
+    _assert_snippets_in_order(text, REQUIRED_HEADINGS)
 
 
 def test_repository_structure_sections_include_expected_anchors() -> None:
-    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+    text = _read_repository_structure_text()
 
     for index, heading in enumerate(REQUIRED_HEADINGS):
         start = text.index(heading)
@@ -100,7 +108,7 @@ def test_repository_structure_sections_include_expected_anchors() -> None:
 
 
 def test_repository_structure_includes_required_phrases_and_omits_forbidden_snippets() -> None:
-    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+    text = _read_repository_structure_text()
 
     for phrase in REQUIRED_PHRASES:
         assert phrase in text, f"Missing required phrase: {phrase}"
@@ -110,6 +118,6 @@ def test_repository_structure_includes_required_phrases_and_omits_forbidden_snip
 
 
 def test_repository_structure_stays_within_line_budget() -> None:
-    text = REPOSITORY_STRUCTURE_PATH.read_text(encoding="utf-8")
+    text = _read_repository_structure_text()
 
     assert len(text.splitlines()) <= MAX_LINE_COUNT, f"Repository structure doc exceeds line budget of {MAX_LINE_COUNT}"


### PR DESCRIPTION
Closes #15

## Summary
Adds `docs/repository-structure.md` documenting the current top-level tree, placement rules for `src/`, `tests/`, and `docs/`, and the reservation of `abdp.domains` as a framework layer name (real domain plugins ship as separate Python packages, not under `src/abdp/`). Locks the contract with a 6-test meta spec.

## TDD evidence
- RED `99fd052` — `test: add failing repository structure meta test (#15)` — adds `tests/meta/test_doc_repository_structure.py` (6 tests fail because doc absent)
- GREEN `ebf3e5d` — `docs: add repository structure guide (#15)` — adds `docs/repository-structure.md` (52 lines), all 6 tests pass
- REFACTOR — `refactor: extract repository-structure meta-test helpers (#15)` — extracts `_read_repository_structure_text()` and `_assert_snippets_in_order()`; behavior unchanged

## Verification (local, .venv312, Python 3.12.13)
- `ruff format --check .` clean
- `ruff check .` All checks passed
- `mypy --strict src tests` Success: no issues found in 21 source files
- `pytest` 63 passed, 100% coverage
- `mutmut run < /dev/null` exit 0 (1 file mutated, 4 ignored; 2/2 mutants caught)

## Oracle
Design session: `ses_24e2f5c02ffeoBzExFOYk2KLFa` (100/100 review pending).