### PR TITLE
feat: add core manifest factory protocol (#25)

### DIFF
--- a/src/abdp/core/manifest_factory.py
+++ b/src/abdp/core/manifest_factory.py
@@ -1,0 +1,24 @@
+"""Core manifest factory protocol contract:
+
+- Defines the minimal core manifest-construction contract.
+- Domain-neutral and generic over payload and manifest types.
+- Synchronous only.
+- Contract is ``create(payload) -> manifest``.
+- Intended for structural typing in core; implementations live outside core.
+- Runtime protocol checks are shallow: they verify attribute presence only and
+  do not validate call signatures or generic type arguments.
+- Exception behavior is intentionally unspecified.
+- No guarantees about persistence, validation, idempotency, or thread safety.
+- Does not prescribe snapshots, tiers, or any concrete manifest schema.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["ManifestFactory"]
+
+
+@runtime_checkable
+class ManifestFactory[PayloadT, ManifestT](Protocol):
+    def create(self, payload: PayloadT) -> ManifestT: ...

--- a/tests/core/test_manifest_factory.py
+++ b/tests/core/test_manifest_factory.py
@@ -1,0 +1,39 @@
+"""Conformance tests for the core manifest factory protocol contract."""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from abdp.core import manifest_factory
+from abdp.core.manifest_factory import ManifestFactory
+
+
+class _ValidFactory:
+    def create(self, payload: dict[str, int]) -> tuple[str, dict[str, int]]:
+        return ("manifest", payload)
+
+
+class _MissingCreate:
+    pass
+
+
+def test_manifest_factory_module_exports_manifest_factory() -> None:
+    assert manifest_factory.__all__ == ["ManifestFactory"]
+    assert manifest_factory.ManifestFactory is ManifestFactory
+
+
+def test_manifest_factory_is_protocol() -> None:
+    assert getattr(ManifestFactory, "_is_protocol", False) is True
+
+
+def test_manifest_factory_is_runtime_checkable_and_accepts_minimal_structural_impl() -> None:
+    dummy = _ValidFactory()
+    assert isinstance(dummy, ManifestFactory) is True
+    factory: ManifestFactory[dict[str, int], tuple[str, dict[str, int]]] = dummy
+    result = factory.create({"a": 1})
+    assert_type(result, tuple[str, dict[str, int]])
+    assert result == ("manifest", {"a": 1})
+
+
+def test_manifest_factory_runtime_check_rejects_missing_create() -> None:
+    assert isinstance(_MissingCreate(), ManifestFactory) is False


### PR DESCRIPTION
Closes #25

## Summary
Add `ManifestFactory[PayloadT, ManifestT]` runtime-checkable Protocol to `abdp.core.manifest_factory` with sync `create(payload) -> manifest`. Generic, domain-neutral, makes no mention of snapshots, tiers, persistence, or any concrete manifest schema.

## TDD Evidence
- **RED** (`3e50dce`): `tests/core/test_manifest_factory.py` — 4 conformance tests (exports, `_is_protocol`, runtime structural acceptance + `assert_type`, missing-`create` rejection). Failed with `ImportError`.
- **GREEN** (`bbeffa0`): `src/abdp/core/manifest_factory.py` — `@runtime_checkable class ManifestFactory[PayloadT, ManifestT](Protocol)` with single sync `create` method. PEP 695 inferred variance.
- **REFACTOR**: N/A — pure protocol module, no algorithmic surface to refactor.

## Property / Mutation
**N/A.** Pure structural protocol with no internal branching, state transitions, or algorithmic behavior; meaningful verification is provided by unit tests plus static typing and runtime protocol conformance checks.

## Verification
\`\`\`
ruff format/check: clean
mypy strict: clean (38 source files)
pytest: 230 passed, 100% line+branch coverage
\`\`\`

## Oracle Design
Session \`ses_24d86508bffef8boVOCwxIvmdq\` produced the 10-point contract this implementation follows verbatim.