### PR TITLE
feat: freeze abdp.core public surface (#26)

### DIFF
--- a/src/abdp/core/__init__.py
+++ b/src/abdp/core/__init__.py
@@ -6,8 +6,6 @@ hashing, deterministic retry, fixed-window rate limiting, the connector
 protocol, and the manifest factory protocol.
 """
 
-from __future__ import annotations
-
 from abdp.core.connectors import Connector
 from abdp.core.hashing import stable_hash
 from abdp.core.ids import deterministic_uuid, parse_uuid
@@ -22,6 +20,13 @@ from abdp.core.types import (
     is_json_value,
     validate_seed,
 )
+
+globals().pop("connectors", None)
+globals().pop("hashing", None)
+globals().pop("ids", None)
+globals().pop("manifest_factory", None)
+globals().pop("rate_limit", None)
+globals().pop("types", None)
 
 __all__ = [
     "Backoff",

--- a/src/abdp/core/__init__.py
+++ b/src/abdp/core/__init__.py
@@ -1,1 +1,42 @@
-""""""
+"""Public surface of the ``abdp.core`` package.
+
+Exposes the deterministic, domain-neutral building blocks of the framework:
+JSON value types and seed validation, deterministic identifiers, stable
+hashing, deterministic retry, fixed-window rate limiting, the connector
+protocol, and the manifest factory protocol.
+"""
+
+from __future__ import annotations
+
+from abdp.core.connectors import Connector
+from abdp.core.hashing import stable_hash
+from abdp.core.ids import deterministic_uuid, parse_uuid
+from abdp.core.manifest_factory import ManifestFactory
+from abdp.core.rate_limit import Clock, FixedWindowRateLimiter
+from abdp.core.retry import Backoff, retry
+from abdp.core.types import (
+    JsonObject,
+    JsonPrimitive,
+    JsonValue,
+    Seed,
+    is_json_value,
+    validate_seed,
+)
+
+__all__ = [
+    "Backoff",
+    "Clock",
+    "Connector",
+    "FixedWindowRateLimiter",
+    "JsonObject",
+    "JsonPrimitive",
+    "JsonValue",
+    "ManifestFactory",
+    "Seed",
+    "deterministic_uuid",
+    "is_json_value",
+    "parse_uuid",
+    "retry",
+    "stable_hash",
+    "validate_seed",
+]

--- a/tests/core/test_core_public_surface.py
+++ b/tests/core/test_core_public_surface.py
@@ -1,0 +1,78 @@
+"""Frozen public surface of the ``abdp.core`` package."""
+
+from __future__ import annotations
+
+import abdp.core
+from abdp.core import connectors as connectors_module
+from abdp.core import hashing as hashing_module
+from abdp.core import ids as ids_module
+from abdp.core import manifest_factory as manifest_factory_module
+from abdp.core import rate_limit as rate_limit_module
+from abdp.core import retry as retry_module
+from abdp.core import types as types_module
+
+EXPECTED_PUBLIC_NAMES: list[str] = [
+    "Backoff",
+    "Clock",
+    "Connector",
+    "FixedWindowRateLimiter",
+    "JsonObject",
+    "JsonPrimitive",
+    "JsonValue",
+    "ManifestFactory",
+    "Seed",
+    "deterministic_uuid",
+    "is_json_value",
+    "parse_uuid",
+    "retry",
+    "stable_hash",
+    "validate_seed",
+]
+
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "Backoff": retry_module.Backoff,
+    "Clock": rate_limit_module.Clock,
+    "Connector": connectors_module.Connector,
+    "FixedWindowRateLimiter": rate_limit_module.FixedWindowRateLimiter,
+    "JsonObject": types_module.JsonObject,
+    "JsonPrimitive": types_module.JsonPrimitive,
+    "JsonValue": types_module.JsonValue,
+    "ManifestFactory": manifest_factory_module.ManifestFactory,
+    "Seed": types_module.Seed,
+    "deterministic_uuid": ids_module.deterministic_uuid,
+    "is_json_value": types_module.is_json_value,
+    "parse_uuid": ids_module.parse_uuid,
+    "retry": retry_module.retry,
+    "stable_hash": hashing_module.stable_hash,
+    "validate_seed": types_module.validate_seed,
+}
+
+REPRESENTATIVE_INTERNAL_NAMES: list[str] = [
+    "_validate_init",
+    "_validate_clock_reading",
+    "_MIN_MAX_CALLS",
+    "_validate_config",
+    "_UINT32_MAX",
+]
+
+
+def test_core_package_all_lists_exact_expected_symbols() -> None:
+    assert abdp.core.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+def test_core_package_exposes_each_listed_symbol_with_source_identity() -> None:
+    for name in EXPECTED_PUBLIC_NAMES:
+        attr = getattr(abdp.core, name)
+        assert attr is EXPECTED_SOURCE_IDENTITY[name]
+
+
+def test_core_package_does_not_leak_representative_internal_helpers() -> None:
+    for name in REPRESENTATIVE_INTERNAL_NAMES:
+        assert not hasattr(abdp.core, name)
+
+
+def test_core_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.core import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)

--- a/tests/core/test_core_public_surface.py
+++ b/tests/core/test_core_public_surface.py
@@ -86,3 +86,8 @@ def test_core_package_star_import_yields_exactly_the_public_surface() -> None:
     exec("from abdp.core import *", namespace)
     namespace.pop("__builtins__", None)
     assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_core_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.core) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)

--- a/tests/core/test_core_public_surface.py
+++ b/tests/core/test_core_public_surface.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import sys
+
 import abdp.core
-from abdp.core import connectors as connectors_module
-from abdp.core import hashing as hashing_module
-from abdp.core import ids as ids_module
-from abdp.core import manifest_factory as manifest_factory_module
-from abdp.core import rate_limit as rate_limit_module
-from abdp.core import retry as retry_module
-from abdp.core import types as types_module
+import abdp.core.connectors  # noqa: F401
+import abdp.core.hashing  # noqa: F401
+import abdp.core.ids  # noqa: F401
+import abdp.core.manifest_factory  # noqa: F401
+import abdp.core.rate_limit  # noqa: F401
+import abdp.core.retry  # noqa: F401
+import abdp.core.types  # noqa: F401
+
+connectors_module = sys.modules["abdp.core.connectors"]
+hashing_module = sys.modules["abdp.core.hashing"]
+ids_module = sys.modules["abdp.core.ids"]
+manifest_factory_module = sys.modules["abdp.core.manifest_factory"]
+rate_limit_module = sys.modules["abdp.core.rate_limit"]
+retry_module = sys.modules["abdp.core.retry"]
+types_module = sys.modules["abdp.core.types"]
 
 EXPECTED_PUBLIC_NAMES: list[str] = [
     "Backoff",

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -11,8 +11,11 @@ from abdp.core.retry import Backoff, retry
 
 
 def test_retry_module_exposes_only_retry_and_backoff_publicly() -> None:
-    import abdp.core.retry as module
+    import sys
 
+    import abdp.core.retry  # noqa: F401
+
+    module = sys.modules["abdp.core.retry"]
     assert sorted(module.__all__) == ["Backoff", "retry"]
 
 

--- a/tests/meta/test_repo_scaffold.py
+++ b/tests/meta/test_repo_scaffold.py
@@ -18,7 +18,6 @@ REQUIRED_SCAFFOLD_PATHS = (
 
 PACKAGE_MODULES_WITH_EMPTY_DOCSTRING = (
     "abdp",
-    "abdp.core",
     "abdp.data",
     "abdp.simulation",
 )


### PR DESCRIPTION
Closes #26

## Summary
Freeze the explicit public API of `abdp.core` to exactly the 15 approved symbols, with named re-exports, alphabetical `__all__`, and a substantive package docstring.

## TDD Evidence
- **RED** (`fb1b79a`): `tests/core/test_core_public_surface.py` — four freeze tests (exact `__all__` sequence, source-module identity for every name, no-leak on representative internal helpers, `from abdp.core import *` yields exactly the public surface). All failed pre-implementation.
- **GREEN** (`9257a4e`): `src/abdp/core/__init__.py` re-exports the 15 approved symbols with an alphabetical `__all__` and a category-level docstring.
- **REFACTOR** (`b880a82`): tighten the runtime namespace to exactly the approved 15. Drop `from __future__ import annotations` (it leaked the `annotations` attribute), add `globals().pop(...)` for the six submodule attributes Python attaches when `__init__` imports from them, and add a fifth freeze test asserting the full non-underscore namespace equals the approved 15. The `retry` submodule is intentionally shadowed by the exported `retry` function and stays.

## Out-of-scope but unavoidable test updates (in GREEN)
Two pre-existing meta tests became inconsistent with the freeze and were updated minimally:
- `tests/meta/test_repo_scaffold.py` — `abdp.core` removed from `PACKAGE_MODULES_WITH_EMPTY_DOCSTRING` (the freeze itself adds the contract docstring).
- `tests/core/test_retry.py::test_retry_module_exposes_only_retry_and_backoff_publicly` — switched from `import abdp.core.retry as module` to `sys.modules["abdp.core.retry"]`. After the facade exposes the `retry` function, that name shadows the `retry` submodule on the `abdp.core` namespace; `sys.modules` still holds the actual submodule object, which is what the introspection assertion needs.

## Rebase notes
This branch was rebased onto current main (`abed38d`, post #46) and the freeze test file was renamed `test_public_surface.py` → `test_core_public_surface.py` to avoid a pytest collection collision with `tests/data/test_public_surface.py` that surfaced once the namespace `pythonpath` from #46 was applied. Force-push with `--force-with-lease`.

## Property / Mutation
**N/A.** Pure re-export module with no new runtime behavior.

## Verification
\`\`\`
ruff format/check: clean (70 files)
mypy --strict src tests: clean (70 source files)
pytest: 411 passed, 100% line+branch coverage (433 stmts / 154 branches)
python -m build: abdp-0.1.0.dev0 wheel + sdist OK
\`\`\`

## Oracle Reviews
- Design session: `ses_24d812df8ffeQ49dyN7IkiAtrI` produced the contract this implementation follows: explicit named re-exports (no `import *`), hard-coded alphabetical `__all__`, all 15 symbols, no `__getattr__` magic, and the freeze tests.
- First post-implementation review (`ses_24ca4be3affe6bNmkKrF4z1izz`) scored 84/100 and flagged two blocking gaps: the runtime namespace still leaked `annotations` plus six submodule attributes, and the freeze tests did not assert the full non-underscore namespace. Both are fixed in `b880a82`.