### PR TITLE
feat(data): add GoldContract protocol (#31)

### DIFF
--- a/src/abdp/data/__init__.py
+++ b/src/abdp/data/__init__.py
@@ -1,7 +1,14 @@
 """"""
 
 from abdp.data.bronze import BronzeContract
+from abdp.data.gold import GoldContract
 from abdp.data.silver import SilverContract
 from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
 
-__all__ = ["BronzeContract", "SilverContract", "SnapshotManifest", "SnapshotTier"]
+__all__ = [
+    "BronzeContract",
+    "GoldContract",
+    "SilverContract",
+    "SnapshotManifest",
+    "SnapshotTier",
+]

--- a/src/abdp/data/gold.py
+++ b/src/abdp/data/gold.py
@@ -1,0 +1,35 @@
+"""Gold snapshot contract:
+
+- Defines the decision-ready snapshot contract for the gold tier.
+- Domain-neutral and row-shape-agnostic.
+- Contract consists of ``manifest: SnapshotManifest`` and ``rows: tuple[RowT, ...]``.
+- ``manifest`` references snapshot metadata, but tier-specific validation is out of scope for
+  this structural contract.
+- ``rows`` must be exposed as an immutable tuple; row contents are not validated, copied, or
+  further interpreted by this protocol.
+- The gold tier represents rows prepared for downstream decision-making, but this contract does
+  not define how that readiness is produced or verified.
+- No schema enforcement, deduplication, aggregation, or ordering semantics are implied for
+  ``RowT`` values.
+- Synchronous access only.
+- Runtime protocol checks are shallow: they verify attribute presence only and do not validate
+  attribute values or generic type arguments.
+- No guarantees about persistence, serialization, storage backends, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from abdp.data.snapshot_manifest import SnapshotManifest
+
+__all__ = ["GoldContract"]
+
+
+@runtime_checkable
+class GoldContract[RowT](Protocol):
+    @property
+    def manifest(self) -> SnapshotManifest: ...
+
+    @property
+    def rows(self) -> tuple[RowT, ...]: ...

--- a/tests/data/test_bronze.py
+++ b/tests/data/test_bronze.py
@@ -69,6 +69,7 @@ def test_bronze_module_exports_public_symbols_only() -> None:
 def test_data_package_exports_bronze_contract_publicly() -> None:
     assert abdp.data.__all__ == [
         "BronzeContract",
+        "GoldContract",
         "SilverContract",
         "SnapshotManifest",
         "SnapshotTier",

--- a/tests/data/test_gold.py
+++ b/tests/data/test_gold.py
@@ -1,0 +1,111 @@
+"""Conformance tests for the gold snapshot protocol contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import assert_type
+from uuid import UUID
+
+import abdp.data
+from abdp.core.hashing import stable_hash
+from abdp.core.types import validate_seed
+from abdp.data import gold
+from abdp.data.gold import GoldContract
+from abdp.data.snapshot_manifest import SnapshotManifest
+
+_SNAPSHOT_ID = UUID("11111111-1111-1111-1111-111111111111")
+_CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
+_CONTENT_HASH = stable_hash({"value": 1})
+_SEED = validate_seed(7)
+
+
+def _make_manifest() -> SnapshotManifest:
+    return SnapshotManifest(
+        snapshot_id=_SNAPSHOT_ID,
+        tier="gold",
+        storage_key="snapshots/gold/example.json",
+        content_hash=_CONTENT_HASH,
+        created_at=_CREATED_AT,
+        seed=_SEED,
+    )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _ValidGoldRows:
+    manifest: SnapshotManifest
+    rows: tuple[dict[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _MissingManifest:
+    rows: tuple[dict[str, int], ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _MissingRows:
+    manifest: SnapshotManifest
+
+
+def test_gold_module_docstring_is_anchored_on_line_one() -> None:
+    assert gold.__file__ is not None
+    first_line = Path(gold.__file__).read_text(encoding="utf-8").splitlines()[0]
+    assert first_line == '"""Gold snapshot contract:'
+
+
+def test_gold_module_docstring_includes_contract_guards() -> None:
+    doc = gold.__doc__ or ""
+    assert "Gold snapshot contract:" in doc
+    assert "Defines the decision-ready snapshot contract for the gold tier." in doc
+    assert "prepared for downstream decision-making" in doc
+    assert "readiness is produced or verified" in doc
+    assert "Runtime protocol checks are shallow" in doc
+    assert "metrics" not in doc
+    assert "gates" not in doc
+    assert "claims" not in doc
+    assert "reports" not in doc
+
+
+def test_gold_module_exports_public_symbols_only() -> None:
+    assert gold.__all__ == ["GoldContract"]
+    assert gold.GoldContract is GoldContract
+
+
+def test_data_package_exports_gold_contract_publicly() -> None:
+    assert abdp.data.__all__ == [
+        "BronzeContract",
+        "GoldContract",
+        "SilverContract",
+        "SnapshotManifest",
+        "SnapshotTier",
+    ]
+    assert abdp.data.GoldContract is GoldContract
+
+
+def test_gold_contract_is_protocol() -> None:
+    assert getattr(GoldContract, "_is_protocol", False) is True
+
+
+def test_gold_contract_is_runtime_checkable_and_accepts_minimal_structural_impl() -> None:
+    dummy = _ValidGoldRows(
+        manifest=_make_manifest(),
+        rows=({"agent_id": 1}, {"agent_id": 2}),
+    )
+
+    assert isinstance(dummy, GoldContract) is True
+
+    contract: GoldContract[dict[str, int]] = dummy
+    assert_type(contract, GoldContract[dict[str, int]])
+    assert_type(contract.manifest, SnapshotManifest)
+    assert_type(contract.rows, tuple[dict[str, int], ...])
+    assert contract.manifest.tier == "gold"
+    assert contract.rows == ({"agent_id": 1}, {"agent_id": 2})
+
+
+def test_gold_contract_runtime_check_rejects_missing_manifest() -> None:
+    assert isinstance(_MissingManifest(rows=({"agent_id": 1},)), GoldContract) is False
+
+
+def test_gold_contract_runtime_check_rejects_missing_rows() -> None:
+    assert isinstance(_MissingRows(manifest=_make_manifest()), GoldContract) is False

--- a/tests/data/test_silver.py
+++ b/tests/data/test_silver.py
@@ -70,6 +70,7 @@ def test_silver_module_exports_public_symbols_only() -> None:
 def test_data_package_exports_silver_contract_publicly() -> None:
     assert abdp.data.__all__ == [
         "BronzeContract",
+        "GoldContract",
         "SilverContract",
         "SnapshotManifest",
         "SnapshotTier",

--- a/tests/data/test_snapshot_manifest.py
+++ b/tests/data/test_snapshot_manifest.py
@@ -54,6 +54,7 @@ def test_snapshot_manifest_module_exports_public_symbols_only() -> None:
 def test_data_package_exports_snapshot_manifest_publicly() -> None:
     assert abdp.data.__all__ == [
         "BronzeContract",
+        "GoldContract",
         "SilverContract",
         "SnapshotManifest",
         "SnapshotTier",


### PR DESCRIPTION
Closes #31

## Summary
- add `GoldContract[RowT]` as the decision-ready tier protocol in `abdp.data`
- structurally parallel to `BronzeContract`/`SilverContract`: `manifest: SnapshotManifest` + immutable `tuple[RowT, ...]`
- distinguished from bronze/silver by name and docstring (no extra fields, no domain assumptions)
- re-export `GoldContract` from `abdp.data` and add runtime-checkable protocol tests

## Design notes
- Per Oracle: gold is structurally identical to bronze/silver; semantic distinction lives in the docstring ("decision-ready snapshot contract", "prepared for downstream decision-making")
- Docstring intentionally avoids "metrics", "gates", "claims", "reports" per acceptance: contract stays generic and does not mention metrics or claims
- Test asserts these terms are NOT present in the docstring as a structural anchor for the acceptance constraint
- Validation, aggregation, persistence, and threading guarantees remain out of scope

## TDD evidence
1. **RED** (`c58a713`) — `test(data): add GoldContract conformance tests (#31)`
   - adds `tests/data/test_gold.py`
   - updates `__all__` expectations in `test_bronze.py`, `test_silver.py`, `test_snapshot_manifest.py`
   - fails: `ImportError: cannot import name 'gold' from 'abdp.data'`
2. **GREEN** — `feat(data): add GoldContract protocol (#31)`
   - adds `src/abdp/data/gold.py` and re-exports `GoldContract` from `abdp.data` (alphabetical)
   - 289 tests pass

No REFACTOR commit: pure protocol surface.

## Verification
\`\`\`
ruff check .                     # All checks passed!
ruff format --check .            # 48 files already formatted
mypy src tests                   # Success: no issues found in 48 source files
pytest -q                        # 289 passed
coverage                         # 100.00%
\`\`\`

## Property / mutation testing
- **Property tests: N/A** — pure protocol surface
- **Mutation tests: N/A** — protocol declaration and shallow runtime structural membership; no business-rule branches

## Acceptance criteria
- [x] All tests pass (289 passed)
- [x] mypy strict clean
- [x] ruff clean
- [x] 100% line coverage
- [x] Contract stays generic and does not mention metrics or claims (test-enforced via negative substring assertions)
- [x] Contract remains distinct from bronze/silver by tier semantics only