### PR TITLE
docs: add first domain example walking credit underwriting onto v0.1 contracts (#45)

### DIFF
--- a/docs/examples/first-domain-example.md
+++ b/docs/examples/first-domain-example.md
@@ -1,0 +1,86 @@
+# First domain example
+
+This example complements [docs/architecture.md](../architecture.md),
+[docs/models/scenario-model.md](../models/scenario-model.md), and
+[docs/plugin-system.md](../plugin-system.md) by walking one concrete domain through the v0.1
+contracts. It does not add code to `src/abdp/`.
+
+## Overview
+
+This is the first canonical domain example for ABDP v0.1.
+It shows how one credit underwriting workflow maps onto the existing contracts without extending
+the framework.
+The goal is contract mapping, not plugin implementation.
+
+## Domain framing
+
+The domain is a neutral credit underwriting workflow for one loan application.
+The applicant is the focal business entity in the example, but the framework still sees only
+neutral simulation contracts.
+An underwriting job is one run through ordered review segments.
+The example stays in credit underwriting and keeps domain meaning outside the framework.
+
+## Mapping participants and segments
+
+An applicant maps to `ParticipantState` via `participant_id`. In this example, the plugin gives
+the applicant domain meaning such as credit profile, document status, or employment details, but
+the framework contract only requires a stable participant identity.
+
+A review stage such as intake, verification, or approval maps to `SegmentState` via `segment_id`.
+`SegmentState.participant_ids` lists the participants active in that stage of the underwriting
+job. The `participant_ids` tuple can include the applicant and a review service or reviewer, but
+the contract stays neutral about what those roles mean.
+
+The framework does not know why a segment exists; it only preserves stable identities and
+membership. That keeps the example concrete for credit underwriting while still proving that the
+core contracts do not need domain-specific fields.
+
+## Mapping action proposals
+
+A recommended next step maps to `ActionProposal`. In credit underwriting, that recommendation
+might be "request a missing pay stub", "flag a verification mismatch", or "advance to approval",
+but the framework only sees four neutral fields.
+
+`proposal_id` identifies the recommendation, `actor_id` identifies who proposed it, and
+`action_key` names the neutral action. `payload` carries domain details such as requested
+documents, risk notes, or a proposed disposition.
+
+The proposal stays a candidate action until the simulation decides what to record next. The
+contract does not encode how proposals are ranked, accepted, or rejected; that policy belongs
+to the plugin.
+
+## Mapping snapshots and scenario
+
+A case extract for the underwriting job is stored as a `SnapshotManifest` in the data layer. The
+manifest captures the snapshot identity, tier, storage key, and other reproducibility fields
+that the data layer already owns.
+
+`SnapshotRef.from_manifest(SnapshotManifest)` gives simulation a lightweight pointer to that
+case snapshot. Simulation does not load the snapshot contents; it only carries the
+`SnapshotRef`.
+
+A single underwriting job is represented by one `SimulationState` value with `step_index`,
+`snapshot_ref`, `segments`, `participants`, and `pending_actions`. A domain `ScenarioSpec` sets
+`scenario_key`, carries `seed`, and `build_initial_state()` returns the initial
+`SimulationState`. The plugin owns the construction logic; the framework only enforces the
+contract shape.
+
+## Plugin packaging boundary
+
+In real use, this example belongs in a separate plugin package.
+Its domain classes live outside `src/abdp/` and outside `src/abdp/simulation/`.
+The framework keeps domain concepts out of `src/abdp/`.
+If credit underwriting needs extra fields, the plugin adds them without changing the core
+contracts.
+
+The boundary is not a style preference. It is the only way the v0.1 abstractions can be reused
+by a different domain without forcing framework edits for each new use case.
+
+## Comparison to the second-domain proof
+
+This is the first domain proof for the v0.1 contracts.
+Issue #046 adds a queue scheduling example as the second domain proof.
+If credit underwriting and queue scheduling both fit the same contracts, the framework boundary
+is earning its place.
+One domain example explains the mapping; the second checks that the contracts stay
+domain-neutral.

--- a/tests/meta/test_doc_first_domain_example.py
+++ b/tests/meta/test_doc_first_domain_example.py
@@ -1,0 +1,212 @@
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = REPO_ROOT / "docs" / "examples" / "first-domain-example.md"
+
+TITLE = "# First domain example"
+MAX_LINE_COUNT = 105
+
+DOC_REFERENCE_COUNTS = {
+    "[docs/architecture.md](../architecture.md)": 1,
+    "[docs/models/scenario-model.md](../models/scenario-model.md)": 1,
+    "[docs/plugin-system.md](../plugin-system.md)": 1,
+}
+
+REQUIRED_HEADINGS = [
+    "## Overview",
+    "## Domain framing",
+    "## Mapping participants and segments",
+    "## Mapping action proposals",
+    "## Mapping snapshots and scenario",
+    "## Plugin packaging boundary",
+    "## Comparison to the second-domain proof",
+]
+
+SECTION_ANCHORS = {
+    "## Overview": [
+        "This is the first canonical domain example for ABDP v0.1.",
+        (
+            "It shows how one credit underwriting workflow maps onto the existing "
+            "contracts without extending the framework."
+        ),
+        "The goal is contract mapping, not plugin implementation.",
+    ],
+    "## Domain framing": [
+        "The domain is a neutral credit underwriting workflow for one loan application.",
+        (
+            "The applicant is the focal business entity in the example, but the framework "
+            "still sees only neutral simulation contracts."
+        ),
+        "An underwriting job is one run through ordered review segments.",
+        "The example stays in credit underwriting and keeps domain meaning outside the framework.",
+    ],
+    "## Mapping participants and segments": [
+        "An applicant maps to `ParticipantState` via `participant_id`.",
+        ("A review stage such as intake, verification, or approval maps to `SegmentState` via `segment_id`."),
+        ("`SegmentState.participant_ids` lists the participants active in that stage of the underwriting job."),
+        ("The framework does not know why a segment exists; it only preserves stable identities and membership."),
+    ],
+    "## Mapping action proposals": [
+        "A recommended next step maps to `ActionProposal`.",
+        (
+            "`proposal_id` identifies the recommendation, `actor_id` identifies who proposed "
+            "it, and `action_key` names the neutral action."
+        ),
+        ("`payload` carries domain details such as requested documents, risk notes, or a proposed disposition."),
+        "The proposal stays a candidate action until the simulation decides what to record next.",
+    ],
+    "## Mapping snapshots and scenario": [
+        "A case extract for the underwriting job is stored as a `SnapshotManifest` in the data layer.",
+        ("`SnapshotRef.from_manifest(SnapshotManifest)` gives simulation a lightweight pointer to that case snapshot."),
+        (
+            "A single underwriting job is represented by one `SimulationState` value with "
+            "`step_index`, `snapshot_ref`, `segments`, `participants`, and `pending_actions`."
+        ),
+        (
+            "A domain `ScenarioSpec` sets `scenario_key`, carries `seed`, and "
+            "`build_initial_state()` returns the initial `SimulationState`."
+        ),
+    ],
+    "## Plugin packaging boundary": [
+        "In real use, this example belongs in a separate plugin package.",
+        "Its domain classes live outside `src/abdp/` and outside `src/abdp/simulation/`.",
+        "The framework keeps domain concepts out of `src/abdp/`.",
+        ("If credit underwriting needs extra fields, the plugin adds them without changing the core contracts."),
+    ],
+    "## Comparison to the second-domain proof": [
+        "This is the first domain proof for the v0.1 contracts.",
+        "Issue #046 adds a queue scheduling example as the second domain proof.",
+        (
+            "If credit underwriting and queue scheduling both fit the same contracts, the "
+            "framework boundary is earning its place."
+        ),
+        "One domain example explains the mapping; the second checks that the contracts stay domain-neutral.",
+    ],
+}
+
+REQUIRED_PHRASES = [
+    "`ParticipantState`",
+    "`SegmentState`",
+    "`ActionProposal`",
+    "`SnapshotRef`",
+    "`SimulationState`",
+    "`ScenarioSpec`",
+    "`SnapshotManifest`",
+    "`participant_id`",
+    "`segment_id`",
+    "`participant_ids`",
+    "`proposal_id`",
+    "`actor_id`",
+    "`action_key`",
+    "`payload`",
+    "`step_index`",
+    "`scenario_key`",
+    "`seed`",
+    "`build_initial_state()`",
+    "`SnapshotRef.from_manifest(SnapshotManifest)`",
+    "credit underwriting",
+    "In real use, this example belongs in a separate plugin package.",
+    "The framework keeps domain concepts out of `src/abdp/`.",
+    "Issue #046",
+    "queue scheduling",
+]
+
+FORBIDDEN_SNIPPETS = [
+    "SQLAlchemy",
+    "Alembic",
+    "Django",
+    "Flask",
+    "FastAPI",
+    "OpenAI",
+    "Anthropic",
+    "MLflow",
+    "Weights & Biases",
+    "W&B",
+    "real estate",
+    "real-estate",
+    "mortgage",
+    "vacancy rate",
+    "korean",
+    "Korean",
+    "south korea",
+    "housing",
+    "tenant",
+    "landlord",
+    "apartment",
+    "condo",
+    "lease",
+    "rental yield",
+    "cap rate",
+    "insurance",
+]
+
+
+def _read_text() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _section_texts(text: str) -> dict[str, str]:
+    ordered_positions = [(heading, text.index(heading)) for heading in REQUIRED_HEADINGS]
+    ordered_positions.sort(key=lambda item: item[1])
+
+    sections: dict[str, str] = {}
+    for index, (heading, start) in enumerate(ordered_positions):
+        end = ordered_positions[index + 1][1] if index + 1 < len(ordered_positions) else len(text)
+        sections[heading] = _normalize(text[start:end])
+
+    return sections
+
+
+def test_first_domain_example_file_exists() -> None:
+    assert DOC_PATH.is_file()
+
+
+def test_first_domain_example_has_title_and_single_doc_references() -> None:
+    text = _read_text()
+
+    assert text.startswith(f"{TITLE}\n")
+    assert text.count(TITLE) == 1
+
+    for reference, expected_count in DOC_REFERENCE_COUNTS.items():
+        assert text.count(reference) == expected_count
+
+
+def test_first_domain_example_has_required_section_headings_in_order() -> None:
+    text = _read_text()
+    cursor = 0
+
+    for heading in REQUIRED_HEADINGS:
+        position = text.find(heading, cursor)
+        assert position != -1, f"Missing heading: {heading}"
+        cursor = position + len(heading)
+
+
+def test_first_domain_example_sections_include_expected_anchors() -> None:
+    text = _read_text()
+    sections = _section_texts(text)
+
+    for heading, anchors in SECTION_ANCHORS.items():
+        section_text = sections[heading]
+        for anchor in anchors:
+            assert _normalize(anchor) in section_text, f"Missing anchor in {heading}: {anchor}"
+
+
+def test_first_domain_example_includes_required_phrases_and_omits_forbidden_snippets() -> None:
+    text = _read_text()
+    normalized_text = _normalize(text)
+
+    for phrase in REQUIRED_PHRASES:
+        assert _normalize(phrase) in normalized_text, f"Missing required phrase: {phrase}"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, f"Forbidden snippet present: {snippet}"
+
+
+def test_first_domain_example_stays_within_line_budget() -> None:
+    line_count = len(_read_text().splitlines())
+    assert line_count <= MAX_LINE_COUNT


### PR DESCRIPTION
Closes #45

## Summary
Adds `docs/examples/first-domain-example.md`, the first canonical domain example for ABDP v0.1. The doc walks one credit underwriting workflow onto the existing simulation contracts (`ParticipantState`, `SegmentState`, `ActionProposal`, `SnapshotRef`, `SimulationState`, `ScenarioSpec`, `SnapshotManifest`) without adding any code under `src/abdp/`. It explicitly states the plugin packaging boundary and ties the proof to the second-domain spike in #46.

## TDD evidence
- **RED** `889bbb2` — test(docs): add failing meta test for first domain example (#45)
  - Adds `tests/meta/test_doc_first_domain_example.py` with the standard six meta tests using `_normalize` + `_section_texts` helpers. Initially fails with `FileNotFoundError`/`AssertionError` because the doc does not exist.
- **GREEN** `5e5cc05` — docs: add first domain example walking credit underwriting onto v0.1 contracts (#45)
  - Adds `docs/examples/first-domain-example.md` (86 lines) with seven ordered sections: Overview, Domain framing, Mapping participants and segments, Mapping action proposals, Mapping snapshots and scenario, Plugin packaging boundary, Comparison to the second-domain proof.

## Verification
\`\`\`
ruff format --check .   → 67 files already formatted
ruff check .            → All checks passed
mypy --strict src tests → Success: no issues found in 67 source files
pytest --cov=abdp --cov-branch --cov-fail-under=100
                        → 398 passed, 100% coverage
python -m build         → Successfully built abdp-0.1.0.dev0
\`\`\`

## Notes
- Doc framing is neutral credit underwriting; no real-estate, mortgage, housing, or insurance vocabulary (enforced by `FORBIDDEN_SNIPPETS`).
- All seven required contracts and their key fields appear in the doc and are asserted by the meta test.
- Plugin packaging boundary is stated explicitly: domain classes live outside `src/abdp/`.
- Mutmut policy: macOS local mutmut SIGSEGVs in `os.fork()`; Ubuntu CI is authoritative.