### PR TITLE
feat(simulation): add SnapshotRef reference model (#33)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 [tool.mutmut]
 paths_to_mutate = ["src/abdp/"]
 pytest_add_cli_args = ["-p", "no:cacheprovider", "--no-cov"]
-pytest_add_cli_args_test_selection = ["tests/unit/", "tests/core/", "tests/data/"]
+pytest_add_cli_args_test_selection = ["tests/unit/", "tests/core/", "tests/data/", "tests/simulation/"]
 also_copy = ["pytest.ini"]
 do_not_mutate = [
     "src/abdp/__init__.py",

--- a/src/abdp/simulation/__init__.py
+++ b/src/abdp/simulation/__init__.py
@@ -1,1 +1,7 @@
 """"""
+
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+globals().pop("snapshot_ref", None)
+
+__all__ = ["SnapshotRef"]

--- a/src/abdp/simulation/snapshot_ref.py
+++ b/src/abdp/simulation/snapshot_ref.py
@@ -1,0 +1,73 @@
+"""Snapshot reference contract:
+
+- Priority-3 role: simulation state carries lightweight pointers to snapshots without loading snapshot contents.
+- ``SnapshotRef`` is an immutable reference model for locating an existing snapshot.
+- Contract consists of ``snapshot_id``, ``tier``, and ``storage_key`` only.
+- ``snapshot_id`` must be a ``UUID`` instance; string parsing is out of scope.
+- ``tier`` must be one of ``"bronze"``, ``"silver"``, or ``"gold"``.
+- ``storage_key`` must be non-empty when stripped of surrounding whitespace.
+- ``from_manifest(...)`` projects only reference fields from ``SnapshotManifest`` and performs no I/O.
+- ``content_hash``, ``created_at``, ``seed``, and ``parent_snapshot_id`` are intentionally excluded.
+- No guarantees about persistence, storage existence, payload parsing, integrity verification, or thread safety.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Self, get_args
+from uuid import UUID
+
+from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
+
+__all__ = ["SnapshotRef"]
+
+_ALLOWED_TIERS: tuple[SnapshotTier, ...] = get_args(SnapshotTier.__value__)
+
+
+def _validate_uuid(field_name: str, value: object) -> None:
+    if not isinstance(value, UUID):
+        raise TypeError(f"{field_name} must be UUID, got {type(value).__name__}")
+
+
+def _validate_tier(value: object) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"tier must be str, got {type(value).__name__}")
+    if value not in _ALLOWED_TIERS:
+        raise ValueError(f"tier must be one of {_ALLOWED_TIERS!r}, got {value!r}")
+
+
+def _validate_storage_key(value: object) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"storage_key must be str, got {type(value).__name__}")
+    if not value.strip():
+        raise ValueError("storage_key must not be empty or whitespace")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SnapshotRef:
+    """SnapshotRef contract:
+
+    - Immutable dataclass record with slot-backed, keyword-only fields.
+    - Represents a snapshot pointer only; it does not load, parse, or verify snapshot contents.
+    - Stores reference fields exactly as provided after validation; no normalization or I/O is performed.
+    - Validation is limited to basic runtime type checks and field invariants.
+    - Construction is synchronous only.
+    - No guarantees about storage existence, payload integrity, persistence, or thread safety.
+    """
+
+    snapshot_id: UUID
+    tier: SnapshotTier
+    storage_key: str
+
+    def __post_init__(self) -> None:
+        _validate_uuid("snapshot_id", self.snapshot_id)
+        _validate_tier(self.tier)
+        _validate_storage_key(self.storage_key)
+
+    @classmethod
+    def from_manifest(cls, manifest: SnapshotManifest) -> Self:
+        return cls(
+            snapshot_id=manifest.snapshot_id,
+            tier=manifest.tier,
+            storage_key=manifest.storage_key,
+        )

--- a/src/abdp/simulation/snapshot_ref.py
+++ b/src/abdp/simulation/snapshot_ref.py
@@ -36,11 +36,11 @@ def _validate_tier(value: object) -> None:
         raise ValueError(f"tier must be one of {_ALLOWED_TIERS!r}, got {value!r}")
 
 
-def _validate_storage_key(value: object) -> None:
+def _validate_non_empty_text(field_name: str, value: object) -> None:
     if not isinstance(value, str):
-        raise TypeError(f"storage_key must be str, got {type(value).__name__}")
+        raise TypeError(f"{field_name} must be str, got {type(value).__name__}")
     if not value.strip():
-        raise ValueError("storage_key must not be empty or whitespace")
+        raise ValueError(f"{field_name} must not be empty or whitespace")
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -62,7 +62,7 @@ class SnapshotRef:
     def __post_init__(self) -> None:
         _validate_uuid("snapshot_id", self.snapshot_id)
         _validate_tier(self.tier)
-        _validate_storage_key(self.storage_key)
+        _validate_non_empty_text("storage_key", self.storage_key)
 
     @classmethod
     def from_manifest(cls, manifest: SnapshotManifest) -> Self:

--- a/tests/simulation/test_snapshot_ref.py
+++ b/tests/simulation/test_snapshot_ref.py
@@ -1,0 +1,190 @@
+"""Contract tests for the SnapshotRef reference model."""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import inspect
+import sys
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+from types import ModuleType
+from typing import assert_type, cast
+from uuid import UUID
+
+import pytest
+
+from abdp.core.hashing import stable_hash
+from abdp.core.types import Seed, validate_seed
+from abdp.data.snapshot_manifest import SnapshotManifest, SnapshotTier
+from abdp.simulation import snapshot_ref as sr
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+_SNAPSHOT_ID = UUID("11111111-1111-1111-1111-111111111111")
+_OTHER_SNAPSHOT_ID = UUID("33333333-3333-3333-3333-333333333333")
+_CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
+_DEFAULT_CONTENT_HASH = stable_hash({"value": 1})
+_DEFAULT_SEED = validate_seed(7)
+_STORAGE_KEY = "snapshots/bronze/example.json"
+_OTHER_STORAGE_KEY = "snapshots/bronze/other.json"
+
+_APPROVED_PUBLIC_NAMES = ["SnapshotRef"]
+
+
+def _make_manifest(
+    *,
+    snapshot_id: UUID = _SNAPSHOT_ID,
+    tier: SnapshotTier = "bronze",
+    storage_key: str = _STORAGE_KEY,
+    content_hash: str = _DEFAULT_CONTENT_HASH,
+    created_at: datetime = _CREATED_AT,
+    seed: Seed = _DEFAULT_SEED,
+    parent_snapshot_id: UUID | None = None,
+) -> SnapshotManifest:
+    return SnapshotManifest(
+        snapshot_id=snapshot_id,
+        tier=tier,
+        storage_key=storage_key,
+        content_hash=content_hash,
+        created_at=created_at,
+        seed=seed,
+        parent_snapshot_id=parent_snapshot_id,
+    )
+
+
+def _make_ref(
+    *,
+    snapshot_id: UUID = _SNAPSHOT_ID,
+    tier: SnapshotTier = "bronze",
+    storage_key: str = _STORAGE_KEY,
+) -> SnapshotRef:
+    return SnapshotRef(snapshot_id=snapshot_id, tier=tier, storage_key=storage_key)
+
+
+def _import_fresh_simulation_package() -> ModuleType:
+    sys.modules.pop("abdp.simulation", None)
+    return importlib.import_module("abdp.simulation")
+
+
+def _public_names(module: ModuleType) -> list[str]:
+    return [name for name, _ in inspect.getmembers(module) if not name.startswith("_")]
+
+
+def test_snapshot_ref_module_docstring_includes_contract_anchor() -> None:
+    doc = sr.__doc__ or ""
+    assert "Snapshot reference contract:" in doc
+    assert "Priority-3 role" in doc
+    assert "No guarantees about persistence" in doc
+
+
+def test_snapshot_ref_module_exports_public_symbols_only() -> None:
+    assert sr.__all__ == ["SnapshotRef"]
+    assert sr.SnapshotRef is SnapshotRef
+
+
+def test_simulation_package_dunder_all_matches_approved_public_surface() -> None:
+    pkg = _import_fresh_simulation_package()
+    assert pkg.__all__ == _APPROVED_PUBLIC_NAMES
+
+
+def test_simulation_package_public_surface_matches_dunder_all() -> None:
+    pkg = _import_fresh_simulation_package()
+    assert _public_names(pkg) == _APPROVED_PUBLIC_NAMES
+    assert pkg.SnapshotRef is SnapshotRef
+
+
+def test_snapshot_ref_class_docstring_includes_contract_anchor() -> None:
+    doc = SnapshotRef.__doc__ or ""
+    assert "SnapshotRef contract:" in doc
+    assert "does not load, parse, or verify snapshot contents" in doc
+
+
+def test_snapshot_ref_constructs_valid_reference() -> None:
+    ref = _make_ref()
+    assert ref.snapshot_id == _SNAPSHOT_ID
+    assert ref.tier == "bronze"
+    assert ref.storage_key == _STORAGE_KEY
+
+
+def test_snapshot_ref_from_manifest_preserves_reference_fields_only() -> None:
+    manifest = _make_manifest(tier="silver")
+    ref = SnapshotRef.from_manifest(manifest)
+    assert ref.snapshot_id == manifest.snapshot_id
+    assert ref.tier == manifest.tier
+    assert ref.storage_key == manifest.storage_key
+
+
+def test_snapshot_ref_field_set_excludes_non_reference_manifest_metadata() -> None:
+    field_names = {field.name for field in dataclasses.fields(SnapshotRef)}
+    assert field_names == {"snapshot_id", "tier", "storage_key"}
+
+
+def test_snapshot_ref_from_manifest_returns_snapshot_ref() -> None:
+    manifest = _make_manifest()
+    ref = SnapshotRef.from_manifest(manifest)
+    assert_type(ref, SnapshotRef)
+    assert isinstance(ref, SnapshotRef)
+
+
+def test_snapshot_ref_is_frozen() -> None:
+    ref = _make_ref()
+    with pytest.raises(FrozenInstanceError):
+        setattr(ref, "tier", "silver")  # noqa: B010
+
+
+def test_snapshot_ref_equal_instances_compare_equal_and_have_same_hash() -> None:
+    a = _make_ref()
+    b = _make_ref()
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_snapshot_ref_equality_is_structural_not_snapshot_id_only() -> None:
+    base = _make_ref()
+    different_tier = _make_ref(tier="silver")
+    different_storage_key = _make_ref(storage_key=_OTHER_STORAGE_KEY)
+    assert base != different_tier
+    assert base != different_storage_key
+
+
+def test_snapshot_ref_is_hashable() -> None:
+    a = _make_ref()
+    b = _make_ref()
+    different = _make_ref(snapshot_id=_OTHER_SNAPSHOT_ID)
+    collected = {a, b}
+    assert collected == {a}
+    collected.add(different)
+    assert len(collected) == 2
+
+
+def test_snapshot_ref_rejects_non_uuid_snapshot_id() -> None:
+    with pytest.raises(TypeError, match=r"^snapshot_id must be UUID, got str$"):
+        _make_ref(snapshot_id=cast(UUID, str(_SNAPSHOT_ID)))
+
+
+def test_snapshot_ref_rejects_non_string_tier() -> None:
+    with pytest.raises(TypeError, match=r"^tier must be str, got int$"):
+        _make_ref(tier=cast(SnapshotTier, 1))
+
+
+def test_snapshot_ref_rejects_unknown_tier() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^tier must be one of \('bronze', 'silver', 'gold'\), got 'platinum'$",
+    ):
+        _make_ref(tier=cast(SnapshotTier, "platinum"))
+
+
+def test_snapshot_ref_rejects_non_string_storage_key() -> None:
+    with pytest.raises(TypeError, match=r"^storage_key must be str, got int$"):
+        _make_ref(storage_key=cast(str, 1))
+
+
+def test_snapshot_ref_rejects_empty_storage_key() -> None:
+    with pytest.raises(ValueError, match=r"^storage_key must not be empty or whitespace$"):
+        _make_ref(storage_key="")
+
+
+def test_snapshot_ref_rejects_whitespace_only_storage_key() -> None:
+    with pytest.raises(ValueError, match=r"^storage_key must not be empty or whitespace$"):
+        _make_ref(storage_key="   ")


### PR DESCRIPTION
Closes #33

## Summary

Introduces `abdp.simulation.SnapshotRef`, the immutable lightweight pointer that simulation state will use to reference snapshots without loading payloads. First issue in Layer 3 (`abdp.simulation`).

## Design (Oracle-approved)

- Field set: `snapshot_id: UUID`, `tier: SnapshotTier`, `storage_key: str` only.
  - `content_hash`, `created_at`, `seed`, `parent_snapshot_id` are intentionally excluded — these are integrity/provenance/lineage metadata, not locator state.
- Frozen, slots, kw-only dataclass.
- `from_manifest(...)` classmethod projects only the three reference fields.
- Equality is structural across all retained fields (not `snapshot_id`-only) — divergent locator metadata must not collapse silently.
- Shallow runtime validation in `__post_init__` (UUID type, allowed tier, non-empty storage_key) so direct construction stays safe.

## TDD evidence

| Phase | Commit | Description |
|---|---|---|
| RED | `b2f1311` | failing contract tests (collection fails on missing module) |
| GREEN | `218e324` | `SnapshotRef` + `from_manifest` + package re-export + mutmut config |
| REFACTOR | `08a2078` | rename validator to match `snapshot_manifest._validate_non_empty_text` convention |

## Verification

- `ruff format` / `ruff check`: clean (51 files)
- `mypy --strict src tests`: clean (51 files)
- `pytest --cov`: **310 passed**, **100.00% line coverage**
- `tests/simulation/test_snapshot_ref.py`: 19 tests covering docstring anchors, package public surface, projection, field-set exclusion, frozen, equality/hash, type strictness via `assert_type`, and validator branches.

## Mutation strategy

Targeted at `src/abdp/simulation/snapshot_ref.py` constructor logic. Per-mutant kill mapping documented in design (projection lines, field-set additions, equality collapse, validator removal/inversion). Ubuntu CI is authoritative for mutmut runs (macOS local mutmut SIGSEGVs in `os.fork()`).

## Files

- `src/abdp/simulation/snapshot_ref.py` (new)
- `src/abdp/simulation/__init__.py` (re-export + freeze public surface)
- `tests/simulation/test_snapshot_ref.py` (new, 19 tests)
- `pyproject.toml` (mutmut test selection extended)