### PR TITLE
feat: add snapshot manifest schema (#27)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 [tool.mutmut]
 paths_to_mutate = ["src/abdp/"]
 pytest_add_cli_args = ["-p", "no:cacheprovider", "--no-cov"]
-pytest_add_cli_args_test_selection = ["tests/unit/", "tests/core/"]
+pytest_add_cli_args_test_selection = ["tests/unit/", "tests/core/", "tests/data/"]
 also_copy = ["pytest.ini"]
 do_not_mutate = [
     "src/abdp/__init__.py",

--- a/src/abdp/data/__init__.py
+++ b/src/abdp/data/__init__.py
@@ -1,1 +1,5 @@
 """"""
+
+from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
+
+__all__ = ["SnapshotManifest", "SnapshotTier"]

--- a/src/abdp/data/snapshot_manifest.py
+++ b/src/abdp/data/snapshot_manifest.py
@@ -1,0 +1,82 @@
+"""Snapshot manifest contract:
+
+- ``SnapshotTier`` is the closed set of supported tiers: ``"bronze"``, ``"silver"``, and ``"gold"``.
+- ``SnapshotManifest`` is an immutable record for snapshot manifest metadata.
+- Construction is synchronous only.
+- ``snapshot_id`` and ``parent_snapshot_id`` must be ``UUID`` instances; string parsing is out of scope.
+- ``storage_key`` and ``content_hash`` must be non-empty when stripped of surrounding whitespace.
+- ``created_at`` must be a timezone-aware UTC ``datetime``.
+- ``seed`` is validated with ``validate_seed``.
+- ``parent_snapshot_id`` may be ``None`` and otherwise must differ from ``snapshot_id``.
+- No guarantees about persistence, serialization, storage backends, or thread safety.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Literal, get_args
+from uuid import UUID
+
+from abdp.core.types import Seed, validate_seed
+
+__all__ = ["SnapshotManifest", "SnapshotTier"]
+
+type SnapshotTier = Literal["bronze", "silver", "gold"]
+
+_ALLOWED_TIERS: tuple[SnapshotTier, ...] = get_args(SnapshotTier.__value__)
+_ZERO_OFFSET = timedelta(0)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SnapshotManifest:
+    """SnapshotManifest contract:
+
+    - Immutable dataclass record with slot-backed, keyword-only fields.
+    - Stores manifest metadata exactly as provided after validation; no parsing, normalization, or I/O is performed.
+    - Validation is limited to basic runtime type checks and field invariants.
+    - Construction is synchronous only.
+    - No guarantees about persistence or thread safety.
+    """
+
+    snapshot_id: UUID
+    tier: SnapshotTier
+    storage_key: str
+    content_hash: str
+    created_at: datetime
+    seed: Seed
+    parent_snapshot_id: UUID | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.snapshot_id, UUID):
+            raise TypeError(f"snapshot_id must be UUID, got {type(self.snapshot_id).__name__}")
+
+        if not isinstance(self.tier, str):
+            raise TypeError(f"tier must be str, got {type(self.tier).__name__}")
+        if self.tier not in _ALLOWED_TIERS:
+            raise ValueError(f"tier must be one of {_ALLOWED_TIERS!r}, got {self.tier!r}")
+
+        if not isinstance(self.storage_key, str):
+            raise TypeError(f"storage_key must be str, got {type(self.storage_key).__name__}")
+        if not self.storage_key.strip():
+            raise ValueError("storage_key must not be empty or whitespace")
+
+        if not isinstance(self.content_hash, str):
+            raise TypeError(f"content_hash must be str, got {type(self.content_hash).__name__}")
+        if not self.content_hash.strip():
+            raise ValueError("content_hash must not be empty or whitespace")
+
+        if not isinstance(self.created_at, datetime):
+            raise TypeError(f"created_at must be datetime, got {type(self.created_at).__name__}")
+        offset = self.created_at.utcoffset()
+        if offset is None:
+            raise ValueError("created_at must be timezone-aware")
+        if offset != _ZERO_OFFSET:
+            raise ValueError("created_at must be UTC")
+
+        validate_seed(self.seed)
+
+        if self.parent_snapshot_id is not None and not isinstance(self.parent_snapshot_id, UUID):
+            raise TypeError(f"parent_snapshot_id must be UUID or None, got {type(self.parent_snapshot_id).__name__}")
+        if self.parent_snapshot_id is not None and self.parent_snapshot_id == self.snapshot_id:
+            raise ValueError("parent_snapshot_id must not equal snapshot_id")

--- a/src/abdp/data/snapshot_manifest.py
+++ b/src/abdp/data/snapshot_manifest.py
@@ -28,6 +28,44 @@ _ALLOWED_TIERS: tuple[SnapshotTier, ...] = get_args(SnapshotTier.__value__)
 _ZERO_OFFSET = timedelta(0)
 
 
+def _validate_uuid(field_name: str, value: object) -> None:
+    if not isinstance(value, UUID):
+        raise TypeError(f"{field_name} must be UUID, got {type(value).__name__}")
+
+
+def _validate_tier(value: object) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"tier must be str, got {type(value).__name__}")
+    if value not in _ALLOWED_TIERS:
+        raise ValueError(f"tier must be one of {_ALLOWED_TIERS!r}, got {value!r}")
+
+
+def _validate_non_empty_text(field_name: str, value: object) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be str, got {type(value).__name__}")
+    if not value.strip():
+        raise ValueError(f"{field_name} must not be empty or whitespace")
+
+
+def _validate_created_at(value: object) -> None:
+    if not isinstance(value, datetime):
+        raise TypeError(f"created_at must be datetime, got {type(value).__name__}")
+    offset = value.utcoffset()
+    if offset is None:
+        raise ValueError("created_at must be timezone-aware")
+    if offset != _ZERO_OFFSET:
+        raise ValueError("created_at must be UTC")
+
+
+def _validate_parent_snapshot_id(parent: object, snapshot_id: UUID) -> None:
+    if parent is None:
+        return
+    if not isinstance(parent, UUID):
+        raise TypeError(f"parent_snapshot_id must be UUID or None, got {type(parent).__name__}")
+    if parent == snapshot_id:
+        raise ValueError("parent_snapshot_id must not equal snapshot_id")
+
+
 @dataclass(frozen=True, slots=True, kw_only=True)
 class SnapshotManifest:
     """SnapshotManifest contract:
@@ -48,35 +86,10 @@ class SnapshotManifest:
     parent_snapshot_id: UUID | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.snapshot_id, UUID):
-            raise TypeError(f"snapshot_id must be UUID, got {type(self.snapshot_id).__name__}")
-
-        if not isinstance(self.tier, str):
-            raise TypeError(f"tier must be str, got {type(self.tier).__name__}")
-        if self.tier not in _ALLOWED_TIERS:
-            raise ValueError(f"tier must be one of {_ALLOWED_TIERS!r}, got {self.tier!r}")
-
-        if not isinstance(self.storage_key, str):
-            raise TypeError(f"storage_key must be str, got {type(self.storage_key).__name__}")
-        if not self.storage_key.strip():
-            raise ValueError("storage_key must not be empty or whitespace")
-
-        if not isinstance(self.content_hash, str):
-            raise TypeError(f"content_hash must be str, got {type(self.content_hash).__name__}")
-        if not self.content_hash.strip():
-            raise ValueError("content_hash must not be empty or whitespace")
-
-        if not isinstance(self.created_at, datetime):
-            raise TypeError(f"created_at must be datetime, got {type(self.created_at).__name__}")
-        offset = self.created_at.utcoffset()
-        if offset is None:
-            raise ValueError("created_at must be timezone-aware")
-        if offset != _ZERO_OFFSET:
-            raise ValueError("created_at must be UTC")
-
+        _validate_uuid("snapshot_id", self.snapshot_id)
+        _validate_tier(self.tier)
+        _validate_non_empty_text("storage_key", self.storage_key)
+        _validate_non_empty_text("content_hash", self.content_hash)
+        _validate_created_at(self.created_at)
         validate_seed(self.seed)
-
-        if self.parent_snapshot_id is not None and not isinstance(self.parent_snapshot_id, UUID):
-            raise TypeError(f"parent_snapshot_id must be UUID or None, got {type(self.parent_snapshot_id).__name__}")
-        if self.parent_snapshot_id is not None and self.parent_snapshot_id == self.snapshot_id:
-            raise ValueError("parent_snapshot_id must not equal snapshot_id")
+        _validate_parent_snapshot_id(self.parent_snapshot_id, self.snapshot_id)

--- a/tests/data/test_snapshot_manifest.py
+++ b/tests/data/test_snapshot_manifest.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
-from datetime import datetime, timedelta, timezone, UTC
-from typing import Any, cast
+from datetime import UTC, datetime, timedelta, timezone
+from typing import cast
 from uuid import UUID
 
 import pytest
@@ -16,20 +16,29 @@ from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
 _SNAPSHOT_ID = UUID("11111111-1111-1111-1111-111111111111")
 _PARENT_ID = UUID("22222222-2222-2222-2222-222222222222")
 _CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
+_DEFAULT_CONTENT_HASH = stable_hash({"value": 1})
+_DEFAULT_SEED = validate_seed(7)
 
 
-def _make_manifest(**overrides: Any) -> SnapshotManifest:
-    defaults: dict[str, Any] = {
-        "snapshot_id": _SNAPSHOT_ID,
-        "tier": "bronze",
-        "storage_key": "snapshots/bronze/example.json",
-        "content_hash": stable_hash({"value": 1}),
-        "created_at": _CREATED_AT,
-        "seed": validate_seed(7),
-        "parent_snapshot_id": None,
-    }
-    defaults.update(overrides)
-    return SnapshotManifest(**defaults)
+def _make_manifest(
+    *,
+    snapshot_id: UUID = _SNAPSHOT_ID,
+    tier: SnapshotTier = "bronze",
+    storage_key: str = "snapshots/bronze/example.json",
+    content_hash: str = _DEFAULT_CONTENT_HASH,
+    created_at: datetime = _CREATED_AT,
+    seed: Seed = _DEFAULT_SEED,
+    parent_snapshot_id: UUID | None = None,
+) -> SnapshotManifest:
+    return SnapshotManifest(
+        snapshot_id=snapshot_id,
+        tier=tier,
+        storage_key=storage_key,
+        content_hash=content_hash,
+        created_at=created_at,
+        seed=seed,
+        parent_snapshot_id=parent_snapshot_id,
+    )
 
 
 def test_snapshot_manifest_module_docstring_includes_contract_anchor() -> None:
@@ -59,9 +68,9 @@ def test_snapshot_manifest_constructs_valid_root_record() -> None:
     assert manifest.snapshot_id == _SNAPSHOT_ID
     assert manifest.tier == "bronze"
     assert manifest.storage_key == "snapshots/bronze/example.json"
-    assert manifest.content_hash == stable_hash({"value": 1})
+    assert manifest.content_hash == _DEFAULT_CONTENT_HASH
     assert manifest.created_at == _CREATED_AT
-    assert manifest.seed == validate_seed(7)
+    assert manifest.seed == _DEFAULT_SEED
     assert manifest.parent_snapshot_id is None
 
 
@@ -73,7 +82,7 @@ def test_snapshot_manifest_constructs_valid_child_record() -> None:
 def test_snapshot_manifest_is_frozen() -> None:
     manifest = _make_manifest()
     with pytest.raises(FrozenInstanceError):
-        cast(Any, manifest).tier = "silver"
+        setattr(manifest, "tier", "silver")  # noqa: B010
 
 
 def test_snapshot_manifest_equal_instances_compare_equal_and_have_same_hash() -> None:
@@ -91,7 +100,7 @@ def test_snapshot_manifest_accepts_each_supported_tier(tier: SnapshotTier) -> No
 
 def test_snapshot_manifest_rejects_non_string_tier() -> None:
     with pytest.raises(TypeError, match=r"^tier must be str, got int$"):
-        _make_manifest(tier=cast(Any, 1))
+        _make_manifest(tier=cast(SnapshotTier, 1))
 
 
 def test_snapshot_manifest_rejects_unknown_tier() -> None:
@@ -99,17 +108,17 @@ def test_snapshot_manifest_rejects_unknown_tier() -> None:
         ValueError,
         match=r"^tier must be one of \('bronze', 'silver', 'gold'\), got 'platinum'$",
     ):
