### PR TITLE
feat(data): add SilverContract protocol (#30)

### DIFF
--- a/src/abdp/data/__init__.py
+++ b/src/abdp/data/__init__.py
@@ -1,6 +1,7 @@
 """"""
 
 from abdp.data.bronze import BronzeContract
+from abdp.data.silver import SilverContract
 from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
 
-__all__ = ["BronzeContract", "SnapshotManifest", "SnapshotTier"]
+__all__ = ["BronzeContract", "SilverContract", "SnapshotManifest", "SnapshotTier"]

--- a/src/abdp/data/silver.py
+++ b/src/abdp/data/silver.py
@@ -1,0 +1,35 @@
+"""Silver snapshot contract:
+
+- Defines the normalized snapshot contract for the silver tier.
+- Domain-neutral and row-shape-agnostic.
+- Contract consists of ``manifest: SnapshotManifest`` and ``rows: tuple[RowT, ...]``.
+- ``manifest`` references snapshot metadata, but tier-specific validation is out of scope for
+  this structural contract.
+- ``rows`` must be exposed as an immutable tuple; row contents are not validated, copied, or
+  further interpreted by this protocol.
+- The silver tier represents normalized rows, but this contract does not define how
+  normalization is performed or verified.
+- Aggregation is out of scope for this tier.
+- No schema enforcement, deduplication, or ordering semantics are implied for ``RowT`` values.
+- Synchronous access only.
+- Runtime protocol checks are shallow: they verify attribute presence only and do not validate
+  attribute values or generic type arguments.
+- No guarantees about persistence, serialization, storage backends, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from abdp.data.snapshot_manifest import SnapshotManifest
+
+__all__ = ["SilverContract"]
+
+
+@runtime_checkable
+class SilverContract[RowT](Protocol):
+    @property
+    def manifest(self) -> SnapshotManifest: ...
+
+    @property
+    def rows(self) -> tuple[RowT, ...]: ...

--- a/tests/data/test_bronze.py
+++ b/tests/data/test_bronze.py
@@ -67,7 +67,12 @@ def test_bronze_module_exports_public_symbols_only() -> None:
 
 
 def test_data_package_exports_bronze_contract_publicly() -> None:
-    assert abdp.data.__all__ == ["BronzeContract", "SnapshotManifest", "SnapshotTier"]
+    assert abdp.data.__all__ == [
+        "BronzeContract",
+        "SilverContract",
+        "SnapshotManifest",
+        "SnapshotTier",
+    ]
     assert abdp.data.BronzeContract is BronzeContract
 
 

--- a/tests/data/test_silver.py
+++ b/tests/data/test_silver.py
@@ -1,0 +1,105 @@
+"""Conformance tests for the silver snapshot protocol contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import assert_type
+from uuid import UUID
+
+import abdp.data
+from abdp.core.hashing import stable_hash
+from abdp.core.types import validate_seed
+from abdp.data import silver
+from abdp.data.silver import SilverContract
+from abdp.data.snapshot_manifest import SnapshotManifest
+
+_SNAPSHOT_ID = UUID("11111111-1111-1111-1111-111111111111")
+_CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
+_CONTENT_HASH = stable_hash({"value": 1})
+_SEED = validate_seed(7)
+
+
+def _make_manifest() -> SnapshotManifest:
+    return SnapshotManifest(
+        snapshot_id=_SNAPSHOT_ID,
+        tier="silver",
+        storage_key="snapshots/silver/example.json",
+        content_hash=_CONTENT_HASH,
+        created_at=_CREATED_AT,
+        seed=_SEED,
+    )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ValidSilverRows:
+    manifest: SnapshotManifest
+    rows: tuple[dict[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _MissingManifest:
+    rows: tuple[dict[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _MissingRows:
+    manifest: SnapshotManifest
+
+
+def test_silver_module_docstring_is_anchored_on_line_one() -> None:
+    assert silver.__file__ is not None
+    first_line = Path(silver.__file__).read_text(encoding="utf-8").splitlines()[0]
+    assert first_line == '"""Silver snapshot contract:'
+
+
+def test_silver_module_docstring_includes_contract_guards() -> None:
+    doc = silver.__doc__ or ""
+    assert "Silver snapshot contract:" in doc
+    assert "Defines the normalized snapshot contract for the silver tier." in doc
+    assert "Aggregation is out of scope for this tier." in doc
+    assert "Runtime protocol checks are shallow" in doc
+
+
+def test_silver_module_exports_public_symbols_only() -> None:
+    assert silver.__all__ == ["SilverContract"]
+    assert silver.SilverContract is SilverContract
+
+
+def test_data_package_exports_silver_contract_publicly() -> None:
+    assert abdp.data.__all__ == [
+        "BronzeContract",
+        "SilverContract",
+        "SnapshotManifest",
+        "SnapshotTier",
+    ]
+    assert abdp.data.SilverContract is SilverContract
+
+
+def test_silver_contract_is_protocol() -> None:
+    assert getattr(SilverContract, "_is_protocol", False) is True
+
+
+def test_silver_contract_is_runtime_checkable_and_accepts_minimal_structural_impl() -> None:
+    dummy = _ValidSilverRows(
+        manifest=_make_manifest(),
+        rows=({"agent_id": 1}, {"agent_id": 2}),
+    )
+
+    assert isinstance(dummy, SilverContract) is True
+
+    contract: SilverContract[dict[str, int]] = dummy
+    assert_type(contract, SilverContract[dict[str, int]])
+    assert_type(contract.manifest, SnapshotManifest)
+    assert_type(contract.rows, tuple[dict[str, int], ...])
+    assert contract.manifest.tier == "silver"
+    assert contract.rows == ({"agent_id": 1}, {"agent_id": 2})
+
+
+def test_silver_contract_runtime_check_rejects_missing_manifest() -> None:
+    assert isinstance(_MissingManifest(rows=({"agent_id": 1},)), SilverContract) is False
+
+
+def test_silver_contract_runtime_check_rejects_missing_rows() -> None:
+    assert isinstance(_MissingRows(manifest=_make_manifest()), SilverContract) is False

--- a/tests/data/test_snapshot_manifest.py
+++ b/tests/data/test_snapshot_manifest.py
@@ -52,7 +52,12 @@ def test_snapshot_manifest_module_exports_public_symbols_only() -> None:
 
 
 def test_data_package_exports_snapshot_manifest_publicly() -> None:
-    assert abdp.data.__all__ == ["BronzeContract", "SnapshotManifest", "SnapshotTier"]
+    assert abdp.data.__all__ == [
+        "BronzeContract",
+        "SilverContract",
+        "SnapshotManifest",
+        "SnapshotTier",
+    ]
     assert abdp.data.SnapshotManifest is SnapshotManifest
     assert abdp.data.SnapshotTier is SnapshotTier
 


### PR DESCRIPTION
Closes #30

## Summary
- add `SilverContract[RowT]` as the normalized-tier protocol in `abdp.data`
- structurally parallel to `BronzeContract`: `manifest: SnapshotManifest` + immutable `tuple[RowT, ...]`
- distinguished from bronze/gold by name and docstring (no extra fields, no domain assumptions)
- re-export `SilverContract` from `abdp.data` and add runtime-checkable protocol tests

## Design notes
- Per Oracle: silver is structurally identical to bronze; semantic distinction lives in the docstring ("normalized snapshot contract", "Aggregation is out of scope for this tier")
- Validation, aggregation, persistence, and threading guarantees remain out of scope
- A protocol cannot enforce `manifest.tier == "silver"`; that belongs in a future concrete value object
- PEP 695 generic with read-only properties (covariant by inference)

## TDD evidence
1. **RED** (`ff3e4a3`) — `test(data): add SilverContract conformance tests (#30)`
   - adds `tests/data/test_silver.py`
   - updates `__all__` expectations in `tests/data/test_bronze.py` and `tests/data/test_snapshot_manifest.py`
   - fails: `ImportError: cannot import name 'silver' from 'abdp.data'`
2. **GREEN** (`69c4188`) — `feat(data): add SilverContract protocol (#30)`
   - adds `src/abdp/data/silver.py` and re-exports `SilverContract` from `abdp.data`
   - 281 tests pass

No REFACTOR commit: pure protocol surface, no logic to extract.

## Verification
```
ruff check .                     # All checks passed!
ruff format --check .            # 46 files already formatted
mypy src tests                   # Success: no issues found in 46 source files
pytest -q                        # 281 passed
coverage                         # 100.00%
```

## Property / mutation testing
- **Property tests: N/A** — pure protocol surface
- **Mutation tests: N/A** — protocol declaration and shallow runtime structural membership; no business-rule branches

## Acceptance criteria
- [x] All tests pass (281 passed)
- [x] mypy strict clean
- [x] ruff clean
- [x] 100% line coverage
- [x] Contract semantically distinct from bronze/gold by docstring and name, not domain assumptions
- [x] Contract remains generic over row type