### PR TITLE
feat: add core connector protocol (#24)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,4 +14,4 @@ exclude_lines =
     ^\s*\.\.\.\s*$
 partial_branches =
     pragma: no branch
-    \.\.\.
+    ^\s*(?:async\s+def|def)\b.*:\s*\.\.\.\s*$

--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,7 @@ exclude_lines =
     pragma: no cover
     if __name__ == "__main__":
     if TYPE_CHECKING:
+    ^\s*\.\.\.\s*$
+partial_branches =
+    pragma: no branch
+    \.\.\.

--- a/src/abdp/core/connectors.py
+++ b/src/abdp/core/connectors.py
@@ -1,0 +1,26 @@
+"""Core connector protocol contract:
+
+- Defines the minimal core connector contract.
+- Domain-neutral and transport-agnostic.
+- Synchronous only.
+- Contract consists of ``name`` and ``send(request) -> response``.
+- Intended for structural typing in core; implementations live outside core.
+- Runtime protocol checks are shallow: they verify attribute presence only and
+  do not validate call signatures or generic type arguments.
+- No guarantees about retries, rate limiting, thread safety, connection
+  lifecycle, or resource management.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["Connector"]
+
+
+@runtime_checkable
+class Connector[RequestT, ResponseT](Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def send(self, request: RequestT) -> ResponseT: ...

--- a/tests/core/test_connectors.py
+++ b/tests/core/test_connectors.py
@@ -1,0 +1,55 @@
+"""Conformance tests for the core connector protocol contract."""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from abdp.core import connectors
+from abdp.core.connectors import Connector
+
+
+class _ValidConnector:
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    def send(self, request: int) -> str:
+        return str(request)
+
+
+class _MissingSend:
+    @property
+    def name(self) -> str:
+        return "no-send"
+
+
+class _MissingName:
+    def send(self, request: int) -> str:
+        return str(request)
+
+
+def test_connectors_module_exports_connector() -> None:
+    assert connectors.__all__ == ["Connector"]
+    assert connectors.Connector is Connector
+
+
+def test_connector_is_protocol() -> None:
+    assert getattr(Connector, "_is_protocol", False) is True
+
+
+def test_connector_is_runtime_checkable_and_accepts_minimal_structural_impl() -> None:
+    dummy = _ValidConnector()
+    assert isinstance(dummy, Connector) is True
+    connector: Connector[int, str] = dummy
+    response = connector.send(1)
+    assert_type(response, str)
+    assert response == "1"
+    assert connector.name == "dummy"
+
+
+def test_connector_runtime_check_rejects_missing_send() -> None:
+    assert isinstance(_MissingSend(), Connector) is False
+
+
+def test_connector_runtime_check_rejects_missing_name() -> None:
+    assert isinstance(_MissingName(), Connector) is False

--- a/tests/meta/test_tooling_config.py
+++ b/tests/meta/test_tooling_config.py
@@ -39,7 +39,7 @@ EXPECTED_COVERAGE_EXCLUDE_LINES = (
 )
 EXPECTED_COVERAGE_PARTIAL_BRANCHES = (
     "pragma: no branch",
-    r"\.\.\.",
+    r"^\s*(?:async\s+def|def)\b.*:\s*\.\.\.\s*$",
 )
 
 EXPECTED_RUNTIME_DEPENDENCIES: list[str] = []

--- a/tests/meta/test_tooling_config.py
+++ b/tests/meta/test_tooling_config.py
@@ -35,6 +35,11 @@ EXPECTED_COVERAGE_EXCLUDE_LINES = (
     "pragma: no cover",
     'if __name__ == "__main__":',
     "if TYPE_CHECKING:",
+    r"^\s*\.\.\.\s*$",
+)
+EXPECTED_COVERAGE_PARTIAL_BRANCHES = (
+    "pragma: no branch",
+    r"\.\.\.",
 )
 
 EXPECTED_RUNTIME_DEPENDENCIES: list[str] = []
@@ -122,6 +127,7 @@ def test_coverage_configuration_requires_full_branch_coverage_for_package_code()
     assert coverage_config.getboolean("report", "show_missing") is True
     assert coverage_config.getboolean("report", "skip_covered") is True
     assert _split_lines(coverage_config["report"]["exclude_lines"]) == EXPECTED_COVERAGE_EXCLUDE_LINES
+    assert _split_lines(coverage_config["report"]["partial_branches"]) == EXPECTED_COVERAGE_PARTIAL_BRANCHES
 
 
 def test_pyproject_dev_extras_include_required_tooling_dependencies() -> None:


### PR DESCRIPTION
Closes #24

## Summary
Add `Connector[RequestT, ResponseT]` runtime-checkable Protocol to `abdp.core.connectors`, defining the minimal sync contract: read-only `name` property and `send(request) -> response`. Domain-neutral and transport-agnostic.

## TDD Evidence
- **RED** (`b5cdd41`): `tests/core/test_connectors.py` — 5 conformance tests (exports, `_is_protocol`, runtime structural acceptance + `assert_type`, missing-`send` rejection, missing-`name` rejection). Failed with `ImportError`.
- **GREEN** (`1c03967`): `src/abdp/core/connectors.py` — `@runtime_checkable class Connector[RequestT, ResponseT](Protocol)` with read-only `name` property and `send(request)` method. PEP 695 generics let variance be inferred (request contravariant, response covariant).
- **REFACTOR**: N/A — pure protocol module, no algorithmic surface to refactor. Oracle design explicitly approved a 2-commit cycle for this XS pure-spec PR.

## Coverage tooling change
The protocol's `...` stub bodies create unreachable branches under `branch=True` coverage. Added two coveragerc patterns:
- `exclude_lines += ^\s*\.\.\.\s*$` (excludes ellipsis-only lines)
- `partial_branches = ... \.\.\.` (allows partial branches on lines containing `...`, covering the `def f(): ...` single-line stub form)

`tests/meta/test_tooling_config.py` updated to assert the new expected configuration.

## Property / Mutation
**N/A.** Pure structural protocol with no internal branching, state transitions, or algorithmic behavior; meaningful verification is provided by unit tests plus static typing and runtime protocol conformance checks.

## Verification
\`\`\`
ruff format/check: clean
mypy strict: clean (36 source files)
pytest: 226 passed, 100% line+branch coverage
\`\`\`

## Oracle Design
Oracle session \`ses_24d918a6affeh3KelFAhFvwJ3a\` produced the 10-point contract this implementation follows verbatim (PEP 695 inferred variance, @runtime_checkable, read-only \`name\` property, single-arg sync \`send\`, anchored docstring with no-guarantee clauses).