-        _make_manifest(tier=cast(Any, "platinum"))
+        _make_manifest(tier=cast(SnapshotTier, "platinum"))
 
 
 def test_snapshot_manifest_rejects_non_uuid_snapshot_id() -> None:
     with pytest.raises(TypeError, match=r"^snapshot_id must be UUID, got str$"):
-        _make_manifest(snapshot_id=cast(Any, str(_SNAPSHOT_ID)))
+        _make_manifest(snapshot_id=cast(UUID, str(_SNAPSHOT_ID)))
 
 
 def test_snapshot_manifest_rejects_non_string_storage_key() -> None:
     with pytest.raises(TypeError, match=r"^storage_key must be str, got int$"):
-        _make_manifest(storage_key=cast(Any, 1))
+        _make_manifest(storage_key=cast(str, 1))
 
 
 def test_snapshot_manifest_rejects_empty_storage_key() -> None:
@@ -124,7 +133,7 @@ def test_snapshot_manifest_rejects_whitespace_only_storage_key() -> None:
 
 def test_snapshot_manifest_rejects_non_string_content_hash() -> None:
     with pytest.raises(TypeError, match=r"^content_hash must be str, got int$"):
-        _make_manifest(content_hash=cast(Any, 1))
+        _make_manifest(content_hash=cast(str, 1))
 
 
 def test_snapshot_manifest_rejects_empty_content_hash() -> None:
