### PR TITLE
feat(scenario): add ActionResolver protocol (#96)

### DIFF
--- a/src/abdp/scenario/__init__.py
+++ b/src/abdp/scenario/__init__.py
@@ -1,0 +1,5 @@
+from abdp.scenario.resolver import ActionResolver
+
+globals().pop("resolver", None)
+
+__all__ = ("ActionResolver",)

--- a/src/abdp/scenario/resolver.py
+++ b/src/abdp/scenario/resolver.py
@@ -1,3 +1,5 @@
+"""Action resolver protocol for the abdp scenario package."""
+
 from typing import Protocol, runtime_checkable
 
 from abdp.simulation.action_proposal import ActionProposal

--- a/src/abdp/scenario/resolver.py
+++ b/src/abdp/scenario/resolver.py
@@ -1,0 +1,23 @@
+from typing import Protocol, runtime_checkable
+
+from abdp.simulation.action_proposal import ActionProposal
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
+from abdp.simulation.state import SimulationState
+
+__all__ = ["ActionResolver"]
+
+
+@runtime_checkable
+class ActionResolver[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
+    """Resolve agent proposals into the next SimulationState.
+
+    Implementations MUST NOT mutate the input ``state``; they return the next
+    ``SimulationState[S, P, A]`` derived from ``state`` and ``proposals``.
+    """
+
+    def resolve(
+        self,
+        state: SimulationState[S, P, A],
+        proposals: tuple[A, ...],
+    ) -> SimulationState[S, P, A]: ...  # pragma: no cover

--- a/tests/scenario/test_action_resolver.py
+++ b/tests/scenario/test_action_resolver.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import get_args, get_origin, get_type_hints
+from uuid import uuid4
+
+from abdp.scenario import ActionResolver
+from abdp.core.types import Seed
+from abdp.simulation import SimulationState
+from abdp.simulation.action_proposal import ActionProposal
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+def test_action_resolver_is_runtime_checkable_protocol() -> None:
+    assert getattr(ActionResolver, "_is_protocol", False) is True
+    assert getattr(ActionResolver, "_is_runtime_protocol", False) is True
+
+
+def test_action_resolver_declares_expected_type_parameters() -> None:
+    assert tuple(param.__name__ for param in ActionResolver.__type_params__) == ("S", "P", "A")
+
+
+def test_action_resolver_declares_expected_resolve_signature() -> None:
+    signature = inspect.signature(ActionResolver.resolve)
+    hints = get_type_hints(ActionResolver.resolve)
+    type_params = ActionResolver.__type_params__
+    expected_simulation_state_args = tuple(type_params[: len(SimulationState.__type_params__)])
+
+    assert tuple(signature.parameters) == ("self", "state", "proposals")
+
+    state_annotation = hints["state"]
+    proposals_annotation = hints["proposals"]
+    return_annotation = hints["return"]
+
+    assert get_origin(state_annotation) is SimulationState
+    assert get_args(state_annotation) == expected_simulation_state_args
+    assert get_origin(proposals_annotation) is tuple
+    assert get_args(proposals_annotation) == (type_params[2], Ellipsis)
+    assert get_origin(return_annotation) is SimulationState
+    assert get_args(return_annotation) == expected_simulation_state_args
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleSegment:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleParticipant:
+    participant_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleAction:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: str
+
+
+class ExampleResolver:
+    def resolve(
+        self,
+        state: SimulationState[ExampleSegment, ExampleParticipant, ExampleAction],
+        proposals: tuple[ExampleAction, ...],
+    ) -> SimulationState[ExampleSegment, ExampleParticipant, ExampleAction]:
+        return state
+
+
+def test_concrete_resolver_satisfies_action_resolver_protocol() -> None:
+    segment = ExampleSegment(segment_id="segment-1", participant_ids=("participant-1",))
+    participant = ExampleParticipant(participant_id="participant-1")
+    action = ExampleAction(
+        proposal_id="proposal-1",
+        actor_id="participant-1",
+        action_key="hold",
+        payload="{}",
+    )
+    state = SimulationState[ExampleSegment, ExampleParticipant, ExampleAction](
+        step_index=0,
+        seed=Seed(1),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=uuid4(),
+            tier="bronze",
+            storage_key="snapshots/1.json",
+        ),
+        segments=(segment,),
+        participants=(participant,),
+        pending_actions=(action,),
+    )
+    resolver = ExampleResolver()
+
+    assert isinstance(segment, SegmentState)
+    assert isinstance(participant, ParticipantState)
+    assert isinstance(action, ActionProposal)
+    assert resolver.resolve(state, (action,)) is state
+    assert isinstance(resolver, ActionResolver)

--- a/tests/scenario/test_scenario_public_surface.py
+++ b/tests/scenario/test_scenario_public_surface.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from types import ModuleType
+
+from abdp.scenario.resolver import ActionResolver
+
+_APPROVED_PUBLIC_NAMES = ("ActionResolver",)
+
+
+def _import_fresh_scenario_package() -> ModuleType:
+    sys.modules.pop("abdp.scenario", None)
+    return importlib.import_module("abdp.scenario")
+
+
+def _public_names(module: ModuleType) -> list[str]:
+    return [name for name, _ in inspect.getmembers(module) if not name.startswith("_")]
+
+
+def test_scenario_package_dunder_all_matches_approved_public_surface() -> None:
+    pkg = _import_fresh_scenario_package()
+    assert pkg.__all__ == _APPROVED_PUBLIC_NAMES
+
+
+def test_scenario_package_public_surface_matches_dunder_all() -> None:
+    pkg = _import_fresh_scenario_package()
+    assert tuple(_public_names(pkg)) == _APPROVED_PUBLIC_NAMES
+    assert pkg.ActionResolver is ActionResolver


### PR DESCRIPTION
Closes #96

## Summary
- add the new `abdp.scenario` package and export a runtime-checkable `ActionResolver[S, P, A]` protocol
- define `resolve(state, proposals)` against `SimulationState[S, P, A]` and document the required non-mutating behavior
- freeze the `abdp.scenario` public surface and add structural protocol tests

## TDD evidence (3 commits)
- `6212cab` — `test(scenario): add failing test for ActionResolver protocol (#96)`
- `a117678` — `feat(scenario): add ActionResolver protocol (#96)`
- `3f101e5` — `refactor(scenario): polish ActionResolver docs (#96)`

## Verification
- `pytest -q`
- `ruff check .`
- `ruff format --check .`
- `mypy --strict src tests`

## Scope discipline
- limited changes to `src/abdp/scenario/` and `tests/scenario/`
- no changes to `src/abdp/core`, `src/abdp/data`, `src/abdp/simulation`, or `src/abdp/agents`
- no runner or domain logic added; only the protocol surface requested in #96