### PR TITLE
feat(agents): add AgentContext dataclass (#94)

### DIFF
--- a/src/abdp/agents/__init__.py
+++ b/src/abdp/agents/__init__.py
@@ -1,5 +1,7 @@
+from abdp.agents.context import AgentContext
 from abdp.agents.decision import AgentDecision
 
+globals().pop("context", None)
 globals().pop("decision", None)
 
-__all__ = ("AgentDecision",)
+__all__ = ("AgentContext", "AgentDecision")

--- a/src/abdp/agents/context.py
+++ b/src/abdp/agents/context.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from abdp.core import Seed
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+
+__all__ = ["AgentContext"]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentContext[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Read-only snapshot passed to ``Agent.decide`` for one step.
+
+    Carries the deterministic seed, current simulation state, and identifiers
+    that scope an agent's decision within a scenario step.
+    """
+
+    scenario_key: str
+    agent_id: str
+    step_index: int
+    seed: Seed
+    state: SimulationState[S, P, A]

--- a/src/abdp/agents/context.py
+++ b/src/abdp/agents/context.py
@@ -1,3 +1,5 @@
+"""Public ``AgentContext`` model exposed by ``abdp.agents``."""
+
 from dataclasses import dataclass
 
 from abdp.core import Seed
@@ -8,10 +10,10 @@ __all__ = ["AgentContext"]
 
 @dataclass(frozen=True, slots=True)
 class AgentContext[S: SegmentState, P: ParticipantState, A: ActionProposal]:
-    """Read-only snapshot passed to ``Agent.decide`` for one step.
+    """Immutable agent-scoped view of a single scenario step.
 
-    Carries the deterministic seed, current simulation state, and identifiers
-    that scope an agent's decision within a scenario step.
+    Packages the scenario identifier, agent identifier, step index, seed, and
+    simulation state needed for one ``Agent.decide`` call.
     """
 
     scenario_key: str

--- a/tests/agents/test_agent_context.py
+++ b/tests/agents/test_agent_context.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol, cast, get_args, get_origin, get_type_hints
+
+from abdp.agents import AgentContext
+from abdp.core import Seed
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+
+
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+class _SupportsCopyWith(Protocol):
+    def copy_with(self, params: tuple[object, ...]) -> object: ...
+
+
+def test_agent_context_is_a_frozen_slot_backed_dataclass() -> None:
+    assert dataclasses.is_dataclass(AgentContext)
+    assert AgentContext.__dataclass_params__.frozen is True
+    assert "__slots__" in AgentContext.__dict__
+
+
+def test_agent_context_declares_expected_fields_and_types() -> None:
+    fields = {field.name: field.type for field in dataclasses.fields(AgentContext)}
+
+    assert set(fields) == {"scenario_key", "agent_id", "step_index", "seed", "state"}
+    assert fields["scenario_key"] is str
+    assert fields["agent_id"] is str
+    assert fields["step_index"] is int
+
+
+def test_agent_context_specialization_resolves_type_hints() -> None:
+    specialized = AgentContext[SegmentState, ParticipantState, ActionProposal]
+    hints: dict[str, object] = get_type_hints(AgentContext)
+    state_type = cast(_SupportsCopyWith, hints["state"]).copy_with(get_args(specialized))
+
+    assert get_origin(specialized) is AgentContext
+    assert get_args(specialized) == (SegmentState, ParticipantState, ActionProposal)
+    assert hints["scenario_key"] is str
+    assert hints["agent_id"] is str
+    assert hints["step_index"] is int
+    assert hints["seed"] is Seed
+    assert get_origin(state_type) is SimulationState
+    assert get_args(state_type) == (SegmentState, ParticipantState, ActionProposal)
+    assert len(AgentContext.__type_params__) == 3

--- a/tests/agents/test_agent_context.py
+++ b/tests/agents/test_agent_context.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Protocol, cast, get_args, get_origin, get_type_hints
+from typing import get_args, get_origin, get_type_hints
 
 from abdp.agents import AgentContext
 from abdp.core import Seed
 from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
-
-
-class _DataclassParams(Protocol):
-    frozen: bool
-
-
-class _SupportsCopyWith(Protocol):
-    def copy_with(self, params: tuple[object, ...]) -> object: ...
 
 
 def test_agent_context_is_a_frozen_slot_backed_dataclass() -> None:
@@ -33,8 +25,8 @@ def test_agent_context_declares_expected_fields_and_types() -> None:
 
 def test_agent_context_specialization_resolves_type_hints() -> None:
     specialized = AgentContext[SegmentState, ParticipantState, ActionProposal]
-    hints: dict[str, object] = get_type_hints(AgentContext)
-    state_type = cast(_SupportsCopyWith, hints["state"]).copy_with(get_args(specialized))
+    hints = get_type_hints(AgentContext)
+    state_type = hints["state"].copy_with(get_args(specialized))
 
     assert get_origin(specialized) is AgentContext
     assert get_args(specialized) == (SegmentState, ParticipantState, ActionProposal)

--- a/tests/agents/test_agent_context.py
+++ b/tests/agents/test_agent_context.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import get_args, get_origin, get_type_hints
+from typing import Protocol, cast, get_args, get_origin, get_type_hints
 
 from abdp.agents import AgentContext
 from abdp.core import Seed
 from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
 
 
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+class _SupportsCopyWith(Protocol):
+    def copy_with(self, params: tuple[object, ...]) -> object: ...
+
+
 def test_agent_context_is_a_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(AgentContext, "__dataclass_params__"))
+
     assert dataclasses.is_dataclass(AgentContext)
-    assert AgentContext.__dataclass_params__.frozen is True
+    assert params.frozen is True
     assert "__slots__" in AgentContext.__dict__
 
 
@@ -25,8 +35,8 @@ def test_agent_context_declares_expected_fields_and_types() -> None:
 
 def test_agent_context_specialization_resolves_type_hints() -> None:
     specialized = AgentContext[SegmentState, ParticipantState, ActionProposal]
-    hints = get_type_hints(AgentContext)
-    state_type = hints["state"].copy_with(get_args(specialized))
+    hints: dict[str, object] = get_type_hints(AgentContext)
+    state_type = cast(_SupportsCopyWith, hints["state"]).copy_with(get_args(specialized))
 
     assert get_origin(specialized) is AgentContext
     assert get_args(specialized) == (SegmentState, ParticipantState, ActionProposal)

--- a/tests/agents/test_agents_public_surface.py
+++ b/tests/agents/test_agents_public_surface.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import abdp.agents
+from abdp.agents.context import AgentContext as SourceAgentContext
 from abdp.agents.decision import AgentDecision as SourceAgentDecision
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("AgentDecision",)
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("AgentContext", "AgentDecision")
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "AgentContext": SourceAgentContext,
     "AgentDecision": SourceAgentDecision,
 }
 
-REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["decision"]
+REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["context", "decision"]
 
 
 def test_agents_package_all_lists_exact_expected_symbols() -> None:
@@ -17,6 +19,7 @@ def test_agents_package_all_lists_exact_expected_symbols() -> None:
 
 
 def test_agents_package_exposes_each_listed_symbol_with_source_identity() -> None:
+    assert abdp.agents.AgentContext is EXPECTED_SOURCE_IDENTITY["AgentContext"]
     assert abdp.agents.AgentDecision is EXPECTED_SOURCE_IDENTITY["AgentDecision"]
 
 


### PR DESCRIPTION
Closes #94

## Summary
- add frozen slot-backed `AgentContext[S, P, A]` and export it from `abdp.agents`
- extend the agents public-surface contract and structural dataclass tests for the new API
- polish the public docs for the module and class after the implementation went green

## TDD evidence (3 commits)
- `c126497` — RED: add failing public-surface and structural tests for `AgentContext`
- `1853688` — GREEN: implement `AgentContext` and wire the frozen package export
- `8da6e0f` — REFACTOR: polish public docs and tighten test typing helpers

## Verification
- `pytest -q` ✅ `432 passed`, coverage `100.00%`
- `ruff check .` ✅
- `ruff format --check .` ✅
- `mypy --strict src tests` ✅
- `lsp_diagnostics` on changed files ✅ clean

## Scope discipline
- touched only `src/abdp/agents` and `tests/agents`
- left `src/abdp/core`, `src/abdp/data`, `src/abdp/simulation`, and `src/abdp/scenario` unchanged
- did not modify `src/abdp/agents/decision.py`