@@ -139,7 +148,7 @@ def test_snapshot_manifest_rejects_whitespace_only_content_hash() -> None:
 
 def test_snapshot_manifest_rejects_non_datetime_created_at() -> None:
     with pytest.raises(TypeError, match=r"^created_at must be datetime, got str$"):
-        _make_manifest(created_at=cast(Any, "2024-01-01T00:00:00Z"))
+        _make_manifest(created_at=cast(datetime, "2024-01-01T00:00:00Z"))
 
 
 def test_snapshot_manifest_rejects_naive_created_at() -> None:
@@ -175,7 +184,7 @@ def test_snapshot_manifest_delegates_seed_validation_for_bool_seed() -> None:
 
 def test_snapshot_manifest_rejects_non_uuid_parent_snapshot_id() -> None:
     with pytest.raises(TypeError, match=r"^parent_snapshot_id must be UUID or None, got str$"):
-        _make_manifest(parent_snapshot_id=cast(Any, str(_PARENT_ID)))
+        _make_manifest(parent_snapshot_id=cast(UUID, str(_PARENT_ID)))
 
 
 def test_snapshot_manifest_rejects_parent_snapshot_id_matching_snapshot_id() -> None:

--- a/tests/data/test_snapshot_manifest.py
+++ b/tests/data/test_snapshot_manifest.py
@@ -32,8 +32,6 @@ def _make_manifest(**overrides: Any) -> SnapshotManifest:
     return SnapshotManifest(**defaults)
 
 
