### PR TITLE
feat(agents): add AgentDecision protocol (#93)

### DIFF
--- a/src/abdp/agents/__init__.py
+++ b/src/abdp/agents/__init__.py
@@ -1,0 +1,5 @@
+from abdp.agents.decision import AgentDecision
+
+globals().pop("decision", None)
+
+__all__ = ("AgentDecision",)

--- a/src/abdp/agents/decision.py
+++ b/src/abdp/agents/decision.py
@@ -6,8 +6,8 @@ class AgentDecision[A](Protocol):
     """Output of an agent for a single scenario step.
 
     ``agent_id`` identifies the emitting agent; ``proposals`` are the actions
-    the agent suggests for this step. Proposals are an ordered tuple so that
-    downstream resolvers can apply deterministic tie-breaking.
+    the agent suggests for this step. The ordered tuple preserves deterministic
+    downstream tie-breaking.
     """
 
     agent_id: str

--- a/src/abdp/agents/decision.py
+++ b/src/abdp/agents/decision.py
@@ -1,0 +1,14 @@
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class AgentDecision[A](Protocol):
+    """Output of an agent for a single scenario step.
+
+    ``agent_id`` identifies the emitting agent; ``proposals`` are the actions
+    the agent suggests for this step. Proposals are an ordered tuple so that
+    downstream resolvers can apply deterministic tie-breaking.
+    """
+
+    agent_id: str
+    proposals: tuple[A, ...]

--- a/tests/agents/test_agent_decision.py
+++ b/tests/agents/test_agent_decision.py
@@ -1,41 +1,51 @@
 from __future__ import annotations
 
-from typing import TypeVar, get_args, get_origin, get_protocol_members
+from typing import TypeVar, get_type_hints
 
 from abdp.agents import AgentDecision
 
 
 class _ValidDecision:
+    agent_id: str
+    proposals: tuple[str, ...]
+
     def __init__(self, agent_id: str, proposals: tuple[str, ...]) -> None:
         self.agent_id = agent_id
         self.proposals = proposals
 
 
 class _MissingAgentId:
+    proposals: tuple[str, ...]
+
     def __init__(self) -> None:
         self.proposals = ("approve",)
 
 
 class _MissingProposals:
+    agent_id: str
+
     def __init__(self) -> None:
         self.agent_id = "agent-1"
+
+
+def _agent_decision_annotations() -> dict[str, object]:
+    return get_type_hints(AgentDecision)
 
 
 def test_agent_decision_is_generic_runtime_checkable_protocol() -> None:
     assert getattr(AgentDecision, "_is_protocol", False) is True
     assert getattr(AgentDecision, "_is_runtime_protocol", False) is True
-    assert get_protocol_members(AgentDecision) == frozenset({"agent_id", "proposals"})
+    assert set(AgentDecision.__annotations__) == {"agent_id", "proposals"}
 
 
 def test_agent_decision_declares_expected_annotations() -> None:
-    annotation_namespace = AgentDecision.__annotations__
+    annotation_namespace = _agent_decision_annotations()
     assert annotation_namespace["agent_id"] is str
 
     proposals_annotation = annotation_namespace["proposals"]
-    assert get_origin(proposals_annotation) is tuple
-    assert get_args(proposals_annotation)[1] is Ellipsis
+    assert str(proposals_annotation) == "tuple[A, ...]"
 
-    proposal_type = get_args(proposals_annotation)[0]
+    proposal_type = AgentDecision.__type_params__[0]
     assert isinstance(proposal_type, TypeVar)
     assert proposal_type.__name__ == "A"
 

--- a/tests/agents/test_agent_decision.py
+++ b/tests/agents/test_agent_decision.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TypeVar, get_args, get_origin, get_protocol_members
+
+from abdp.agents import AgentDecision
+
+
+class _ValidDecision:
+    def __init__(self, agent_id: str, proposals: tuple[str, ...]) -> None:
+        self.agent_id = agent_id
+        self.proposals = proposals
+
+
+class _MissingAgentId:
+    def __init__(self) -> None:
+        self.proposals = ("approve",)
+
+
+class _MissingProposals:
+    def __init__(self) -> None:
+        self.agent_id = "agent-1"
+
+
+def test_agent_decision_is_generic_runtime_checkable_protocol() -> None:
+    assert getattr(AgentDecision, "_is_protocol", False) is True
+    assert getattr(AgentDecision, "_is_runtime_protocol", False) is True
+    assert get_protocol_members(AgentDecision) == frozenset({"agent_id", "proposals"})
+
+
+def test_agent_decision_declares_expected_annotations() -> None:
+    annotation_namespace = AgentDecision.__annotations__
+    assert annotation_namespace["agent_id"] is str
+
+    proposals_annotation = annotation_namespace["proposals"]
+    assert get_origin(proposals_annotation) is tuple
+    assert get_args(proposals_annotation)[1] is Ellipsis
+
+    proposal_type = get_args(proposals_annotation)[0]
+    assert isinstance(proposal_type, TypeVar)
+    assert proposal_type.__name__ == "A"
+
+
+def test_agent_decision_exposes_generic_parameter_a() -> None:
+    assert AgentDecision.__type_params__[0].__name__ == "A"
+
+
+def test_agent_decision_runtime_checkable_accepts_minimal_valid_impl() -> None:
+    assert isinstance(_ValidDecision("agent-1", ("approve", "review")), AgentDecision) is True
+
+
+def test_agent_decision_runtime_checkable_rejects_missing_agent_id() -> None:
+    assert isinstance(_MissingAgentId(), AgentDecision) is False
+
+
+def test_agent_decision_runtime_checkable_rejects_missing_proposals() -> None:
+    assert isinstance(_MissingProposals(), AgentDecision) is False

--- a/tests/agents/test_agents_public_surface.py
+++ b/tests/agents/test_agents_public_surface.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+
+import abdp.agents
+import abdp.agents.decision  # noqa: F401
+
+decision_module = sys.modules["abdp.agents.decision"]
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("AgentDecision",)
+
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "AgentDecision": decision_module.AgentDecision,
+}
+
+REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["decision"]
+
+
+def test_agents_package_all_lists_exact_expected_symbols() -> None:
+    assert abdp.agents.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+def test_agents_package_exposes_each_listed_symbol_with_source_identity() -> None:
+    for name in EXPECTED_PUBLIC_NAMES:
+        attr = getattr(abdp.agents, name)
+        assert attr is EXPECTED_SOURCE_IDENTITY[name]
+
+
+def test_agents_package_does_not_leak_representative_internal_helpers() -> None:
+    for name in REPRESENTATIVE_INTERNAL_NAMES:
+        assert not hasattr(abdp.agents, name)
+
+
+def test_agents_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.agents import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_agents_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.agents) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)

