### PR TITLE
feat(simulation): add ScenarioSpec protocol (#38)

### DIFF
--- a/src/abdp/simulation/__init__.py
+++ b/src/abdp/simulation/__init__.py
@@ -2,14 +2,23 @@
 
 from abdp.simulation.action_proposal import ActionProposal
 from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.scenario_spec import ScenarioSpec
 from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
 from abdp.simulation.state import SimulationState
 
 globals().pop("action_proposal", None)
 globals().pop("participant_state", None)
+globals().pop("scenario_spec", None)
 globals().pop("segment_state", None)
 globals().pop("snapshot_ref", None)
 globals().pop("state", None)
 
-__all__ = ["ActionProposal", "ParticipantState", "SegmentState", "SimulationState", "SnapshotRef"]
+__all__ = [
+    "ActionProposal",
+    "ParticipantState",
+    "ScenarioSpec",
+    "SegmentState",
+    "SimulationState",
+    "SnapshotRef",
+]

--- a/src/abdp/simulation/scenario_spec.py
+++ b/src/abdp/simulation/scenario_spec.py
@@ -1,0 +1,46 @@
+"""Scenario spec protocol contract:
+
+- Defines the minimal seed-aware scenario contract that produces an initial
+  ``SimulationState`` for a deterministic simulation run.
+- Domain-neutral and simulation-agnostic.
+- Contract consists of readable ``scenario_key: str``, ``seed: Seed``, and
+  ``build_initial_state()`` access only.
+- ``scenario_key`` is a neutral scenario discriminator only; it does not imply
+  registry semantics, validation rules, or domain-specific scenario taxonomies.
+- ``seed`` carries the deterministic randomness source for the scenario; it
+  does not imply any RNG implementation, sampling policy, or reseeding
+  semantics.
+- ``build_initial_state()`` returns a fully constructed ``SimulationState``
+  instance for the scenario; it does not imply caching, idempotence beyond
+  the seed contract, persistence, or side-effect semantics.
+- Intended for structural typing in simulation; implementations live outside
+  simulation.
+- Runtime protocol checks are shallow: they verify attribute and method
+  presence only and do not validate attribute types or method signatures.
+- The protocol does not require a stored field, a property setter, or mutation semantics.
+- No guarantees about scenario-key uniqueness, determinism beyond seed carriage,
+  validation, persistence, serialization, or thread safety.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from abdp.core.types import Seed
+from abdp.simulation.action_proposal import ActionProposal
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
+from abdp.simulation.state import SimulationState
+
+__all__ = ["ScenarioSpec"]
+
+
+@runtime_checkable
+class ScenarioSpec[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
+    @property
+    def scenario_key(self) -> str: ...
+
+    @property
+    def seed(self) -> Seed: ...
+
+    def build_initial_state(self) -> SimulationState[S, P, A]: ...

--- a/tests/simulation/test_scenario_spec.py
+++ b/tests/simulation/test_scenario_spec.py
@@ -1,0 +1,159 @@
+"""Conformance tests for the scenario spec protocol contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import assert_type
+from uuid import UUID
+
+from abdp.core.types import JsonValue, Seed
+from abdp.simulation import scenario_spec
+from abdp.simulation.scenario_spec import ScenarioSpec
+from abdp.simulation.snapshot_ref import SnapshotRef
+from abdp.simulation.state import SimulationState
+
+_SNAPSHOT_ID = UUID("00000000-0000-0000-0000-000000000001")
+_SEED = Seed(7)
+_STORAGE_KEY = "snapshots/abc"
+
+
+def _make_snapshot_ref() -> SnapshotRef:
+    return SnapshotRef(snapshot_id=_SNAPSHOT_ID, tier="bronze", storage_key=_STORAGE_KEY)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Participant:
+    participant_id: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Segment:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+def _make_initial_state(
+    *,
+    seed: Seed = _SEED,
+) -> SimulationState[_Segment, _Participant, _Action]:
+    participant = _Participant(participant_id="p1")
+    segment = _Segment(segment_id="s1", participant_ids=("p1",))
+    action = _Action(proposal_id="prop-1", actor_id="p1", action_key="advance", payload=1)
+    return SimulationState[_Segment, _Participant, _Action](
+        step_index=0,
+        seed=seed,
+        snapshot_ref=_make_snapshot_ref(),
+        segments=(segment,),
+        participants=(participant,),
+        pending_actions=(action,),
+    )
+
+
+class _ValidImpl:
+    def __init__(self, scenario_key: str, seed: Seed) -> None:
+        self.scenario_key = scenario_key
+        self.seed = seed
+
+    def build_initial_state(self) -> SimulationState[_Segment, _Participant, _Action]:
+        return _make_initial_state(seed=self.seed)
+
+
+class _MissingScenarioKey:
+    def __init__(self) -> None:
+        self.seed = _SEED
+
+    def build_initial_state(self) -> SimulationState[_Segment, _Participant, _Action]:
+        return _make_initial_state(seed=self.seed)
+
+
+class _MissingSeed:
+    def __init__(self) -> None:
+        self.scenario_key = "baseline"
+
+    def build_initial_state(self) -> SimulationState[_Segment, _Participant, _Action]:
+        return _make_initial_state()
+
+
+class _MissingBuildInitialState:
+    def __init__(self) -> None:
+        self.scenario_key = "baseline"
+        self.seed = _SEED
+
+
+def _public_protocol_members(proto: type) -> set[str]:
+    return {
+        name
+        for name, value in proto.__dict__.items()
+        if not name.startswith("_") and (callable(value) or isinstance(value, property))
+    }
+
+
+def test_scenario_spec_module_docstring_includes_contract_anchor() -> None:
+    doc = scenario_spec.__doc__ or ""
+    assert "Scenario spec protocol contract:" in doc
+    assert "minimal seed-aware scenario contract" in doc
+    assert "scenario_key: str" in doc
+    assert "seed: Seed" in doc
+    assert "build_initial_state()" in doc
+    assert "neutral scenario discriminator" in doc
+    assert "Runtime protocol checks are shallow" in doc
+    assert "do not validate attribute types or method signatures" in doc
+    assert "The protocol does not require a stored field, a property setter, or mutation semantics" in doc
+    assert ("No guarantees about scenario-key uniqueness, determinism beyond seed carriage,") in doc
+    assert "validation, persistence, serialization, or thread safety." in doc
+
+
+def test_scenario_spec_module_exports_public_symbols_only() -> None:
+    assert scenario_spec.__all__ == ["ScenarioSpec"]
+    assert scenario_spec.ScenarioSpec is ScenarioSpec
+
+
+def test_scenario_spec_is_protocol() -> None:
+    assert getattr(ScenarioSpec, "_is_protocol", False) is True
+
+
+def test_scenario_spec_class_docstring_is_omitted_for_pure_protocol_exemplar() -> None:
+    assert ScenarioSpec.__doc__ is None
+
+
+def test_scenario_spec_runtime_checkable_accepts_minimal_valid_impl() -> None:
+    instance = _ValidImpl("baseline", _SEED)
+    assert isinstance(instance, ScenarioSpec) is True
+    spec: ScenarioSpec[_Segment, _Participant, _Action] = instance
+    assert_type(spec.scenario_key, str)
+    assert_type(spec.seed, Seed)
+    state = spec.build_initial_state()
+    assert_type(state, SimulationState[_Segment, _Participant, _Action])
+    assert spec.scenario_key == "baseline"
+    assert spec.seed == _SEED
+    assert isinstance(state, SimulationState) is True
+    assert state.step_index == 0
+    assert state.seed == _SEED
+
+
+def test_scenario_spec_runtime_checkable_rejects_missing_scenario_key() -> None:
+    assert isinstance(_MissingScenarioKey(), ScenarioSpec) is False
+
+
+def test_scenario_spec_runtime_checkable_rejects_missing_seed() -> None:
+    assert isinstance(_MissingSeed(), ScenarioSpec) is False
+
+
+def test_scenario_spec_runtime_checkable_rejects_missing_build_initial_state() -> None:
+    assert isinstance(_MissingBuildInitialState(), ScenarioSpec) is False
+
+
+def test_scenario_spec_contract_is_identity_seed_and_builder_only() -> None:
+    assert _public_protocol_members(ScenarioSpec) == {
+        "scenario_key",
+        "seed",
+        "build_initial_state",
+    }

--- a/tests/simulation/test_simulation_public_surface.py
+++ b/tests/simulation/test_simulation_public_surface.py
@@ -9,6 +9,7 @@ from types import ModuleType
 
 from abdp.simulation.action_proposal import ActionProposal
 from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.scenario_spec import ScenarioSpec
 from abdp.simulation.segment_state import SegmentState
 from abdp.simulation.snapshot_ref import SnapshotRef
 from abdp.simulation.state import SimulationState
@@ -16,6 +17,7 @@ from abdp.simulation.state import SimulationState
 _APPROVED_PUBLIC_NAMES = [
     "ActionProposal",
     "ParticipantState",
+    "ScenarioSpec",
     "SegmentState",
     "SimulationState",
     "SnapshotRef",
@@ -41,6 +43,7 @@ def test_simulation_package_public_surface_matches_dunder_all() -> None:
     assert _public_names(pkg) == _APPROVED_PUBLIC_NAMES
     assert pkg.ActionProposal is ActionProposal
     assert pkg.ParticipantState is ParticipantState
+    assert pkg.ScenarioSpec is ScenarioSpec
     assert pkg.SegmentState is SegmentState
     assert pkg.SimulationState is SimulationState
     assert pkg.SnapshotRef is SnapshotRef


### PR DESCRIPTION
Closes #38

## Summary
Adds `ScenarioSpec` runtime-checkable Protocol — a seed-aware scenario contract that produces an initial `SimulationState`. Pure protocol; structural typing only.

## TDD Evidence
- **RED** `edecf93`: `test(simulation): add failing scenario spec contract tests (#38)` — 9 conformance tests + public-surface freeze update; verified collection ImportError pre-implementation.
- **GREEN** `6db26db`: `feat(simulation): add ScenarioSpec protocol (#38)` — anchored module docstring, `@runtime_checkable Protocol` with PEP 695 bounded generics `[S: SegmentState, P: ParticipantState, A: ActionProposal]`, `__init__.py` re-export updated to 6-element alphabetical surface.

## Verification (local, .venv312, py3.12.13)
- `ruff format .` → 62 files left unchanged
- `ruff check .` → All checks passed
- `mypy --strict src tests` → no issues found in 62 source files
- `pytest --cov` → **366 passed**, **100% coverage**
- Mutation testing: **N/A** (pure Protocol — no executable logic to mutate)

## Contract
- `scenario_key: str` — neutral scenario discriminator
- `seed: Seed` — deterministic randomness source
- `build_initial_state() -> SimulationState[S, P, A]` — initial state factory

No guarantees about scenario-key uniqueness, determinism beyond seed carriage, validation, persistence, serialization, or thread safety.