### PR TITLE
chore(examples): promote queue scheduling fixture into example module (#102)

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,3 @@
+from . import queue_scheduling
+
+__all__ = ("queue_scheduling",)

--- a/examples/queue_scheduling/__init__.py
+++ b/examples/queue_scheduling/__init__.py
@@ -1,0 +1,3 @@
+from .domain import Job, QueueProposal, QueueScenario, Slot, Worker
+
+__all__ = ("Job", "QueueProposal", "QueueScenario", "Slot", "Worker")

--- a/examples/queue_scheduling/__init__.py
+++ b/examples/queue_scheduling/__init__.py
@@ -1,3 +1,5 @@
+"""Queue scheduling example package mapping one domain onto the ABDP simulation contracts."""
+
 from .domain import Job, QueueProposal, QueueScenario, Slot, Worker
 
 __all__ = ("Job", "QueueProposal", "QueueScenario", "Slot", "Worker")

--- a/examples/queue_scheduling/domain.py
+++ b/examples/queue_scheduling/domain.py
@@ -1,4 +1,4 @@
-"""Test-local queue scheduling domain proving the v0.1 simulation contracts admit a second domain."""
+"""Queue scheduling example proving the v0.1 simulation contracts admit a second domain."""
 
 from __future__ import annotations
 

--- a/examples/queue_scheduling/domain.py
+++ b/examples/queue_scheduling/domain.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import override
 from uuid import UUID
 
 from abdp.core.types import JsonValue, Seed
@@ -48,11 +49,20 @@ class QueueProposal:
     payload: JsonValue
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
 class QueueScenario(ScenarioSpec[Slot, Worker, QueueProposal]):
-    scenario_key: str
-    seed: Seed
+    def __init__(self, *, scenario_key: str, seed: Seed) -> None:
+        self._scenario_key = scenario_key
+        self._seed = seed
 
+    @property
+    def scenario_key(self) -> str:
+        return self._scenario_key
+
+    @property
+    def seed(self) -> Seed:
+        return self._seed
+
+    @override
     def build_initial_state(self) -> SimulationState[Slot, Worker, QueueProposal]:
         workers = (
             Worker(participant_id="worker-fast", queue_id="expedite", max_parallel_jobs=1),

--- a/tests/examples/test_queue_scheduling_example.py
+++ b/tests/examples/test_queue_scheduling_example.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from abdp.core.types import Seed
+from abdp.simulation import SimulationState
+from examples.queue_scheduling.domain import QueueProposal, QueueScenario, Slot, Worker
+
+
+def test_queue_scheduling_example_import_path_builds_expected_state() -> None:
+    scenario = QueueScenario(scenario_key="latency-baseline", seed=Seed(11))
+
+    state = scenario.build_initial_state()
+
+    assert isinstance(state, SimulationState)
+    assert tuple(slot.segment_id for slot in state.segments) == (
+        "slot-expedite",
+        "slot-standard",
+    )
+    assert tuple(worker.participant_id for worker in state.participants) == (
+        "worker-fast",
+        "worker-flex",
+    )
+    assert tuple(proposal.action_key for proposal in state.pending_actions) == (
+        "enqueue",
+        "promote",
+        "drop",
+    )
+    assert all(isinstance(slot, Slot) for slot in state.segments)
+    assert all(isinstance(worker, Worker) for worker in state.participants)
+    assert all(isinstance(proposal, QueueProposal) for proposal in state.pending_actions)

--- a/tests/integration/test_queue_scheduling_domain.py
+++ b/tests/integration/test_queue_scheduling_domain.py
@@ -17,7 +17,7 @@ from abdp.simulation import (
     SimulationState,
     SnapshotRef,
 )
-from tests.fixtures.queue_scheduling_domain import (
+from examples.queue_scheduling.domain import (
     Job,
     QueueProposal,
     QueueScenario,
@@ -100,7 +100,7 @@ def test_scenario_satisfies_scenario_spec_protocol() -> None:
     assert scenario.seed == SEED
 
     state = scenario.build_initial_state()
-    assert_type(state, SimulationState[Slot, Worker, QueueProposal])
+    _ = assert_type(state, SimulationState[Slot, Worker, QueueProposal])
     assert isinstance(state, SimulationState)
 
 
@@ -118,9 +118,9 @@ def test_build_initial_state_returns_valid_simulation_state() -> None:
 def test_simulation_state_has_expected_field_types_and_ordering() -> None:
     state = _build_state()
 
-    assert_type(state.segments, tuple[Slot, ...])
-    assert_type(state.participants, tuple[Worker, ...])
-    assert_type(state.pending_actions, tuple[QueueProposal, ...])
+    _ = assert_type(state.segments, tuple[Slot, ...])
+    _ = assert_type(state.participants, tuple[Worker, ...])
+    _ = assert_type(state.pending_actions, tuple[QueueProposal, ...])
 
     assert isinstance(state.segments, tuple)
     assert isinstance(state.participants, tuple)
@@ -141,12 +141,12 @@ def test_simulation_state_has_expected_field_types_and_ordering() -> None:
     )
 
 
-def test_no_abdp_source_files_were_modified_by_this_fixture() -> None:
+def test_no_abdp_source_files_were_modified_by_this_example() -> None:
     fixture_path = Path(inspect.getfile(QueueScenario)).resolve()
     abdp_pkg_path = Path(inspect.getfile(abdp)).resolve().parent
     sim_state_path = Path(inspect.getfile(SimulationState)).resolve()
 
-    assert fixture_path.is_relative_to(REPO_ROOT / "tests")
+    assert fixture_path.is_relative_to(REPO_ROOT / "examples")
     assert not fixture_path.is_relative_to(REPO_ROOT / "src")
     assert abdp_pkg_path == REPO_ROOT / "src" / "abdp"
     assert sim_state_path == REPO_ROOT / "src" / "abdp" / "simulation" / "state.py"


### PR DESCRIPTION
Closes #102

## Summary
- promote the queue scheduling domain fixture into `examples/queue_scheduling/domain.py` as an importable example module
- update integration coverage and add a dedicated public-path example smoke test for `examples.queue_scheduling.domain`
- keep the example outside `src/abdp/` while preserving green checks and 100% coverage

## TDD evidence (3 commits)
- `3ea5008` RED — `test(examples): add failing import test for examples.queue_scheduling.domain (#102)`
- `820a198` GREEN — `chore(examples): promote queue scheduling fixture to examples module (#102)`
- `e3a4f11` REFACTOR — `refactor(examples): align queue scheduling example docstrings with credit underwriting (#102)`

## Verification
- `pytest -q`
- `ruff check .`
- `ruff format --check .`
- `mypy --strict src tests`

## Scope discipline
- no new domain code under `src/abdp/`
- queue scheduling remains an external example package under `examples/`
- PR scope limited to fixture promotion, importer updates, and example-path/docs alignment