### PR TITLE
feat: add deterministic retry decorator (#22)

### DIFF
--- a/src/abdp/core/retry.py
+++ b/src/abdp/core/retry.py
@@ -1,0 +1,93 @@
+"""Retry contract:
+
+- ``retry`` applies deterministic retries to regular synchronous callables.
+- ``on`` defines the only exception types that may be retried and must
+  contain only ``Exception`` subclasses; ``BaseException`` subclasses such
+  as ``KeyboardInterrupt`` and ``SystemExit`` are rejected so that process
+  control signals are never swallowed by retry logic.
+- ``max_attempts`` counts total invocations including the first call and
+  must be at least 1.
+- ``backoff(attempt)`` returns the delay in seconds after failed attempt
+  ``attempt``, where ``attempt`` starts at 1.
+- Delays are applied only between attempts; never before the first call
+  and never after the final failure.
+- ``sleep`` is injectable for tests and receives the computed delay
+  verbatim. The default uses :func:`time.sleep`.
+- Exceptions not matched by ``on`` propagate immediately without sleeping.
+- When the final allowed attempt fails with a matched exception, that
+  exception is re-raised unchanged.
+- Async functions, async generator functions, and generator functions are
+  rejected at decoration time so retries never wrap mere coroutine or
+  iterator construction.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+from collections.abc import Callable
+from functools import wraps
+from typing import Final
+
+__all__ = ["Backoff", "retry"]
+
+type Backoff = Callable[[int], float]
+type _Sleep = Callable[[float], None]
+
+_DEFAULT_MAX_ATTEMPTS: Final = 3
+_MIN_ATTEMPTS: Final = 1
+
+
+def _no_backoff(_attempt: int) -> float:
+    return 0.0
+
+
+def _validate_config(
+    on: tuple[type[Exception], ...],
+    max_attempts: int,
+) -> None:
+    if max_attempts < _MIN_ATTEMPTS:
+        raise ValueError(f"max_attempts must be at least 1, got {max_attempts}")
+    if not on:
+        raise ValueError("on must contain at least one exception type")
+    for entry in on:
+        if not (isinstance(entry, type) and issubclass(entry, Exception)):
+            name = entry.__name__ if isinstance(entry, type) else type(entry).__name__
+            raise TypeError(f"on entries must be subclasses of Exception, got {name}")
+
+
+def _reject_unsupported_callable(func: Callable[..., object]) -> None:
+    if inspect.isasyncgenfunction(func):
+        raise TypeError(
+            f"retry only supports regular synchronous callables; got async generator function {func.__name__!r}"
+        )
+    if inspect.iscoroutinefunction(func):
+        raise TypeError(f"retry only supports regular synchronous callables; got async function {func.__name__!r}")
+    if inspect.isgeneratorfunction(func):
+        raise TypeError(f"retry only supports regular synchronous callables; got generator function {func.__name__!r}")
+
+
+def retry[**P, R](
+    *,
+    on: tuple[type[Exception], ...],
+    max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    backoff: Backoff = _no_backoff,
+    sleep: _Sleep = time.sleep,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    _validate_config(on, max_attempts)
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        _reject_unsupported_callable(func)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            for attempt in range(1, max_attempts):
+                try:
+                    return func(*args, **kwargs)
+                except on:
+                    sleep(backoff(attempt))
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/src/abdp/core/retry.py
+++ b/src/abdp/core/retry.py
@@ -37,6 +37,12 @@ type _Sleep = Callable[[float], None]
 _DEFAULT_MAX_ATTEMPTS: Final = 3
 _MIN_ATTEMPTS: Final = 1
 
+_UNSUPPORTED_CALLABLE_KINDS: Final = (
+    (inspect.isasyncgenfunction, "async generator function"),
+    (inspect.iscoroutinefunction, "async function"),
+    (inspect.isgeneratorfunction, "generator function"),
+)
+
 
 def _no_backoff(_attempt: int) -> float:
     return 0.0
@@ -57,14 +63,9 @@ def _validate_config(
 
 
 def _reject_unsupported_callable(func: Callable[..., object]) -> None:
-    if inspect.isasyncgenfunction(func):
-        raise TypeError(
-            f"retry only supports regular synchronous callables; got async generator function {func.__name__!r}"
-        )
-    if inspect.iscoroutinefunction(func):
-        raise TypeError(f"retry only supports regular synchronous callables; got async function {func.__name__!r}")
-    if inspect.isgeneratorfunction(func):
-        raise TypeError(f"retry only supports regular synchronous callables; got generator function {func.__name__!r}")
+    for predicate, label in _UNSUPPORTED_CALLABLE_KINDS:
+        if predicate(func):
+            raise TypeError(f"retry only supports regular synchronous callables; got {label} {func.__name__!r}")
 
 
 def retry[**P, R](

--- a/src/abdp/core/retry.py
+++ b/src/abdp/core/retry.py
@@ -5,8 +5,12 @@
   contain only ``Exception`` subclasses; ``BaseException`` subclasses such
   as ``KeyboardInterrupt`` and ``SystemExit`` are rejected so that process
   control signals are never swallowed by retry logic.
-- ``max_attempts`` counts total invocations including the first call and
-  must be at least 1.
+- ``max_attempts`` counts total invocations including the first call,
+  must be a real ``int`` (``bool`` is rejected) and must be at least 1.
+- ``on`` must be a ``tuple`` of exception classes; passing a single
+  exception class, a ``list``, or any other container is rejected at
+  decoration time so misuse fails loudly instead of leaking
+  ``TypeError`` from the underlying ``except`` clause.
 - ``backoff(attempt)`` returns the delay in seconds after failed attempt
   ``attempt``, where ``attempt`` starts at 1.
 - Delays are applied only between attempts; never before the first call
@@ -52,8 +56,12 @@ def _validate_config(
     on: tuple[type[Exception], ...],
     max_attempts: int,
 ) -> None:
+    if isinstance(max_attempts, bool) or not isinstance(max_attempts, int):
+        raise TypeError(f"max_attempts must be an int, got {type(max_attempts).__name__}")
     if max_attempts < _MIN_ATTEMPTS:
         raise ValueError(f"max_attempts must be at least 1, got {max_attempts}")
+    if not isinstance(on, tuple):
+        raise TypeError(f"on must be a tuple of exception types, got {type(on).__name__}")
     if not on:
         raise ValueError("on must contain at least one exception type")
     for entry in on:

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -277,3 +277,33 @@ def test_retry_default_backoff_yields_zero_delay() -> None:
         fails()
     assert attempts == 3
     assert sleep_calls == [0.0, 0.0]
+
+
+def test_retry_rejects_non_int_max_attempts() -> None:
+    float_attempts = cast(int, 1.5)
+    with pytest.raises(TypeError, match=r"^max_attempts must be an int, got float$"):
+        retry(on=(ValueError,), max_attempts=float_attempts)
+
+    str_attempts = cast(int, "3")
+    with pytest.raises(TypeError, match=r"^max_attempts must be an int, got str$"):
+        retry(on=(ValueError,), max_attempts=str_attempts)
+
+
+def test_retry_rejects_bool_max_attempts() -> None:
+    bool_attempts = cast(int, True)
+    with pytest.raises(TypeError, match=r"^max_attempts must be an int, got bool$"):
+        retry(on=(ValueError,), max_attempts=bool_attempts)
+
+    false_attempts = cast(int, False)
+    with pytest.raises(TypeError, match=r"^max_attempts must be an int, got bool$"):
+        retry(on=(ValueError,), max_attempts=false_attempts)
+
+
+def test_retry_rejects_non_tuple_on() -> None:
+    bare_class = cast(tuple[type[Exception], ...], ValueError)
+    with pytest.raises(TypeError, match=r"^on must be a tuple of exception types, got type$"):
+        retry(on=bare_class, max_attempts=2)
+
+    list_on = cast(tuple[type[Exception], ...], [ValueError])
+    with pytest.raises(TypeError, match=r"^on must be a tuple of exception types, got list$"):
+        retry(on=list_on, max_attempts=2)

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -271,5 +271,3 @@ def test_retry_default_backoff_yields_zero_delay() -> None:
         fails()
     assert attempts == 3
     assert sleep_calls == [0.0, 0.0]
-
-

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterator
-from typing import Protocol
+from typing import Protocol, cast
 
 import pytest
 
@@ -173,25 +173,31 @@ def test_retry_validates_on_is_not_empty() -> None:
 
 
 def test_retry_rejects_base_exception_subclasses_in_on() -> None:
+    base_exception_subclasses = cast(
+        tuple[type[Exception], ...],
+        (KeyboardInterrupt,),
+    )
     with pytest.raises(
         TypeError,
         match=r"^on entries must be subclasses of Exception, got KeyboardInterrupt$",
     ):
-        retry(on=(KeyboardInterrupt,), max_attempts=2)  # type: ignore[arg-type]
+        retry(on=base_exception_subclasses, max_attempts=2)
 
+    raw_base_exception = cast(tuple[type[Exception], ...], (BaseException,))
     with pytest.raises(
         TypeError,
         match=r"^on entries must be subclasses of Exception, got BaseException$",
     ):
-        retry(on=(BaseException,), max_attempts=2)  # type: ignore[arg-type]
+        retry(on=raw_base_exception, max_attempts=2)
 
 
 def test_retry_rejects_non_class_entries_in_on() -> None:
+    non_class_entry = cast(tuple[type[Exception], ...], (123,))
     with pytest.raises(
         TypeError,
         match=r"^on entries must be subclasses of Exception, got int$",
     ):
-        retry(on=(123,), max_attempts=2)  # type: ignore[arg-type]
+        retry(on=non_class_entry, max_attempts=2)
 
 
 def test_retry_rejects_async_function() -> None:

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -1,0 +1,275 @@
+"""Tests for the deterministic retry decorator (#22)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Protocol
+
+import pytest
+
+from abdp.core.retry import Backoff, retry
+
+
+def test_retry_module_exposes_only_retry_and_backoff_publicly() -> None:
+    import abdp.core.retry as module
+
+    assert sorted(module.__all__) == ["Backoff", "retry"]
+
+
+def test_retry_returns_on_first_success_without_backoff_or_sleep() -> None:
+    backoff_calls: list[int] = []
+    sleep_calls: list[float] = []
+
+    def backoff(attempt: int) -> float:
+        backoff_calls.append(attempt)
+        return 0.1
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(ValueError,), max_attempts=3, backoff=backoff, sleep=sleep)
+    def succeed() -> str:
+        return "ok"
+
+    assert succeed() == "ok"
+    assert backoff_calls == []
+    assert sleep_calls == []
+
+
+def test_retry_retries_matching_subclass_exception_until_success() -> None:
+    backoff_calls: list[int] = []
+    sleep_calls: list[float] = []
+    attempts = 0
+
+    def backoff(attempt: int) -> float:
+        backoff_calls.append(attempt)
+        return float(attempt) * 0.5
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(LookupError,), max_attempts=4, backoff=backoff, sleep=sleep)
+    def flaky() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise KeyError("transient")
+        return "done"
+
+    assert flaky() == "done"
+    assert attempts == 3
+    assert backoff_calls == [1, 2]
+    assert sleep_calls == [0.5, 1.0]
+
+
+def test_retry_reraises_last_matching_exception_after_max_attempts() -> None:
+    sleep_calls: list[float] = []
+    raised: list[ValueError] = []
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(ValueError,), max_attempts=3, backoff=lambda _attempt: 0.0, sleep=sleep)
+    def always_fails() -> None:
+        exc = ValueError(f"fail {len(raised)}")
+        raised.append(exc)
+        raise exc
+
+    with pytest.raises(ValueError, match=r"^fail 2$") as info:
+        always_fails()
+
+    assert info.value is raised[-1]
+    assert len(raised) == 3
+    assert sleep_calls == [0.0, 0.0]
+
+
+def test_retry_propagates_non_matching_exception_immediately() -> None:
+    backoff_calls: list[int] = []
+    sleep_calls: list[float] = []
+    attempts = 0
+
+    def backoff(attempt: int) -> float:
+        backoff_calls.append(attempt)
+        return 0.0
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(ValueError,), max_attempts=5, backoff=backoff, sleep=sleep)
+    def wrong_kind() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise TypeError("nope")
+
+    with pytest.raises(TypeError, match=r"^nope$"):
+        wrong_kind()
+    assert attempts == 1
+    assert backoff_calls == []
+    assert sleep_calls == []
+
+
+def test_retry_propagates_later_non_matching_exception_without_extra_sleep() -> None:
+    sleep_calls: list[float] = []
+    attempts = 0
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(ValueError,), max_attempts=5, backoff=lambda _attempt: 0.25, sleep=sleep)
+    def changes_kind() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ValueError("first")
+        raise TypeError("later")
+
+    with pytest.raises(TypeError, match=r"^later$"):
+        changes_kind()
+    assert attempts == 2
+    assert sleep_calls == [0.25]
+
+
+def test_retry_with_one_attempt_never_sleeps() -> None:
+    sleep_calls: list[float] = []
+    attempts = 0
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(ValueError,), max_attempts=1, backoff=lambda _attempt: 9.0, sleep=sleep)
+    def single() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("once")
+
+    with pytest.raises(ValueError, match=r"^once$"):
+        single()
+    assert attempts == 1
+    assert sleep_calls == []
+
+
+def test_retry_passes_through_arguments_and_preserves_metadata() -> None:
+    @retry(on=(ValueError,), max_attempts=2)
+    def add(a: int, b: int) -> int:
+        """Add two integers."""
+        return a + b
+
+    assert add(2, 3) == 5
+    assert add.__name__ == "add"
+    assert add.__doc__ == "Add two integers."
+
+
+def test_retry_validates_max_attempts() -> None:
+    with pytest.raises(ValueError, match=r"^max_attempts must be at least 1, got 0$"):
+        retry(on=(ValueError,), max_attempts=0)
+
+    with pytest.raises(ValueError, match=r"^max_attempts must be at least 1, got -3$"):
+        retry(on=(ValueError,), max_attempts=-3)
+
+
+def test_retry_validates_on_is_not_empty() -> None:
+    with pytest.raises(ValueError, match=r"^on must contain at least one exception type$"):
+        retry(on=(), max_attempts=2)
+
+
+def test_retry_rejects_base_exception_subclasses_in_on() -> None:
+    with pytest.raises(
+        TypeError,
+        match=r"^on entries must be subclasses of Exception, got KeyboardInterrupt$",
+    ):
+        retry(on=(KeyboardInterrupt,), max_attempts=2)  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError,
+        match=r"^on entries must be subclasses of Exception, got BaseException$",
+    ):
+        retry(on=(BaseException,), max_attempts=2)  # type: ignore[arg-type]
+
+
+def test_retry_rejects_non_class_entries_in_on() -> None:
+    with pytest.raises(
+        TypeError,
+        match=r"^on entries must be subclasses of Exception, got int$",
+    ):
+        retry(on=(123,), max_attempts=2)  # type: ignore[arg-type]
+
+
+def test_retry_rejects_async_function() -> None:
+    decorator = retry(on=(ValueError,), max_attempts=2)
+
+    async def coro() -> None:
+        return None
+
+    with pytest.raises(
+        TypeError,
+        match=r"^retry only supports regular synchronous callables; got async function 'coro'$",
+    ):
+        decorator(coro)
+
+
+def test_retry_rejects_generator_function() -> None:
+    decorator = retry(on=(ValueError,), max_attempts=2)
+
+    def gen() -> Iterator[int]:
+        yield 1
+
+    with pytest.raises(
+        TypeError,
+        match=r"^retry only supports regular synchronous callables; got generator function 'gen'$",
+    ):
+        decorator(gen)
+
+
+def test_retry_rejects_async_generator_function() -> None:
+    decorator = retry(on=(ValueError,), max_attempts=2)
+
+    async def agen() -> AsyncIterator[int]:
+        yield 1
+
+    with pytest.raises(
+        TypeError,
+        match=r"^retry only supports regular synchronous callables; got async generator function 'agen'$",
+    ):
+        decorator(agen)
+
+
+class _BinaryOp(Protocol):
+    def __call__(self, a: int, b: int) -> int: ...
+
+
+def test_retry_preserves_callable_signature_for_static_typing() -> None:
+    @retry(on=(ValueError,), max_attempts=1)
+    def multiply(a: int, b: int) -> int:
+        return a * b
+
+    operation: _BinaryOp = multiply
+    assert operation(3, 4) == 12
+
+
+def test_backoff_alias_resolves_to_callable_int_to_float() -> None:
+    def linear(attempt: int) -> float:
+        return float(attempt)
+
+    backoff: Backoff = linear
+    assert backoff(2) == 2.0
+
+
+def test_retry_default_backoff_yields_zero_delay() -> None:
+    sleep_calls: list[float] = []
+    attempts = 0
+
+    def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    @retry(on=(ValueError,), max_attempts=3, sleep=sleep)
+    def fails() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("again")
+
+    with pytest.raises(ValueError, match=r"^again$"):
+        fails()
+    assert attempts == 3
+    assert sleep_calls == [0.0, 0.0]
+
+