-
-
 def test_snapshot_manifest_module_docstring_includes_contract_anchor() -> None:
     doc = sm.__doc__ or ""
     assert "Snapshot manifest contract:" in doc
@@ -54,8 +52,6 @@ def test_snapshot_manifest_class_docstring_includes_contract_anchor() -> None:
     doc = SnapshotManifest.__doc__ or ""
     assert "SnapshotManifest contract:" in doc
     assert "Construction is synchronous only" in doc
-
-
 
 
 def test_snapshot_manifest_constructs_valid_root_record() -> None:
@@ -87,8 +83,6 @@ def test_snapshot_manifest_equal_instances_compare_equal_and_have_same_hash() ->
     assert hash(a) == hash(b)
 
 
-
-
 @pytest.mark.parametrize("tier", ["bronze", "silver", "gold"])
 def test_snapshot_manifest_accepts_each_supported_tier(tier: SnapshotTier) -> None:
     manifest = _make_manifest(tier=tier)
@@ -108,13 +102,9 @@ def test_snapshot_manifest_rejects_unknown_tier() -> None:
         _make_manifest(tier=cast(Any, "platinum"))
 
 
-
-
 def test_snapshot_manifest_rejects_non_uuid_snapshot_id() -> None:
     with pytest.raises(TypeError, match=r"^snapshot_id must be UUID, got str$"):
         _make_manifest(snapshot_id=cast(Any, str(_SNAPSHOT_ID)))
-
-
 
 
 def test_snapshot_manifest_rejects_non_string_storage_key() -> None:
@@ -132,8 +122,6 @@ def test_snapshot_manifest_rejects_whitespace_only_storage_key() -> None:
         _make_manifest(storage_key="   ")
 
 
