### PR TITLE
feat(agents): add Agent protocol and package exports (#95)

### DIFF
--- a/src/abdp/agents/__init__.py
+++ b/src/abdp/agents/__init__.py
@@ -1,3 +1,5 @@
+"""Public agent-facing contracts exported by ``abdp.agents``."""
+
 from abdp.agents.agent import Agent
 from abdp.agents.context import AgentContext
 from abdp.agents.decision import AgentDecision

--- a/src/abdp/agents/__init__.py
+++ b/src/abdp/agents/__init__.py
@@ -1,7 +1,9 @@
+from abdp.agents.agent import Agent
 from abdp.agents.context import AgentContext
 from abdp.agents.decision import AgentDecision
 
+globals().pop("agent", None)
 globals().pop("context", None)
 globals().pop("decision", None)
 
-__all__ = ("AgentContext", "AgentDecision")
+__all__ = ("Agent", "AgentContext", "AgentDecision")

--- a/src/abdp/agents/agent.py
+++ b/src/abdp/agents/agent.py
@@ -1,0 +1,14 @@
+from typing import Protocol, runtime_checkable
+
+from abdp.agents.context import AgentContext
+from abdp.agents.decision import AgentDecision
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
+
+__all__ = ["Agent"]
+
+
+@runtime_checkable
+class Agent[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
+    agent_id: str
+
+    def decide(self, context: AgentContext[S, P, A]) -> AgentDecision[A]: ...  # pragma: no cover

--- a/src/abdp/agents/agent.py
+++ b/src/abdp/agents/agent.py
@@ -1,3 +1,5 @@
+"""Public ``Agent`` protocol exposed by ``abdp.agents``."""
+
 from typing import Protocol, runtime_checkable
 
 from abdp.agents.context import AgentContext
@@ -9,6 +11,11 @@ __all__ = ["Agent"]
 
 @runtime_checkable
 class Agent[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
+    """Decision-making participant in a scenario step."""
+
     agent_id: str
 
-    def decide(self, context: AgentContext[S, P, A]) -> AgentDecision[A]: ...  # pragma: no cover
+    def decide(self, context: AgentContext[S, P, A]) -> AgentDecision[A]:
+        """Return a decision for the given context."""
+
+        ...  # pragma: no cover

--- a/tests/agents/test_agent_protocol.py
+++ b/tests/agents/test_agent_protocol.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TypeVar, get_origin, get_type_hints
+
+from abdp.agents import Agent, AgentContext, AgentDecision
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
+
+
+class _ValidAgent:
+    agent_id: str
+
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+
+    def decide(
+        self,
+        context: AgentContext[SegmentState, ParticipantState, ActionProposal],
+    ) -> AgentDecision[ActionProposal]:
+        raise NotImplementedError
+
+
+def test_agent_is_generic_runtime_checkable_protocol() -> None:
+    assert getattr(Agent, "_is_protocol", False) is True
+    assert getattr(Agent, "_is_runtime_protocol", False) is True
+
+
+def test_agent_declares_expected_annotations_and_signature() -> None:
+    annotation_namespace = get_type_hints(Agent)
+    assert annotation_namespace["agent_id"] is str
+
+    decide_hints = get_type_hints(Agent.decide)
+    assert get_origin(decide_hints["context"]) is AgentContext
+    assert get_origin(decide_hints["return"]) is AgentDecision
+
+
+def test_agent_exposes_generic_parameters_for_segment_participant_and_action() -> None:
+    type_params = Agent.__type_params__
+
+    assert len(type_params) == 3
+    assert all(isinstance(type_param, TypeVar) for type_param in type_params)
+    assert tuple(type_param.__name__ for type_param in type_params) == ("S", "P", "A")
+
+
+def test_agent_runtime_checkable_accepts_minimal_valid_impl() -> None:
+    assert isinstance(_ValidAgent("agent-1"), Agent) is True

--- a/tests/agents/test_agents_public_surface.py
+++ b/tests/agents/test_agents_public_surface.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 import abdp.agents
+from abdp.agents.agent import Agent as SourceAgent
 from abdp.agents.context import AgentContext as SourceAgentContext
 from abdp.agents.decision import AgentDecision as SourceAgentDecision
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("AgentContext", "AgentDecision")
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("Agent", "AgentContext", "AgentDecision")
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "Agent": SourceAgent,
     "AgentContext": SourceAgentContext,
     "AgentDecision": SourceAgentDecision,
 }
 
-REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["context", "decision"]
+REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["agent", "context", "decision"]
 
 
 def test_agents_package_all_lists_exact_expected_symbols() -> None:
@@ -19,6 +21,7 @@ def test_agents_package_all_lists_exact_expected_symbols() -> None:
 
 
 def test_agents_package_exposes_each_listed_symbol_with_source_identity() -> None:
+    assert abdp.agents.Agent is EXPECTED_SOURCE_IDENTITY["Agent"]
     assert abdp.agents.AgentContext is EXPECTED_SOURCE_IDENTITY["AgentContext"]
     assert abdp.agents.AgentDecision is EXPECTED_SOURCE_IDENTITY["AgentDecision"]
 


### PR DESCRIPTION
Closes #95

## Summary
Adds the `Agent[S, P, A]` runtime-checkable Protocol and finalizes the `abdp.agents` public surface to exactly `(Agent, AgentContext, AgentDecision)`.

## TDD evidence (3 commits)
- `553a470` test(agents): add Agent protocol contract coverage (#95)
- `970cb1c` feat(agents): add Agent protocol and package exports (#95)
- `1596f75` refactor(agents): polish Agent protocol docs (#95)

## Verification
- `uv run pytest -q` — 436 passed, 100% coverage
- `uv run ruff check .` — All checks passed
- `uv run mypy --strict src tests` — Success: no issues found in 84 source files
- `git log origin/main..HEAD --oneline | wc -l` = 3

## Scope discipline
- Adds: `src/abdp/agents/agent.py`, `tests/agents/test_agent_protocol.py`
- Updates: `src/abdp/agents/__init__.py`, `tests/agents/test_agents_public_surface.py`
- No concrete agent classes, no scenario runner integration (out of scope).