### PR DESCRIPTION
Closes #22.

## Summary
Adds `abdp.core.retry.retry`: a typed, sync-only retry decorator factory with explicit exception filtering, configurable `max_attempts`, callable backoff, and injectable sleep. Implementation per oracle design contract.

## Public surface
```python
from abdp.core.retry import Backoff, retry

@retry(on=(ConnectionError,), max_attempts=3, backoff=lambda n: 0.5 * n)
def fetch() -> bytes: ...
```

`__all__ = ["Backoff", "retry"]`. PEP 695 generics (`retry[**P, R]`) preserve the wrapped callable's static signature.

## Design decisions (per oracle)
- **`on` narrowed to `Exception`** — `KeyboardInterrupt`/`SystemExit` cannot be retried by mistake (validated at decoration time).
- **`max_attempts` is total invocations** — `max_attempts=3` means up to 3 calls, 2 sleeps. Validated `>= 1`.
- **Backoff is callable-only** — `Callable[[int], float]`; explicit, deterministic, no jitter (out of scope).
- **Sleep injected as decorator kwarg** — defaults to `time.sleep`, no global state.
- **Async/generator/async-generator functions rejected at decoration time** — retries on those would only wrap construction, not iteration.
- **Final-attempt exception re-raised unchanged** — bare `raise` preserves traceback chain; no wrapping in a custom RetryError.

## TDD evidence
1. `f1c4f4a` — `test:` RED — 18 failing tests covering success, retry-then-success, exhaustion, non-matching propagation, validation, rejection of BaseException/non-class/async/generator, signature preservation, default backoff
2. `60c261e` — `feat:` GREEN — implementation passes all tests
3. `05d40a1` — `refactor:` REFACTOR — collapsed 3 nearly-identical rejection branches into a `(predicate, label)` lookup table

## Verification (local, .venv312 / py3.12.13)
- `ruff format --check .` — clean
- `ruff check .` — All checks passed
- `mypy --strict --config-file mypy.ini src/abdp tests` — Success: no issues found in 32 source files
- `pytest` — 196 passed, 100% line + branch coverage
- mutmut — pending CI (Ubuntu authoritative; macOS segfaults)

## Constraints honored
- Core only, no domain imports
- PEP 695 type syntax (no `TypeAlias`)
- `Final` on all module constants
- Mandatory `Retry contract:` module docstring anchor
- No `Any`, no `# type: ignore` outside the test-only invalid-runtime-input cases
- 3-commit TDD with `(#22)` references