-
-
 def test_snapshot_manifest_rejects_non_string_content_hash() -> None:
     with pytest.raises(TypeError, match=r"^content_hash must be str, got int$"):
         _make_manifest(content_hash=cast(Any, 1))
@@ -147,8 +135,6 @@ def test_snapshot_manifest_rejects_empty_content_hash() -> None:
 def test_snapshot_manifest_rejects_whitespace_only_content_hash() -> None:
     with pytest.raises(ValueError, match=r"^content_hash must not be empty or whitespace$"):
         _make_manifest(content_hash="   ")
-
-
 
 
 def test_snapshot_manifest_rejects_non_datetime_created_at() -> None:
@@ -165,8 +151,6 @@ def test_snapshot_manifest_rejects_non_utc_created_at() -> None:
     non_utc = datetime(2024, 1, 1, tzinfo=timezone(timedelta(hours=9)))
     with pytest.raises(ValueError, match=r"^created_at must be UTC$"):
         _make_manifest(created_at=non_utc)
-
-
 
 
 def test_snapshot_manifest_delegates_seed_validation_for_non_integer_seed() -> None:
@@ -187,8 +171,6 @@ def test_snapshot_manifest_delegates_seed_validation_for_seed_above_uint32_max()
 def test_snapshot_manifest_delegates_seed_validation_for_bool_seed() -> None:
     with pytest.raises(TypeError, match=r"^Seed must be a non-bool int, got bool$"):
         _make_manifest(seed=cast(Seed, True))
-
-
 
 
 def test_snapshot_manifest_rejects_non_uuid_parent_snapshot_id() -> None:

--- a/tests/data/test_snapshot_manifest.py
+++ b/tests/data/test_snapshot_manifest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from typing import Any, cast
 from uuid import UUID
 
@@ -15,7 +15,7 @@ from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
 
 _SNAPSHOT_ID = UUID("11111111-1111-1111-1111-111111111111")
 _PARENT_ID = UUID("22222222-2222-2222-2222-222222222222")
-_CREATED_AT = datetime(2024, 1, 1, tzinfo=timezone.utc)
+_CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
 
 
 def _make_manifest(**overrides: Any) -> SnapshotManifest:

