### PR TITLE
docs: pin v0.2 modeling-toolkit boundary (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # agent-based-decision-pipeline
 
 A Python framework for reproducible agent-based decision simulation
+
+## Roadmap
+
+See [Roadmap](docs/roadmap.md) for milestone scope, including the v0.2 modeling toolkit boundary and v0.3 themes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,6 +24,33 @@ This roadmap keeps `v0.1` focused on layers 1-3 contracts and points contributor
 - `v0.2` should test new shared abstractions against at least two domains before promoting them into the framework.
 - `v0.2` should keep seeded reproducibility, stable contracts, and simple storage assumptions intact.
 
+## v0.2 modeling toolkit boundary
+
+`v0.2` ships the modeling toolkit packages `abdp.agents` and `abdp.scenario` and proves them with two executable example domains under `examples/`. The boundary is locked by the following 14 issues:
+
+- `#092` — `docs: pin v0.2 modeling-toolkit boundary`: lock this section so the v0.2 surface is unambiguous before implementation.
+- `#093` — `feat(agents): add AgentDecision protocol`: introduce the per-step output contract for agents.
+- `#094` — `feat(agents): add AgentContext dataclass`: package the per-step input passed into `Agent.decide`.
+- `#095` — `feat(agents): add Agent protocol and package exports`: finalize the `abdp.agents` public surface.
+- `#096` — `feat(scenario): add ActionResolver protocol`: declare how proposals turn into the next state.
+- `#097` — `feat(scenario): add ScenarioStep dataclass`: capture one runner iteration.
+- `#098` — `feat(scenario): add ScenarioRun dataclass`: capture the full execution trace.
+- `#099` — `feat(scenario): add ScenarioRunner execution loop`: implement the deterministic runner.
+- `#100` — `test(scenario): lock runner determinism and step invariants`: pin the runner contract with invariant tests.
+- `#101` — `feat(examples): add executable credit underwriting sample`: prove the toolkit on the credit underwriting domain.
+- `#102` — `chore(examples): promote queue scheduling fixture into example module`: relocate the second-domain fixture.
+- `#103` — `feat(examples): add executable queue scheduling sample`: prove the toolkit on the queue scheduling domain.
+- `#104` — `docs: add 10-minute modeling quickstart`: walk a new contributor from zero to a runnable scenario.
+- `#105` — `test(agents): freeze agents and scenario public surfaces`: lock both new package namespaces.
+
+## Explicit non-goals for v0.2
+
+- No evaluation symbols, gates, or summaries belong in `v0.2`; that work is reserved for `v0.3`.
+- No evidence records, claims, audit logs, or stores belong in `v0.2`; that work is reserved for `v0.3`.
+- No CLI entry point, run command, or report command belongs in `v0.2`; that work is reserved for `v0.3`.
+- No persistence backends or storage adapters belong in `v0.2`; the in-memory toolkit must remain sufficient.
+- No domain-specific code belongs under `src/abdp/**`; domain logic lives only in `examples/` and tests.
+
 ## v0.3 milestone themes
 
 - `v0.3` may broaden implementations around agents, evaluation, evidence, and reporting once `v0.2` proves the boundaries.

--- a/tests/meta/test_doc_roadmap.py
+++ b/tests/meta/test_doc_roadmap.py
@@ -7,12 +7,14 @@ ARCHITECTURE_REFERENCE = "[docs/architecture.md](architecture.md)"
 AGENT_MODEL_REFERENCE = "[docs/models/agent-model.md](models/agent-model.md)"
 EVALUATION_REFERENCE = "[docs/evaluation.md](evaluation.md)"
 EVIDENCE_REPORTING_REFERENCE = "[docs/evidence-reporting.md](evidence-reporting.md)"
-MAX_LINE_COUNT = 65
+MAX_LINE_COUNT = 90
 
 REQUIRED_HEADINGS: list[str] = [
     "## Scope and non-goals overview",
     "## v0.1 milestone",
     "## v0.2 milestone themes",
+    "## v0.2 modeling toolkit boundary",
+    "## Explicit non-goals for v0.2",
     "## v0.3 milestone themes",
     "## Explicit non-goals for v0.1",
     "## Revisit triggers for more complex infrastructure",
@@ -52,6 +54,30 @@ SECTION_ANCHORS: dict[str, list[str]] = {
         ("`v0.3` may refine cross-layer composition instead of introducing parallel stacks or competing abstractions."),
         "`v0.3` may improve comparison, audit, and reporting workflows that build on earlier contract work.",
         "`v0.3` is still a roadmap milestone, not a calendar promise.",
+    ],
+    "## v0.2 modeling toolkit boundary": [
+        "`v0.2` ships the modeling toolkit packages `abdp.agents` and `abdp.scenario`",
+        "`#092`",
+        "`#093`",
+        "`#094`",
+        "`#095`",
+        "`#096`",
+        "`#097`",
+        "`#098`",
+        "`#099`",
+        "`#100`",
+        "`#101`",
+        "`#102`",
+        "`#103`",
+        "`#104`",
+        "`#105`",
+    ],
+    "## Explicit non-goals for v0.2": [
+        "No evaluation symbols, gates, or summaries belong in `v0.2`; that work is reserved for `v0.3`.",
+        "No evidence records, claims, audit logs, or stores belong in `v0.2`; that work is reserved for `v0.3`.",
+        "No CLI entry point, run command, or report command belongs in `v0.2`; that work is reserved for `v0.3`.",
+        "No persistence backends or storage adapters belong in `v0.2`; the in-memory toolkit must remain sufficient.",
+        "No domain-specific code belongs under `src/abdp/**`; domain logic lives only in `examples/` and tests.",
     ],
     "## Explicit non-goals for v0.1": [
         "No implementation work beyond layers 1-3 belongs in `v0.1`; that includes layers 4, 6, 7, and 8.",
@@ -116,6 +142,10 @@ REQUIRED_PHRASES: list[str] = [
     "complex infrastructure",
     "file-and-test workflow",
     "contract baseline",
+    "modeling toolkit",
+    "`abdp.agents`",
+    "`abdp.scenario`",
+    "`examples/`",
 ]
 
 FORBIDDEN_SNIPPETS: list[str] = [
@@ -180,16 +210,16 @@ def test_roadmap_has_title_and_single_doc_references() -> None:
     text = _read_roadmap_text()
 
     assert text.startswith(f"{TITLE}\n"), f"Expected roadmap doc to start with {TITLE!r}"
-    assert text.count(ARCHITECTURE_REFERENCE) == 1, (
-        f"Expected exactly one architecture reference: {ARCHITECTURE_REFERENCE}"
-    )
-    assert text.count(AGENT_MODEL_REFERENCE) == 1, (
-        f"Expected exactly one agent model reference: {AGENT_MODEL_REFERENCE}"
-    )
+    assert (
+        text.count(ARCHITECTURE_REFERENCE) == 1
+    ), f"Expected exactly one architecture reference: {ARCHITECTURE_REFERENCE}"
+    assert (
+        text.count(AGENT_MODEL_REFERENCE) == 1
+    ), f"Expected exactly one agent model reference: {AGENT_MODEL_REFERENCE}"
     assert text.count(EVALUATION_REFERENCE) == 1, f"Expected exactly one evaluation reference: {EVALUATION_REFERENCE}"
-    assert text.count(EVIDENCE_REPORTING_REFERENCE) == 1, (
-        f"Expected exactly one evidence/reporting reference: {EVIDENCE_REPORTING_REFERENCE}"
-    )
+    assert (
+        text.count(EVIDENCE_REPORTING_REFERENCE) == 1
+    ), f"Expected exactly one evidence/reporting reference: {EVIDENCE_REPORTING_REFERENCE}"
 
 
 def test_roadmap_has_required_section_headings_in_order() -> None:

--- a/tests/meta/test_doc_roadmap.py
+++ b/tests/meta/test_doc_roadmap.py
@@ -210,16 +210,16 @@ def test_roadmap_has_title_and_single_doc_references() -> None:
     text = _read_roadmap_text()
 
     assert text.startswith(f"{TITLE}\n"), f"Expected roadmap doc to start with {TITLE!r}"
-    assert (
-        text.count(ARCHITECTURE_REFERENCE) == 1
-    ), f"Expected exactly one architecture reference: {ARCHITECTURE_REFERENCE}"
-    assert (
-        text.count(AGENT_MODEL_REFERENCE) == 1
-    ), f"Expected exactly one agent model reference: {AGENT_MODEL_REFERENCE}"
+    assert text.count(ARCHITECTURE_REFERENCE) == 1, (
+        f"Expected exactly one architecture reference: {ARCHITECTURE_REFERENCE}"
+    )
+    assert text.count(AGENT_MODEL_REFERENCE) == 1, (
+        f"Expected exactly one agent model reference: {AGENT_MODEL_REFERENCE}"
+    )
     assert text.count(EVALUATION_REFERENCE) == 1, f"Expected exactly one evaluation reference: {EVALUATION_REFERENCE}"
-    assert (
-        text.count(EVIDENCE_REPORTING_REFERENCE) == 1
-    ), f"Expected exactly one evidence/reporting reference: {EVIDENCE_REPORTING_REFERENCE}"
+    assert text.count(EVIDENCE_REPORTING_REFERENCE) == 1, (
+        f"Expected exactly one evidence/reporting reference: {EVIDENCE_REPORTING_REFERENCE}"
+    )
 
 
 def test_roadmap_has_required_section_headings_in_order() -> None:

--- a/tests/meta/test_repo_scaffold.py
+++ b/tests/meta/test_repo_scaffold.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-EXPECTED_README_TEXT = (
+EXPECTED_README_HEADER = (
     "# agent-based-decision-pipeline\n\nA Python framework for reproducible agent-based decision simulation"
 )
+EXPECTED_README_ROADMAP_LINK = "[Roadmap](docs/roadmap.md)"
 
 REQUIRED_SCAFFOLD_PATHS = (
     "src/abdp/__init__.py",
@@ -23,11 +24,13 @@ PACKAGE_MODULES_WITH_EMPTY_DOCSTRING = (
 )
 
 
-def test_readme_contains_only_project_name_and_tagline() -> None:
+def test_readme_starts_with_tagline_and_links_to_roadmap() -> None:
     readme = REPO_ROOT / "README.md"
 
     assert readme.is_file()
-    assert readme.read_text(encoding="utf-8").strip() == EXPECTED_README_TEXT
+    text = readme.read_text(encoding="utf-8")
+    assert text.startswith(f"{EXPECTED_README_HEADER}\n"), "README must start with project name and tagline"
+    assert EXPECTED_README_ROADMAP_LINK in text, f"README must link to roadmap via {EXPECTED_README_ROADMAP_LINK}"
 
 
 def test_required_scaffold_files_exist() -> None:


### PR DESCRIPTION
Closes #92

## Summary

Locks the v0.2 modeling-toolkit boundary in `docs/roadmap.md` so the next 13 implementation issues (#093–#105) have an unambiguous, reviewable target. Adds an explicit non-goals section that defers evaluation, evidence, CLI, persistence, and domain code to v0.3 or plugins. Surfaces the roadmap from the README so newcomers find it.

## TDD evidence (3 commits)

- `b1477cf` — RED: extend `tests/meta/test_doc_roadmap.py` with new `## v0.2 modeling toolkit boundary` and `## Explicit non-goals for v0.2` headings/anchors/phrases (line budget 65→90); relax `tests/meta/test_repo_scaffold.py` README test to require a tagline + `[Roadmap](docs/roadmap.md)` link.
- `c89f058` — GREEN: add the boundary section listing all 14 issues with one-line goals, add the non-goals section, add a `## Roadmap` section to `README.md` linking to the roadmap doc.
- `ba6cfe2` — REFACTOR: ruff-format reflow of pre-existing assertion error messages touched while editing the roadmap meta test.

## Verification

- `pytest -q` → 411 passed, 100.00% coverage
- `ruff check .` → All checks passed
- `ruff format --check .` → 70 files already formatted
- `mypy --strict src tests` → Success: no issues found in 70 source files

## Scope discipline

- No new code under `src/abdp/**`.
- No domain concepts introduced.
- No randomness introduced.
- Diff size: S (<150 LOC).