--- a/tests/agents/test_agents_public_surface.py
+++ b/tests/agents/test_agents_public_surface.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import sys
-
 import abdp.agents
-import abdp.agents.decision  # noqa: F401
-
-decision_module = sys.modules["abdp.agents.decision"]
+from abdp.agents.decision import AgentDecision as SourceAgentDecision
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("AgentDecision",)
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
-    "AgentDecision": decision_module.AgentDecision,
+    "AgentDecision": SourceAgentDecision,
 }
 
 REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["decision"]
@@ -21,9 +17,7 @@ def test_agents_package_all_lists_exact_expected_symbols() -> None:
 
 
 def test_agents_package_exposes_each_listed_symbol_with_source_identity() -> None:
-    for name in EXPECTED_PUBLIC_NAMES:
-        attr = getattr(abdp.agents, name)
-        assert attr is EXPECTED_SOURCE_IDENTITY[name]
+    assert abdp.agents.AgentDecision is EXPECTED_SOURCE_IDENTITY["AgentDecision"]
 
 
 def test_agents_package_does_not_leak_representative_internal_helpers() -> None:
@@ -34,7 +28,7 @@ def test_agents_package_does_not_leak_representative_internal_helpers() -> None:
 def test_agents_package_star_import_yields_exactly_the_public_surface() -> None:
     namespace: dict[str, object] = {}
     exec("from abdp.agents import *", namespace)
-    namespace.pop("__builtins__", None)
+    _ = namespace.pop("__builtins__", None)
     assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
 
 


### PR DESCRIPTION
Closes #93

## Summary
- add the new `abdp.agents` package and export a generic, runtime-checkable `AgentDecision[A]` protocol
- freeze the initial public surface of `abdp.agents` with the same namespace cleanup pattern used elsewhere in the repo
- add RED/GREEN/REFACTOR tests that verify protocol structure, generic parameter exposure, and public surface identity

## TDD evidence (3 commits)
- `5147f59` — RED: failing tests for `AgentDecision` contract and `abdp.agents` public surface
- `5751319` — GREEN: minimal `abdp.agents` package and `AgentDecision[A]` protocol implementation
- `b92806a` — REFACTOR: doc polish plus test cleanup for stricter static-analysis-friendly assertions

## Verification
- `pytest -q` ✅ (`423 passed`, coverage `100.00%`)
- `ruff check .` ✅
- `ruff format --check .` ✅
- `mypy --strict src tests` ✅

## Scope discipline
- no out-of-scope changes included
- no changes to `src/abdp/core`, `src/abdp/data`, or `src/abdp/simulation`