--- a/tests/data/test_snapshot_manifest.py
+++ b/tests/data/test_snapshot_manifest.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+import abdp.data
+from abdp.core.hashing import stable_hash
+from abdp.core.types import Seed, validate_seed
+from abdp.data import snapshot_manifest as sm
+from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
+
+_SNAPSHOT_ID = UUID("11111111-1111-1111-1111-111111111111")
+_PARENT_ID = UUID("22222222-2222-2222-2222-222222222222")
+_CREATED_AT = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def _make_manifest(**overrides: Any) -> SnapshotManifest:
+    defaults: dict[str, Any] = {
+        "snapshot_id": _SNAPSHOT_ID,
+        "tier": "bronze",
+        "storage_key": "snapshots/bronze/example.json",
+        "content_hash": stable_hash({"value": 1}),
+        "created_at": _CREATED_AT,
+        "seed": validate_seed(7),
+        "parent_snapshot_id": None,
+    }
+    defaults.update(overrides)
+    return SnapshotManifest(**defaults)
+
+
+
+
+def test_snapshot_manifest_module_docstring_includes_contract_anchor() -> None:
+    doc = sm.__doc__ or ""
+    assert "Snapshot manifest contract:" in doc
+    assert "No guarantees about persistence" in doc
+
+
+def test_snapshot_manifest_module_exports_public_symbols_only() -> None:
+    assert sm.__all__ == ["SnapshotManifest", "SnapshotTier"]
+
+
+def test_data_package_exports_snapshot_manifest_publicly() -> None:
+    assert abdp.data.__all__ == ["SnapshotManifest", "SnapshotTier"]
+    assert abdp.data.SnapshotManifest is SnapshotManifest
+    assert abdp.data.SnapshotTier is SnapshotTier
+
+
+def test_snapshot_manifest_class_docstring_includes_contract_anchor() -> None:
+    doc = SnapshotManifest.__doc__ or ""
+    assert "SnapshotManifest contract:" in doc
+    assert "Construction is synchronous only" in doc
+
+
+
+
+def test_snapshot_manifest_constructs_valid_root_record() -> None:
+    manifest = _make_manifest()
+    assert manifest.snapshot_id == _SNAPSHOT_ID
+    assert manifest.tier == "bronze"
+    assert manifest.storage_key == "snapshots/bronze/example.json"
+    assert manifest.content_hash == stable_hash({"value": 1})
+    assert manifest.created_at == _CREATED_AT
+    assert manifest.seed == validate_seed(7)
+    assert manifest.parent_snapshot_id is None
+
+
+def test_snapshot_manifest_constructs_valid_child_record() -> None:
+    manifest = _make_manifest(parent_snapshot_id=_PARENT_ID)
+    assert manifest.parent_snapshot_id == _PARENT_ID
+
+
+def test_snapshot_manifest_is_frozen() -> None:
+    manifest = _make_manifest()
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, manifest).tier = "silver"
+
+
+def test_snapshot_manifest_equal_instances_compare_equal_and_have_same_hash() -> None:
+    a = _make_manifest()
+    b = _make_manifest()
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+
+
+@pytest.mark.parametrize("tier", ["bronze", "silver", "gold"])
+def test_snapshot_manifest_accepts_each_supported_tier(tier: SnapshotTier) -> None:
+    manifest = _make_manifest(tier=tier)
+    assert manifest.tier == tier
+
+
+def test_snapshot_manifest_rejects_non_string_tier() -> None:
+    with pytest.raises(TypeError, match=r"^tier must be str, got int$"):
+        _make_manifest(tier=cast(Any, 1))
+
+
+def test_snapshot_manifest_rejects_unknown_tier() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^tier must be one of \('bronze', 'silver', 'gold'\), got 'platinum'$",
+    ):
+        _make_manifest(tier=cast(Any, "platinum"))
+
+
+
+
+def test_snapshot_manifest_rejects_non_uuid_snapshot_id() -> None:
+    with pytest.raises(TypeError, match=r"^snapshot_id must be UUID, got str$"):
+        _make_manifest(snapshot_id=cast(Any, str(_SNAPSHOT_ID)))
+
+
+
+
+def test_snapshot_manifest_rejects_non_string_storage_key() -> None:
+    with pytest.raises(TypeError, match=r"^storage_key must be str, got int$"):
+        _make_manifest(storage_key=cast(Any, 1))
+
+
+def test_snapshot_manifest_rejects_empty_storage_key() -> None:
+    with pytest.raises(ValueError, match=r"^storage_key must not be empty or whitespace$"):
+        _make_manifest(storage_key="")
+
+
+def test_snapshot_manifest_rejects_whitespace_only_storage_key() -> None:
+    with pytest.raises(ValueError, match=r"^storage_key must not be empty or whitespace$"):
+        _make_manifest(storage_key="   ")
+
+
+
+
+def test_snapshot_manifest_rejects_non_string_content_hash() -> None:
+    with pytest.raises(TypeError, match=r"^content_hash must be str, got int$"):
+        _make_manifest(content_hash=cast(Any, 1))
+
+
+def test_snapshot_manifest_rejects_empty_content_hash() -> None:
+    with pytest.raises(ValueError, match=r"^content_hash must not be empty or whitespace$"):
+        _make_manifest(content_hash="")
+
+
+def test_snapshot_manifest_rejects_whitespace_only_content_hash() -> None:
+    with pytest.raises(ValueError, match=r"^content_hash must not be empty or whitespace$"):
+        _make_manifest(content_hash="   ")
+
+
+
+
+def test_snapshot_manifest_rejects_non_datetime_created_at() -> None:
+    with pytest.raises(TypeError, match=r"^created_at must be datetime, got str$"):
+        _make_manifest(created_at=cast(Any, "2024-01-01T00:00:00Z"))
+
+
+def test_snapshot_manifest_rejects_naive_created_at() -> None:
+    with pytest.raises(ValueError, match=r"^created_at must be timezone-aware$"):
+        _make_manifest(created_at=datetime(2024, 1, 1))  # noqa: DTZ001
+
+
+def test_snapshot_manifest_rejects_non_utc_created_at() -> None:
+    non_utc = datetime(2024, 1, 1, tzinfo=timezone(timedelta(hours=9)))
+    with pytest.raises(ValueError, match=r"^created_at must be UTC$"):
+        _make_manifest(created_at=non_utc)
+
+
+
+
+def test_snapshot_manifest_delegates_seed_validation_for_non_integer_seed() -> None:
+    with pytest.raises(TypeError, match=r"^Seed must be a non-bool int, got str$"):
+        _make_manifest(seed=cast(Seed, "1"))
+
+
+def test_snapshot_manifest_delegates_seed_validation_for_negative_seed() -> None:
+    with pytest.raises(ValueError, match=r"^Seed must be >= 0, got -1$"):
+        _make_manifest(seed=cast(Seed, -1))
+
+
+def test_snapshot_manifest_delegates_seed_validation_for_seed_above_uint32_max() -> None:
+    with pytest.raises(ValueError, match=r"^Seed must be <= 4294967295, got 4294967296$"):
+        _make_manifest(seed=cast(Seed, 2**32))
+
+
+def test_snapshot_manifest_delegates_seed_validation_for_bool_seed() -> None:
+    with pytest.raises(TypeError, match=r"^Seed must be a non-bool int, got bool$"):
+        _make_manifest(seed=cast(Seed, True))
+
+
+
+
+def test_snapshot_manifest_rejects_non_uuid_parent_snapshot_id() -> None:
+    with pytest.raises(TypeError, match=r"^parent_snapshot_id must be UUID or None, got str$"):
+        _make_manifest(parent_snapshot_id=cast(Any, str(_PARENT_ID)))
+
+
+def test_snapshot_manifest_rejects_parent_snapshot_id_matching_snapshot_id() -> None:
+    with pytest.raises(ValueError, match=r"^parent_snapshot_id must not equal snapshot_id$"):
+        _make_manifest(parent_snapshot_id=_SNAPSHOT_ID)


