### PR TITLE
feat: add storage protocol (#28)

### DIFF
--- a/src/abdp/data/storage.py
+++ b/src/abdp/data/storage.py
@@ -1,0 +1,26 @@
+"""Data storage protocol contract:
+
+- Defines the minimal byte-oriented storage contract.
+- Domain-neutral and backend-agnostic.
+- Synchronous only.
+- Contract consists of ``write_bytes(key, data)``, ``read_bytes(key) -> bytes``,
+  and ``exists(key) -> bool``.
+- Intended for structural typing in data; implementations live outside data.
+- Runtime protocol checks are shallow: they verify attribute presence only and
+  do not validate call signatures or generic type arguments.
+- Exception behavior is intentionally unspecified.
+- No guarantees about overwrite behavior, atomicity, durability, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["StorageProtocol"]
+
+
+@runtime_checkable
+class StorageProtocol(Protocol):
+    def write_bytes(self, key: str, data: bytes) -> None: ...
+    def read_bytes(self, key: str) -> bytes: ...
+    def exists(self, key: str) -> bool: ...

--- a/tests/data/test_storage.py
+++ b/tests/data/test_storage.py
@@ -1,3 +1,5 @@
+"""Conformance tests for the data storage protocol contract."""
+
 from __future__ import annotations
 
 from typing import assert_type

--- a/tests/data/test_storage.py
+++ b/tests/data/test_storage.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import assert_type
+
+from abdp.data import storage
+from abdp.data.storage import StorageProtocol
+
+
+class _ValidStorage:
+    def __init__(self) -> None:
+        self._items: dict[str, bytes] = {}
+
+    def write_bytes(self, key: str, data: bytes) -> None:
+        self._items[key] = data
+
+    def read_bytes(self, key: str) -> bytes:
+        return self._items[key]
+
+    def exists(self, key: str) -> bool:
+        return key in self._items
+
+
+class _MissingWriteBytes:
+    def read_bytes(self, key: str) -> bytes:
+        return b""
+
+    def exists(self, key: str) -> bool:
+        return False
+
+
+class _MissingReadBytes:
+    def write_bytes(self, key: str, data: bytes) -> None:
+        return None
+
+    def exists(self, key: str) -> bool:
+        return False
+
+
+class _MissingExists:
+    def write_bytes(self, key: str, data: bytes) -> None:
+        return None
+
+    def read_bytes(self, key: str) -> bytes:
+        return b""
+
+
+def test_storage_module_exports_storage_protocol() -> None:
+    assert storage.__all__ == ["StorageProtocol"]
+    assert storage.StorageProtocol is StorageProtocol
+
+
+def test_storage_protocol_is_protocol() -> None:
+    assert getattr(StorageProtocol, "_is_protocol", False) is True
+
+
+def test_storage_protocol_is_runtime_checkable_and_accepts_minimal_structural_impl() -> None:
+    dummy = _ValidStorage()
+    assert isinstance(dummy, StorageProtocol) is True
+    storage_impl: StorageProtocol = dummy
+    storage_impl.write_bytes("manifest.json", b"{}")
+    assert storage_impl.exists("manifest.json") is True
+    data = storage_impl.read_bytes("manifest.json")
+    assert_type(data, bytes)
+    assert data == b"{}"
+
+
+def test_storage_protocol_runtime_check_rejects_missing_write_bytes() -> None:
+    assert isinstance(_MissingWriteBytes(), StorageProtocol) is False
+
+
+def test_storage_protocol_runtime_check_rejects_missing_read_bytes() -> None:
+    assert isinstance(_MissingReadBytes(), StorageProtocol) is False
+
+
+def test_storage_protocol_runtime_check_rejects_missing_exists() -> None:
+    assert isinstance(_MissingExists(), StorageProtocol) is False


### PR DESCRIPTION
Closes #28

## Summary
Adds the minimal byte-oriented storage contract (`StorageProtocol`) for manifests and snapshots. Pure protocol — backend-agnostic, domain-neutral, sync-only.

## TDD evidence (2-commit pure-protocol pattern, mirroring GH#24/#25)
- `f94fcd6` **test**: 6 conformance tests (`__all__`, `_is_protocol`, runtime structural acceptance with `assert_type(..., bytes)`, three missing-method negatives) — RED via collection ImportError.
- `22cd464` **feat**: `@runtime_checkable class StorageProtocol(Protocol)` with `write_bytes(key, data) -> None`, `read_bytes(key) -> bytes`, `exists(key) -> bool`. Anchored module docstring spelling out the no-guarantee clauses. GREEN.

## Design highlights (Oracle 100/100 design)
- Keys: `str` only. Values: `bytes` only (no `bytes | bytearray | memoryview` widening).
- No generics — no justified type parameter; `str` is universal at this scope.
- Read-missing semantics intentionally **unspecified** (no required exception type).
- Write semantics intentionally **unspecified** (no overwrite/atomicity/durability/thread-safety guarantees).
- No package-level export change in `abdp.data.__init__` — module-local `__all__ = ["StorageProtocol"]` only.
- Coverage handled by existing narrow def-stub regex in `.coveragerc`; no config changes.

## Mutation testing
N/A — pure Protocol module with single-line `...` def-stubs has no killable mutants.

## Verification (.venv312, py 3.12.13)
- `ruff check .` → All checks passed
- `ruff format --check .` → 42 files already formatted
- `mypy src tests` → no issues in 42 source files
- `pytest -q` → **265 passed**, coverage **100%** (258 stmts / 104 branches, 0 missed)

## Files
- `src/abdp/data/storage.py` (new)
- `tests/data/test_storage.py` (new, 6 tests)