### PR TITLE
feat(simulation): add ActionProposal protocol (#36)

### DIFF
--- a/src/abdp/simulation/__init__.py
+++ b/src/abdp/simulation/__init__.py
@@ -1,11 +1,13 @@
 """"""
 
+from abdp.simulation.action_proposal import ActionProposal
 from abdp.simulation.participant_state import ParticipantState
 from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
+globals().pop("action_proposal", None)
 globals().pop("participant_state", None)
 globals().pop("segment_state", None)
 globals().pop("snapshot_ref", None)
 
-__all__ = ["ParticipantState", "SegmentState", "SnapshotRef"]
+__all__ = ["ActionProposal", "ParticipantState", "SegmentState", "SnapshotRef"]

--- a/src/abdp/simulation/action_proposal.py
+++ b/src/abdp/simulation/action_proposal.py
@@ -1,0 +1,46 @@
+"""Action proposal protocol contract:
+
+- Defines the minimal identity-intent-and-payload action proposal contract
+  shared between decision logic and state progression across simulation domains.
+- Domain-neutral and simulation-agnostic.
+- Contract consists of readable ``proposal_id: str``, ``actor_id: str``,
+  ``action_key: str``, and ``payload: JsonValue`` access only.
+- ``proposal_id`` introduces no domain semantics beyond proposal identity.
+- ``actor_id`` introduces no domain semantics beyond identifying the
+  proposing actor.
+- ``action_key`` is a neutral action discriminator only; it does not imply
+  execution semantics, validation rules, or domain-specific action taxonomies.
+- ``payload`` is a generic JSON-compatible value layer for neutral action
+  parameters only; it does not imply schema, storage, transport, or
+  domain-specific action types.
+- Intended for structural typing in simulation; implementations live outside
+  simulation.
+- Runtime protocol checks are shallow: they verify attribute presence only and
+  do not validate attribute types.
+- The protocol does not require a stored field, a property setter, or mutation
+  semantics.
+- No guarantees about non-emptiness, uniqueness, persistence, serialization, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from abdp.core.types import JsonValue
+
+__all__ = ["ActionProposal"]
+
+
+@runtime_checkable
+class ActionProposal(Protocol):
+    @property
+    def proposal_id(self) -> str: ...
+
+    @property
+    def actor_id(self) -> str: ...
+
+    @property
+    def action_key(self) -> str: ...
+
+    @property
+    def payload(self) -> JsonValue: ...

--- a/tests/simulation/test_action_proposal.py
+++ b/tests/simulation/test_action_proposal.py
@@ -1,0 +1,125 @@
+"""Conformance tests for the action proposal protocol contract."""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from abdp.core.types import JsonValue
+from abdp.simulation import action_proposal
+from abdp.simulation.action_proposal import ActionProposal
+
+
+class _ValidImpl:
+    def __init__(
+        self,
+        proposal_id: str,
+        actor_id: str,
+        action_key: str,
+        payload: JsonValue,
+    ) -> None:
+        self.proposal_id = proposal_id
+        self.actor_id = actor_id
+        self.action_key = action_key
+        self.payload = payload
+
+
+class _MissingProposalId:
+    def __init__(self) -> None:
+        self.actor_id = "agent-1"
+        self.action_key = "advance"
+        self.payload: JsonValue = {"step": 1}
+
+
+class _MissingActorId:
+    def __init__(self) -> None:
+        self.proposal_id = "prop-1"
+        self.action_key = "advance"
+        self.payload: JsonValue = {"step": 1}
+
+
+class _MissingActionKey:
+    def __init__(self) -> None:
+        self.proposal_id = "prop-1"
+        self.actor_id = "agent-1"
+        self.payload: JsonValue = {"step": 1}
+
+
+class _MissingPayload:
+    def __init__(self) -> None:
+        self.proposal_id = "prop-1"
+        self.actor_id = "agent-1"
+        self.action_key = "advance"
+
+
+def _public_protocol_members(proto: type) -> set[str]:
+    return {
+        name
+        for name, value in proto.__dict__.items()
+        if not name.startswith("_") and (callable(value) or isinstance(value, property))
+    }
+
+
+def test_action_proposal_module_docstring_includes_contract_anchor() -> None:
+    doc = action_proposal.__doc__ or ""
+    assert "Action proposal protocol contract:" in doc
+    assert "identity-intent-and-payload" in doc
+    assert "decision logic and state progression" in doc
+    assert "proposal_id: str" in doc
+    assert "actor_id: str" in doc
+    assert "action_key: str" in doc
+    assert "payload: JsonValue" in doc
+    assert "Runtime protocol checks are shallow" in doc
+    assert ("No guarantees about non-emptiness, uniqueness, persistence, serialization, or thread safety") in doc
+
+
+def test_action_proposal_module_exports_public_symbols_only() -> None:
+    assert action_proposal.__all__ == ["ActionProposal"]
+    assert action_proposal.ActionProposal is ActionProposal
+
+
+def test_action_proposal_is_protocol() -> None:
+    assert getattr(ActionProposal, "_is_protocol", False) is True
+
+
+def test_action_proposal_class_docstring_is_omitted_for_pure_protocol_exemplar() -> None:
+    assert ActionProposal.__doc__ is None
+
+
+def test_action_proposal_runtime_checkable_accepts_minimal_valid_impl() -> None:
+    payload: JsonValue = {"target": "segment-2", "params": [1, True, None]}
+    instance = _ValidImpl("prop-1", "agent-1", "advance", payload)
+    assert isinstance(instance, ActionProposal) is True
+    proposal: ActionProposal = instance
+    assert_type(proposal.proposal_id, str)
+    assert_type(proposal.actor_id, str)
+    assert_type(proposal.action_key, str)
+    assert_type(proposal.payload, JsonValue)
+    assert proposal.proposal_id == "prop-1"
+    assert proposal.actor_id == "agent-1"
+    assert proposal.action_key == "advance"
+    assert proposal.payload == payload
+
+
+def test_action_proposal_runtime_checkable_rejects_missing_proposal_id() -> None:
+    assert isinstance(_MissingProposalId(), ActionProposal) is False
+
+
+def test_action_proposal_runtime_checkable_rejects_missing_actor_id() -> None:
+    assert isinstance(_MissingActorId(), ActionProposal) is False
+
+
+def test_action_proposal_runtime_checkable_rejects_missing_action_key() -> None:
+    assert isinstance(_MissingActionKey(), ActionProposal) is False
+
+
+def test_action_proposal_runtime_checkable_rejects_missing_payload() -> None:
+    assert isinstance(_MissingPayload(), ActionProposal) is False
+
+
+def test_action_proposal_contract_is_identity_intent_and_payload_only() -> None:
+    assert _public_protocol_members(ActionProposal) == {
+        "proposal_id",
+        "actor_id",
+        "action_key",
+        "payload",
+    }

--- a/tests/simulation/test_simulation_public_surface.py
+++ b/tests/simulation/test_simulation_public_surface.py
@@ -7,11 +7,17 @@ import inspect
 import sys
 from types import ModuleType
 
+from abdp.simulation.action_proposal import ActionProposal
 from abdp.simulation.participant_state import ParticipantState
 from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
-_APPROVED_PUBLIC_NAMES = ["ParticipantState", "SegmentState", "SnapshotRef"]
+_APPROVED_PUBLIC_NAMES = [
+    "ActionProposal",
+    "ParticipantState",
+    "SegmentState",
+    "SnapshotRef",
+]
 
 
 def _import_fresh_simulation_package() -> ModuleType:
@@ -31,6 +37,7 @@ def test_simulation_package_dunder_all_matches_approved_public_surface() -> None
 def test_simulation_package_public_surface_matches_dunder_all() -> None:
     pkg = _import_fresh_simulation_package()
     assert _public_names(pkg) == _APPROVED_PUBLIC_NAMES
+    assert pkg.ActionProposal is ActionProposal
     assert pkg.ParticipantState is ParticipantState
     assert pkg.SegmentState is SegmentState
     assert pkg.SnapshotRef is SnapshotRef


### PR DESCRIPTION
Closes #36

## Design (Oracle 100/100)

Pure structural protocol for the neutral action proposal contract used between decision logic and state progression. Domain-neutral; no execution, validation, or schema semantics implied.

- `@runtime_checkable class ActionProposal(Protocol)`
- `@property proposal_id: str` (neutral identity)
- `@property actor_id: str` (neutral actor identity)
- `@property action_key: str` (neutral discriminator; not enum/literal/executable)
- `@property payload: JsonValue` (broadest neutral JSON-compatible value layer)

## TDD

- RED `2fa9cab`: `tests/simulation/test_action_proposal.py` (11 tests) + public surface expansion to `["ActionProposal", "ParticipantState", "SegmentState", "SnapshotRef"]`
- GREEN `8f74a9c`: `src/abdp/simulation/action_proposal.py` + `__init__.py` re-export

## Verification

- ruff format / check: clean
- mypy --strict src tests: clean (58 files)
- pytest --cov: 335 passed, 100% coverage

## Property/mutation

`ActionProposal` is a read-only structural protocol only. `@runtime_checkable` conformance is intentionally shallow (attribute presence only); payload schema, mutation semantics, and action execution remain out of scope.

## Files

- `src/abdp/simulation/action_proposal.py` (new)
- `src/abdp/simulation/__init__.py` (re-export)
- `tests/simulation/test_action_proposal.py` (new)
- `tests/simulation/test_simulation_public_surface.py` (updated)