### PR TITLE
feat(simulation): add ParticipantState protocol (#34)

### DIFF
--- a/src/abdp/simulation/__init__.py
+++ b/src/abdp/simulation/__init__.py
@@ -1,7 +1,9 @@
 """"""
 
+from abdp.simulation.participant_state import ParticipantState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
+globals().pop("participant_state", None)
 globals().pop("snapshot_ref", None)
 
-__all__ = ["SnapshotRef"]
+__all__ = ["ParticipantState", "SnapshotRef"]

--- a/src/abdp/simulation/participant_state.py
+++ b/src/abdp/simulation/participant_state.py
@@ -1,0 +1,23 @@
+"""Participant state protocol contract:
+
+- Defines the minimal identity-only participant contract shared across simulation domains.
+- Domain-neutral and simulation-agnostic.
+- Contract consists of readable ``participant_id: str`` access only.
+- ``participant_id`` introduces no domain semantics beyond participant identity.
+- Intended for structural typing in simulation; implementations live outside simulation.
+- Runtime protocol checks are shallow: they verify attribute presence only and do not validate attribute types.
+- The protocol does not require a stored field, a property setter, or mutation semantics.
+- No guarantees about persistence, serialization, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["ParticipantState"]
+
+
+@runtime_checkable
+class ParticipantState(Protocol):
+    @property
+    def participant_id(self) -> str: ...

--- a/tests/simulation/test_participant_state.py
+++ b/tests/simulation/test_participant_state.py
@@ -1,0 +1,63 @@
+"""Conformance tests for the participant state protocol contract."""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from abdp.simulation import participant_state
+from abdp.simulation.participant_state import ParticipantState
+
+
+class _ValidParticipant:
+    def __init__(self, participant_id: str) -> None:
+        self.participant_id = participant_id
+
+
+class _MissingParticipantId:
+    pass
+
+
+def _public_protocol_members(proto: type) -> set[str]:
+    return {
+        name
+        for name, value in proto.__dict__.items()
+        if not name.startswith("_") and (callable(value) or isinstance(value, property))
+    }
+
+
+def test_participant_state_module_docstring_includes_contract_anchor() -> None:
+    doc = participant_state.__doc__ or ""
+    assert "Participant state protocol contract:" in doc
+    assert "identity-only" in doc
+    assert "participant_id: str" in doc
+    assert "Runtime protocol checks are shallow" in doc
+    assert "No guarantees about persistence, serialization, or thread safety" in doc
+
+
+def test_participant_state_module_exports_public_symbols_only() -> None:
+    assert participant_state.__all__ == ["ParticipantState"]
+    assert participant_state.ParticipantState is ParticipantState
+
+
+def test_participant_state_is_protocol() -> None:
+    assert getattr(ParticipantState, "_is_protocol", False) is True
+
+
+def test_participant_state_class_docstring_is_omitted_for_pure_protocol_exemplar() -> None:
+    assert ParticipantState.__doc__ is None
+
+
+def test_participant_state_runtime_checkable_accepts_minimal_valid_impl() -> None:
+    instance = _ValidParticipant("p1")
+    assert isinstance(instance, ParticipantState) is True
+    state: ParticipantState = instance
+    assert_type(state.participant_id, str)
+    assert state.participant_id == "p1"
+
+
+def test_participant_state_runtime_checkable_rejects_missing_participant_id() -> None:
+    assert isinstance(_MissingParticipantId(), ParticipantState) is False
+
+
+def test_participant_state_contract_is_identity_only() -> None:
+    assert _public_protocol_members(ParticipantState) == {"participant_id"}

--- a/tests/simulation/test_simulation_public_surface.py
+++ b/tests/simulation/test_simulation_public_surface.py
@@ -1,0 +1,34 @@
+"""Freeze the public surface for abdp.simulation."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from types import ModuleType
+
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+_APPROVED_PUBLIC_NAMES = ["ParticipantState", "SnapshotRef"]
+
+
+def _import_fresh_simulation_package() -> ModuleType:
+    sys.modules.pop("abdp.simulation", None)
+    return importlib.import_module("abdp.simulation")
+
+
+def _public_names(module: ModuleType) -> list[str]:
+    return [name for name, _ in inspect.getmembers(module) if not name.startswith("_")]
+
+
+def test_simulation_package_dunder_all_matches_approved_public_surface() -> None:
+    pkg = _import_fresh_simulation_package()
+    assert pkg.__all__ == _APPROVED_PUBLIC_NAMES
+
+
+def test_simulation_package_public_surface_matches_dunder_all() -> None:
+    pkg = _import_fresh_simulation_package()
+    assert _public_names(pkg) == _APPROVED_PUBLIC_NAMES
+    assert pkg.ParticipantState is ParticipantState
+    assert pkg.SnapshotRef is SnapshotRef

--- a/tests/simulation/test_snapshot_ref.py
+++ b/tests/simulation/test_snapshot_ref.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import dataclasses
-import importlib
-import inspect
-import sys
 from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime
-from types import ModuleType
 from typing import assert_type, cast
 from uuid import UUID
 
@@ -27,8 +23,6 @@ _DEFAULT_CONTENT_HASH = stable_hash({"value": 1})
 _DEFAULT_SEED = validate_seed(7)
 _STORAGE_KEY = "snapshots/bronze/example.json"
 _OTHER_STORAGE_KEY = "snapshots/bronze/other.json"
-
-_APPROVED_PUBLIC_NAMES = ["SnapshotRef"]
 
 
 def _make_manifest(
@@ -61,15 +55,6 @@ def _make_ref(
     return SnapshotRef(snapshot_id=snapshot_id, tier=tier, storage_key=storage_key)
 
 
-def _import_fresh_simulation_package() -> ModuleType:
-    sys.modules.pop("abdp.simulation", None)
-    return importlib.import_module("abdp.simulation")
-
-
-def _public_names(module: ModuleType) -> list[str]:
-    return [name for name, _ in inspect.getmembers(module) if not name.startswith("_")]
-
-
 def test_snapshot_ref_module_docstring_includes_contract_anchor() -> None:
     doc = sr.__doc__ or ""
     assert "Snapshot reference contract:" in doc
@@ -80,17 +65,6 @@ def test_snapshot_ref_module_docstring_includes_contract_anchor() -> None:
 def test_snapshot_ref_module_exports_public_symbols_only() -> None:
     assert sr.__all__ == ["SnapshotRef"]
     assert sr.SnapshotRef is SnapshotRef
-
-
-def test_simulation_package_dunder_all_matches_approved_public_surface() -> None:
-    pkg = _import_fresh_simulation_package()
-    assert pkg.__all__ == _APPROVED_PUBLIC_NAMES
-
-
-def test_simulation_package_public_surface_matches_dunder_all() -> None:
-    pkg = _import_fresh_simulation_package()
-    assert _public_names(pkg) == _APPROVED_PUBLIC_NAMES
-    assert pkg.SnapshotRef is SnapshotRef
 
 
 def test_snapshot_ref_class_docstring_includes_contract_anchor() -> None:


### PR DESCRIPTION
Closes #34

## Summary

Introduces `abdp.simulation.ParticipantState`, the minimal identity-only participant contract shared across simulation domains. Pure runtime-checkable Protocol exposing only readable `participant_id: str` access.

## Design (Oracle-approved)

- **Type of `participant_id`: `str`** — smallest cross-domain identity type, no UUID format imposition, no new core type bloat.
- **Declared as `@property`** (not bare data attribute) — read-only contract, avoids implying mutation under strict typing while still satisfied by plain attributes.
- **No class docstring** — mirrors `StorageProtocol` exemplar; module docstring is the contract anchor.
- **Re-exported** from `abdp.simulation.__init__.py`; package public surface frozen alphabetical: `["ParticipantState", "SnapshotRef"]`.
- **Public-surface tests extracted** to dedicated `tests/simulation/test_simulation_public_surface.py` (mirrors `tests/data/test_public_surface.py` pattern); duplicated package-surface assertions removed from `test_snapshot_ref.py`. Filename uses `test_simulation_public_surface` to avoid pytest/mypy basename collision with the data layer's same-purpose file (no-init test convention).

## Property/mutation N/A

Property/mutation N/A — pure protocol; conformance is structural and requires only readable `participant_id` access.

## TDD evidence

| Phase | Commit | Description |
|---|---|---|
| RED | `d4b7dca` | failing contract tests (collection error: ParticipantState module missing) |
| GREEN | `1942aba` | `ParticipantState` protocol + package re-export |

REFACTOR phase: N/A for pure protocol (nothing to refactor; module is already minimal).

## Verification

- `ruff format` / `ruff check`: clean (54 files)
- `mypy --strict src tests`: clean (54 files)
- `pytest --cov`: **317 passed**, **100.00% line coverage**
- Tests added: 7 in `test_participant_state.py` + 2 in `test_simulation_public_surface.py`
  - module docstring contract anchor
  - `__all__` export check
  - `_is_protocol` truthy
  - class docstring is `None` (matches StorageProtocol exemplar)
  - runtime_checkable accepts minimal valid impl + `assert_type(participant_id, str)`
  - runtime_checkable rejects impl missing `participant_id`
  - identity-only contract guard via class-dict public-member inspection
  - simulation package `__all__` matches frozen surface
  - simulation package `inspect.getmembers` matches `__all__` and `is`-identity holds for both exports

## Files

- `src/abdp/simulation/participant_state.py` (new)
- `src/abdp/simulation/__init__.py` (alphabetical re-exports + scrub)
- `tests/simulation/test_participant_state.py` (new, 7 tests)
- `tests/simulation/test_simulation_public_surface.py` (new, 2 tests; replaces inline assertions in `test_snapshot_ref.py`)
- `tests/simulation/test_snapshot_ref.py` (removed duplicated package-surface tests)