### PR DESCRIPTION
Closes #27

## Summary
First Layer 2 (`abdp.data`) module: introduces an immutable `SnapshotManifest` value object — the generic record shared by later bronze/silver/gold artifacts and snapshot refs.

## TDD evidence
- `0873c37` **test**: 29 contract tests covering construction, immutability, exports, and every validation branch (RED — collection error before module exists).
- `5f8a2d6` **feat**: minimal `@dataclass(frozen=True, slots=True, kw_only=True)` impl with inline `__post_init__` validation; `abdp.data` facade re-exports `SnapshotManifest` and `SnapshotTier` (GREEN — 29 pass, 100% line+branch).
- `0377d3b` **refactor**: extract private validators (`_validate_uuid`, `_validate_tier`, `_validate_non_empty_text`, `_validate_created_at`, `_validate_parent_snapshot_id`) for readability and mutmut-killability; no API change.

## Design highlights (per Oracle 100/100)
- Stdlib dataclass — no new dependency.
- PEP 695 `type SnapshotTier = Literal["bronze", "silver", "gold"]`; allowed set derived via `get_args(SnapshotTier.__value__)`.
- `created_at` must be timezone-aware **and** UTC (`utcoffset() == timedelta(0)`); no coercion.
- `seed` validated by delegating to `validate_seed`.
- `parent_snapshot_id` may be `None`; otherwise must differ from `snapshot_id`.
- Strings stored exactly as provided (no normalization); only blank/whitespace rejection.
- `TypeError` for wrong type, `ValueError` for wrong-but-typed value.
- Anchored module + class docstrings as contract spec; no domain mention; sync only; no thread-safety / persistence / serialization guarantees.
- `ManifestFactory` wiring deferred — schema only, per issue scope.

## Verification (.venv312, py 3.12.13)
- `ruff check .` → All checks passed
- `mypy src tests` → Success: no issues found in 40 source files
- `pytest -q` → **259 passed**, coverage **100%** (250 stmts / 98 branches, 0 missed)
- `mutmut run` → all mutants segfault locally on macOS (known issue documented in `docs/development/mutmut.md`); Ubuntu CI is authoritative.

## Files
- `src/abdp/data/snapshot_manifest.py` (new)
- `src/abdp/data/__init__.py` (re-export `SnapshotManifest`, `SnapshotTier`; package docstring intentionally empty per `tests/meta/test_repo_scaffold.py`)
- `tests/data/test_snapshot_manifest.py` (new, 29 tests)
- `pyproject.toml` (add `tests/data/` to `[tool.mutmut].pytest_add_cli_args_test_selection`)