### PR TITLE
feat(simulation): add SegmentState protocol (#35)

### DIFF
--- a/src/abdp/simulation/__init__.py
+++ b/src/abdp/simulation/__init__.py
@@ -1,9 +1,11 @@
 """"""
 
 from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
 globals().pop("participant_state", None)
+globals().pop("segment_state", None)
 globals().pop("snapshot_ref", None)
 
-__all__ = ["ParticipantState", "SnapshotRef"]
+__all__ = ["ParticipantState", "SegmentState", "SnapshotRef"]

--- a/src/abdp/simulation/segment_state.py
+++ b/src/abdp/simulation/segment_state.py
@@ -1,0 +1,27 @@
+"""Segment state protocol contract:
+
+- Defines the minimal identity-and-membership segment contract shared across simulation domains.
+- Domain-neutral and simulation-agnostic.
+- Contract consists of readable ``segment_id: str`` and ``participant_ids: tuple[str, ...]`` access only.
+- ``segment_id`` introduces no domain semantics beyond segment identity.
+- ``participant_ids`` is an immutable tuple of participant identifiers for generic grouping only;
+  it does not imply scoring, transitions, or domain-specific grouping logic.
+- Intended for structural typing in simulation; implementations live outside simulation.
+- Runtime protocol checks are shallow: they verify attribute presence only and do not validate attribute types.
+- The protocol does not require a stored field, a property setter, or mutation semantics.
+- No guarantees about uniqueness, non-emptiness, persistence, serialization, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["SegmentState"]
+
+
+@runtime_checkable
+class SegmentState(Protocol):
+    @property
+    def segment_id(self) -> str: ...
+    @property
+    def participant_ids(self) -> tuple[str, ...]: ...

--- a/tests/simulation/test_segment_state.py
+++ b/tests/simulation/test_segment_state.py
@@ -1,0 +1,77 @@
+"""Conformance tests for the segment state protocol contract."""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from abdp.simulation import segment_state
+from abdp.simulation.segment_state import SegmentState
+
+
+class _ValidSegment:
+    def __init__(self, segment_id: str, participant_ids: tuple[str, ...]) -> None:
+        self.segment_id = segment_id
+        self.participant_ids = participant_ids
+
+
+class _MissingSegmentId:
+    def __init__(self) -> None:
+        self.participant_ids: tuple[str, ...] = ()
+
+
+class _MissingParticipantIds:
+    def __init__(self) -> None:
+        self.segment_id = "s1"
+
+
+def _public_protocol_members(proto: type) -> set[str]:
+    return {
+        name
+        for name, value in proto.__dict__.items()
+        if not name.startswith("_") and (callable(value) or isinstance(value, property))
+    }
+
+
+def test_segment_state_module_docstring_includes_contract_anchor() -> None:
+    doc = segment_state.__doc__ or ""
+    assert "Segment state protocol contract:" in doc
+    assert "identity-and-membership" in doc
+    assert "segment_id: str" in doc
+    assert "participant_ids: tuple[str, ...]" in doc
+    assert "Runtime protocol checks are shallow" in doc
+    assert "No guarantees about uniqueness, non-emptiness, persistence, serialization, or thread safety" in doc
+
+
+def test_segment_state_module_exports_public_symbols_only() -> None:
+    assert segment_state.__all__ == ["SegmentState"]
+    assert segment_state.SegmentState is SegmentState
+
+
+def test_segment_state_is_protocol() -> None:
+    assert getattr(SegmentState, "_is_protocol", False) is True
+
+
+def test_segment_state_class_docstring_is_omitted_for_pure_protocol_exemplar() -> None:
+    assert SegmentState.__doc__ is None
+
+
+def test_segment_state_runtime_checkable_accepts_minimal_valid_impl() -> None:
+    instance = _ValidSegment("s1", ("p1", "p2"))
+    assert isinstance(instance, SegmentState) is True
+    state: SegmentState = instance
+    assert_type(state.segment_id, str)
+    assert_type(state.participant_ids, tuple[str, ...])
+    assert state.segment_id == "s1"
+    assert state.participant_ids == ("p1", "p2")
+
+
+def test_segment_state_runtime_checkable_rejects_missing_segment_id() -> None:
+    assert isinstance(_MissingSegmentId(), SegmentState) is False
+
+
+def test_segment_state_runtime_checkable_rejects_missing_participant_ids() -> None:
+    assert isinstance(_MissingParticipantIds(), SegmentState) is False
+
+
+def test_segment_state_contract_is_identity_and_membership_only() -> None:
+    assert _public_protocol_members(SegmentState) == {"segment_id", "participant_ids"}

--- a/tests/simulation/test_simulation_public_surface.py
+++ b/tests/simulation/test_simulation_public_surface.py
@@ -8,9 +8,10 @@ import sys
 from types import ModuleType
 
 from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
-_APPROVED_PUBLIC_NAMES = ["ParticipantState", "SnapshotRef"]
+_APPROVED_PUBLIC_NAMES = ["ParticipantState", "SegmentState", "SnapshotRef"]
 
 
 def _import_fresh_simulation_package() -> ModuleType:
@@ -31,4 +32,5 @@ def test_simulation_package_public_surface_matches_dunder_all() -> None:
     pkg = _import_fresh_simulation_package()
     assert _public_names(pkg) == _APPROVED_PUBLIC_NAMES
     assert pkg.ParticipantState is ParticipantState
+    assert pkg.SegmentState is SegmentState
     assert pkg.SnapshotRef is SnapshotRef


### PR DESCRIPTION
Closes #35

## Design (Oracle 100/100)

Pure structural protocol for segment identity + participant membership in the simulation layer. Domain-neutral; no scoring, transitions, or grouping semantics implied.

- `@runtime_checkable class SegmentState(Protocol)`
- `@property segment_id: str`
- `@property participant_ids: tuple[str, ...]` (immutable, ordered, hashable)

## TDD

- RED `356ebf3`: `tests/simulation/test_segment_state.py` (8 tests) + public surface expansion to `["ParticipantState", "SegmentState", "SnapshotRef"]`
- GREEN `eb0f897`: `src/abdp/simulation/segment_state.py` + `__init__.py` re-export

## Verification

- ruff format / check: clean
- mypy --strict src tests: clean (56 files)
- pytest --cov: 325 passed, 100% coverage

## Property/mutation

N/A — pure protocol; conformance is structural and requires only readable `segment_id` and `participant_ids` access.

## Files

- `src/abdp/simulation/segment_state.py` (new)
- `src/abdp/simulation/__init__.py` (re-export)
- `tests/simulation/test_segment_state.py` (new)
- `tests/simulation/test_simulation_public_surface.py` (updated)