### PR TITLE
fix(data): freeze abdp.data public surface (#32)

### DIFF
--- a/src/abdp/data/__init__.py
+++ b/src/abdp/data/__init__.py
@@ -5,6 +5,11 @@ from abdp.data.gold import GoldContract
 from abdp.data.silver import SilverContract
 from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
 
+globals().pop("bronze", None)
+globals().pop("gold", None)
+globals().pop("silver", None)
+globals().pop("snapshot_manifest", None)
+
 __all__ = [
     "BronzeContract",
     "GoldContract",

--- a/tests/data/test_public_surface.py
+++ b/tests/data/test_public_surface.py
@@ -1,0 +1,35 @@
+"""Freeze the public surface for abdp.data."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from types import ModuleType
+
+_APPROVED_PUBLIC_NAMES = [
+    "BronzeContract",
+    "GoldContract",
+    "SilverContract",
+    "SnapshotManifest",
+    "SnapshotTier",
+]
+
+
+def _import_fresh_data_package() -> ModuleType:
+    sys.modules.pop("abdp.data", None)
+    return importlib.import_module("abdp.data")
+
+
+def _public_names(module: ModuleType) -> list[str]:
+    return [name for name, _ in inspect.getmembers(module) if not name.startswith("_")]
+
+
+def test_data_package_dunder_all_matches_approved_public_surface() -> None:
+    data = _import_fresh_data_package()
+    assert data.__all__ == _APPROVED_PUBLIC_NAMES
+
+
+def test_data_package_public_surface_matches_dunder_all() -> None:
+    data = _import_fresh_data_package()
+    assert _public_names(data) == _APPROVED_PUBLIC_NAMES


### PR DESCRIPTION
Closes #32

## Summary
- add `tests/data/test_public_surface.py` to lock the explicit `abdp.data` package API at exactly 5 symbols
- scrub leaked submodule attributes (`bronze`, `gold`, `silver`, `snapshot_manifest`) from the package namespace
- keep `StorageProtocol` public at `abdp.data.storage`, **not** at `abdp.data` (per Oracle: #28 deliberately scoped to module)

## Approved public surface
\`\`\`python
__all__ = ["BronzeContract", "GoldContract", "SilverContract", "SnapshotManifest", "SnapshotTier"]
\`\`\`

## Design notes
- Per Oracle: "approved data symbols from #27–#31" means symbols promoted to the package barrel, not every public symbol in the layer
- Fresh-import helper pops only `abdp.data` (not submodules) so cached class objects retain identity — preserves \`is\` checks in sibling tests
- Submodule-attr scrub via \`globals().pop(...)\` runs at package init time

## TDD evidence (single squashed commit, RED+GREEN cycle done locally)
1. **RED**: added `tests/data/test_public_surface.py` — 1 of 2 tests fails with `Left contains 4 more items, first extra item: 'bronze'` (leaked submodule names)
2. **GREEN**: added `globals().pop(...)` scrub in `src/abdp/data/__init__.py` — both tests pass; 291 total tests pass

## Verification
\`\`\`
ruff check .                     # All checks passed!
ruff format --check .            # 49 files already formatted
mypy src tests                   # Success: no issues found in 49 source files
pytest -q                        # 291 passed
coverage                         # 100.00%
\`\`\`

## Property / mutation testing
- **Property tests: N/A** — frozen-surface test, no behavior under test
- **Mutation tests: N/A** — package re-exports and scrub-pop only; no business-rule branches

## Acceptance criteria
- [x] All tests pass (291 passed)
- [x] mypy strict clean
- [x] ruff clean
- [x] 100% line coverage
- [x] \`__all__\` contains only the approved data symbols from #27–#31 (5 symbols)
- [x] Internal helper names do not leak (submodule attrs scrubbed)