### PR TITLE
feat(simulation): add SimulationState immutable generic container (#37)

### DIFF
--- a/src/abdp/simulation/__init__.py
+++ b/src/abdp/simulation/__init__.py
@@ -4,10 +4,12 @@ from abdp.simulation.action_proposal import ActionProposal
 from abdp.simulation.participant_state import ParticipantState
 from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
+from abdp.simulation.state import SimulationState
 
 globals().pop("action_proposal", None)
 globals().pop("participant_state", None)
 globals().pop("segment_state", None)
 globals().pop("snapshot_ref", None)
+globals().pop("state", None)
 
-__all__ = ["ActionProposal", "ParticipantState", "SegmentState", "SnapshotRef"]
+__all__ = ["ActionProposal", "ParticipantState", "SegmentState", "SimulationState", "SnapshotRef"]

--- a/src/abdp/simulation/state.py
+++ b/src/abdp/simulation/state.py
@@ -1,0 +1,81 @@
+"""Simulation state contract:
+
+- Priority-3 role: packages the immutable state surface needed by the execution layer without
+  implementing transitions.
+- ``SimulationState`` is an immutable generic container for a single simulation step.
+- Contract consists of ``step_index``, ``seed``, ``snapshot_ref``, ``segments``,
+  ``participants``, and ``pending_actions`` only.
+- ``step_index`` must be an ``int`` greater than or equal to zero; ``bool`` is rejected.
+- ``seed`` is validated with ``validate_seed``.
+- ``snapshot_ref`` must be a ``SnapshotRef`` instance.
+- ``segments``, ``participants``, and ``pending_actions`` must be tuple instances and preserve
+  caller-provided ordering.
+- Element values are not runtime-validated against their protocols; structural typing is enforced
+  statically.
+- No cross-field validation is performed for identifiers, membership consistency, uniqueness, or
+  action applicability.
+- No guarantees about state transitions, execution loops, persistence, serialization, or thread
+  safety.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from abdp.core.types import Seed, validate_seed
+from abdp.simulation.action_proposal import ActionProposal
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+__all__ = ["SimulationState"]
+
+
+def _validate_step_index(value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"step_index must be int, got {type(value).__name__}")
+    if value < 0:
+        raise ValueError(f"step_index must be >= 0, got {value}")
+
+
+def _validate_snapshot_ref(value: object) -> None:
+    if not isinstance(value, SnapshotRef):
+        raise TypeError(f"snapshot_ref must be SnapshotRef, got {type(value).__name__}")
+
+
+def _validate_tuple(field_name: str, value: object) -> None:
+    if not isinstance(value, tuple):
+        raise TypeError(f"{field_name} must be tuple, got {type(value).__name__}")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SimulationState[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """SimulationState contract:
+
+    - Immutable generic dataclass record with slot-backed, keyword-only fields.
+    - Brings together the reproducibility anchor, snapshot reference, segment states, participant
+      states, and pending action proposals for a single simulation step.
+    - Generic over segment, participant, and action types via the neutral ``SegmentState``,
+      ``ParticipantState``, and ``ActionProposal`` protocol bounds.
+    - Collection fields are stored exactly as ordered tuples provided; contents are not copied,
+      normalized, or cross-validated.
+    - Validation is limited to basic runtime type checks and field invariants.
+    - Construction is synchronous only.
+    - No guarantees about state transitions, execution semantics, persistence, serialization, or
+      thread safety.
+    """
+
+    step_index: int
+    seed: Seed
+    snapshot_ref: SnapshotRef
+    segments: tuple[S, ...]
+    participants: tuple[P, ...]
+    pending_actions: tuple[A, ...]
+
+    def __post_init__(self) -> None:
+        _validate_step_index(self.step_index)
+        validate_seed(self.seed)
+        _validate_snapshot_ref(self.snapshot_ref)
+        _validate_tuple("segments", self.segments)
+        _validate_tuple("participants", self.participants)
+        _validate_tuple("pending_actions", self.pending_actions)

--- a/tests/simulation/test_simulation_public_surface.py
+++ b/tests/simulation/test_simulation_public_surface.py
@@ -11,11 +11,13 @@ from abdp.simulation.action_proposal import ActionProposal
 from abdp.simulation.participant_state import ParticipantState
 from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
+from abdp.simulation.state import SimulationState
 
 _APPROVED_PUBLIC_NAMES = [
     "ActionProposal",
     "ParticipantState",
     "SegmentState",
+    "SimulationState",
     "SnapshotRef",
 ]
 
@@ -40,4 +42,5 @@ def test_simulation_package_public_surface_matches_dunder_all() -> None:
     assert pkg.ActionProposal is ActionProposal
     assert pkg.ParticipantState is ParticipantState
     assert pkg.SegmentState is SegmentState
+    assert pkg.SimulationState is SimulationState
     assert pkg.SnapshotRef is SnapshotRef

--- a/tests/simulation/test_simulation_state.py
+++ b/tests/simulation/test_simulation_state.py
@@ -1,0 +1,218 @@
+"""Conformance tests for the simulation state container contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import assert_type, cast
+from uuid import UUID
+
+import pytest
+
+from abdp.core.types import JsonValue, Seed
+from abdp.simulation import state as state_module
+from abdp.simulation.snapshot_ref import SnapshotRef
+from abdp.simulation.state import SimulationState
+
+_SNAPSHOT_ID = UUID("00000000-0000-0000-0000-000000000001")
+_SEED = Seed(7)
+_STORAGE_KEY = "snapshots/abc"
+
+
+def _make_snapshot_ref() -> SnapshotRef:
+    return SnapshotRef(snapshot_id=_SNAPSHOT_ID, tier="bronze", storage_key=_STORAGE_KEY)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Participant:
+    participant_id: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Segment:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+def _make_state(
+    *,
+    step_index: int = 0,
+    seed: Seed = _SEED,
+) -> SimulationState[_Segment, _Participant, _Action]:
+    participant = _Participant(participant_id="p1")
+    segment = _Segment(segment_id="s1", participant_ids=("p1",))
+    action = _Action(proposal_id="prop-1", actor_id="p1", action_key="advance", payload=1)
+    return SimulationState[_Segment, _Participant, _Action](
+        step_index=step_index,
+        seed=seed,
+        snapshot_ref=_make_snapshot_ref(),
+        segments=(segment,),
+        participants=(participant,),
+        pending_actions=(action,),
+    )
+
+
+def test_simulation_state_module_docstring_includes_contract_anchor() -> None:
+    doc = state_module.__doc__ or ""
+    assert "Simulation state contract:" in doc
+    assert "immutable generic container" in doc
+    assert "step_index" in doc
+    assert "seed" in doc
+    assert "snapshot_ref" in doc
+    assert "segments" in doc
+    assert "participants" in doc
+    assert "pending_actions" in doc
+    assert "validate_seed" in doc
+    assert "Element values are not runtime-validated" in doc
+    assert "No cross-field validation" in doc
+
+
+def test_simulation_state_module_exports_public_symbols_only() -> None:
+    assert state_module.__all__ == ["SimulationState"]
+    assert state_module.SimulationState is SimulationState
+
+
+def test_simulation_state_class_docstring_includes_contract_anchor() -> None:
+    doc = SimulationState.__doc__ or ""
+    assert "SimulationState contract:" in doc
+    assert "Immutable generic dataclass" in doc
+    assert "Generic over segment, participant, and action types" in doc
+
+
+def test_simulation_state_constructs_valid_state() -> None:
+    s = _make_state()
+    assert s.step_index == 0
+    assert s.seed == _SEED
+    assert s.snapshot_ref == _make_snapshot_ref()
+    assert len(s.segments) == 1
+    assert len(s.participants) == 1
+    assert len(s.pending_actions) == 1
+
+
+def test_simulation_state_is_frozen() -> None:
+    s = _make_state()
+    with pytest.raises((AttributeError, TypeError)):
+        cast(object, s).__setattr__("step_index", 1)
+
+
+def test_simulation_state_uses_slots() -> None:
+    assert hasattr(SimulationState, "__slots__")
+    assert "__dict__" not in dir(_make_state())
+
+
+def test_simulation_state_is_generic_over_domain_types() -> None:
+    s: SimulationState[_Segment, _Participant, _Action] = _make_state()
+    assert_type(s.segments, tuple[_Segment, ...])
+    assert_type(s.participants, tuple[_Participant, ...])
+    assert_type(s.pending_actions, tuple[_Action, ...])
+
+
+def test_simulation_state_equal_instances_compare_equal() -> None:
+    assert _make_state() == _make_state()
+
+
+def test_simulation_state_unequal_when_step_index_differs() -> None:
+    assert _make_state(step_index=0) != _make_state(step_index=1)
+
+
+def test_simulation_state_repr_includes_all_fields_in_definition_order() -> None:
+    r = repr(_make_state())
+    assert r.startswith("SimulationState(")
+    fields_in_order = ["step_index=", "seed=", "snapshot_ref=", "segments=", "participants=", "pending_actions="]
+    positions = [r.index(f) for f in fields_in_order]
+    assert positions == sorted(positions)
+
+
+def test_simulation_state_rejects_non_int_step_index() -> None:
+    with pytest.raises(TypeError, match=r"^step_index must be int, got str$"):
+        _make_state(step_index=cast(int, "0"))
+
+
+def test_simulation_state_rejects_bool_step_index() -> None:
+    with pytest.raises(TypeError, match=r"^step_index must be int, got bool$"):
+        _make_state(step_index=cast(int, True))
+
+
+def test_simulation_state_rejects_float_step_index() -> None:
+    with pytest.raises(TypeError, match=r"^step_index must be int, got float$"):
+        _make_state(step_index=cast(int, 0.0))
+
+
+def test_simulation_state_rejects_negative_step_index() -> None:
+    with pytest.raises(ValueError, match=r"^step_index must be >= 0, got -1$"):
+        _make_state(step_index=-1)
+
+
+def test_simulation_state_delegates_seed_validation_for_non_int_seed() -> None:
+    with pytest.raises(TypeError, match=r"^Seed must be a non-bool int, got str$"):
+        _make_state(seed=cast(Seed, "x"))
+
+
+def test_simulation_state_delegates_seed_validation_for_bool_seed() -> None:
+    with pytest.raises(TypeError, match=r"^Seed must be a non-bool int, got bool$"):
+        _make_state(seed=cast(Seed, True))
+
+
+def test_simulation_state_delegates_seed_validation_for_negative_seed() -> None:
+    with pytest.raises(ValueError, match=r"^Seed must be >= 0"):
+        _make_state(seed=cast(Seed, -1))
+
+
+def test_simulation_state_delegates_seed_validation_for_seed_above_uint32_max() -> None:
+    with pytest.raises(ValueError, match=r"^Seed must be <="):
+        _make_state(seed=cast(Seed, 2**32))
+
+
+def test_simulation_state_rejects_non_snapshot_ref_snapshot_ref() -> None:
+    with pytest.raises(TypeError, match=r"^snapshot_ref must be SnapshotRef, got str$"):
+        SimulationState[_Segment, _Participant, _Action](
+            step_index=0,
+            seed=_SEED,
+            snapshot_ref=cast(SnapshotRef, "not-a-ref"),
+            segments=(),
+            participants=(),
+            pending_actions=(),
+        )
+
+
+def test_simulation_state_rejects_non_tuple_segments() -> None:
+    with pytest.raises(TypeError, match=r"^segments must be tuple, got list$"):
+        SimulationState[_Segment, _Participant, _Action](
+            step_index=0,
+            seed=_SEED,
+            snapshot_ref=_make_snapshot_ref(),
+            segments=cast(tuple[_Segment, ...], []),
+            participants=(),
+            pending_actions=(),
+        )
+
+
+def test_simulation_state_rejects_non_tuple_participants() -> None:
+    with pytest.raises(TypeError, match=r"^participants must be tuple, got list$"):
+        SimulationState[_Segment, _Participant, _Action](
+            step_index=0,
+            seed=_SEED,
+            snapshot_ref=_make_snapshot_ref(),
+            segments=(),
+            participants=cast(tuple[_Participant, ...], []),
+            pending_actions=(),
+        )
+
+
+def test_simulation_state_rejects_non_tuple_pending_actions() -> None:
+    with pytest.raises(TypeError, match=r"^pending_actions must be tuple, got list$"):
+        SimulationState[_Segment, _Participant, _Action](
+            step_index=0,
+            seed=_SEED,
+            snapshot_ref=_make_snapshot_ref(),
+            segments=(),
+            participants=(),
+            pending_actions=cast(tuple[_Action, ...], []),
+        )


### PR DESCRIPTION
Closes #37

## Design (Oracle 100/100)

Concrete frozen+slots+kw_only dataclass `SimulationState[S: SegmentState, P: ParticipantState, A: ActionProposal]` packaging the immutable state surface for a single simulation step, generic over the three neutral protocol bounds. Validation is minimal and container-level only.

- `step_index: int` — must be int (rejects `bool`), `>= 0`
- `seed: Seed` — delegated to `validate_seed`
- `snapshot_ref: SnapshotRef` — `isinstance` check
- `segments: tuple[S, ...]`, `participants: tuple[P, ...]`, `pending_actions: tuple[A, ...]` — tuple instance only; element values are not runtime-validated (structural typing enforced statically)
- No cross-field validation (uniqueness, membership consistency, action applicability all out of scope)

## TDD

- RED `7d21a3a`: `tests/simulation/test_simulation_state.py` (22 tests) + public surface expansion to include `SimulationState`
- GREEN `02874ec`: `src/abdp/simulation/state.py` + `__init__.py` re-export

## Verification

- ruff format / check: clean
- mypy --strict src tests: clean (60 source files)
- pytest --cov: 357 passed, 100% coverage

## Property/mutation

Mutation testing IS applicable to the validation helpers in `state.py` (`_validate_step_index`, `_validate_snapshot_ref`, `_validate_tuple`, `__post_init__` call path). Local macOS mutmut SIGSEGVs in `os.fork()` and is non-authoritative; **Ubuntu CI is the authoritative mutation signal**.

## Files

- `src/abdp/simulation/state.py` (new)
- `src/abdp/simulation/__init__.py` (re-export)
- `tests/simulation/test_simulation_state.py` (new, uses `cast()` per no-`type: ignore` rule)
- `tests/simulation/test_simulation_public_surface.py` (updated)