### PR TITLE
feat(scenario): add ScenarioStep dataclass (#97)

### DIFF
--- a/src/abdp/scenario/__init__.py
+++ b/src/abdp/scenario/__init__.py
@@ -1,5 +1,7 @@
 from abdp.scenario.resolver import ActionResolver
+from abdp.scenario.step import ScenarioStep
 
 globals().pop("resolver", None)
+globals().pop("step", None)
 
-__all__ = ("ActionResolver",)
+__all__ = ("ActionResolver", "ScenarioStep")

--- a/src/abdp/scenario/step.py
+++ b/src/abdp/scenario/step.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from abdp.agents import AgentDecision
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+
+__all__ = ["ScenarioStep"]
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioStep[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    state: SimulationState[S, P, A]
+    decisions: tuple[AgentDecision[A], ...]
+    proposals: tuple[A, ...]

--- a/src/abdp/scenario/step.py
+++ b/src/abdp/scenario/step.py
@@ -1,3 +1,5 @@
+"""Public ``ScenarioStep`` model exposed by ``abdp.scenario``."""
+
 from dataclasses import dataclass
 
 from abdp.agents import AgentDecision
@@ -8,6 +10,13 @@ __all__ = ["ScenarioStep"]
 
 @dataclass(frozen=True, slots=True)
 class ScenarioStep[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Pre-resolution snapshot of one scenario runner iteration.
+
+    Captures the simulation ``state`` before action resolution, the ordered
+    ``decisions`` collected from agents this step, and the merged action
+    ``proposals`` derived from those decisions.
+    """
+
     state: SimulationState[S, P, A]
     decisions: tuple[AgentDecision[A], ...]
     proposals: tuple[A, ...]

--- a/tests/scenario/test_scenario_public_surface.py
+++ b/tests/scenario/test_scenario_public_surface.py
@@ -6,8 +6,9 @@ import sys
 from types import ModuleType
 
 from abdp.scenario.resolver import ActionResolver
+from abdp.scenario.step import ScenarioStep
 
-_APPROVED_PUBLIC_NAMES = ("ActionResolver",)
+_APPROVED_PUBLIC_NAMES = ("ActionResolver", "ScenarioStep")
 
 
 def _import_fresh_scenario_package() -> ModuleType:
@@ -28,3 +29,4 @@ def test_scenario_package_public_surface_matches_dunder_all() -> None:
     pkg = _import_fresh_scenario_package()
     assert tuple(_public_names(pkg)) == _APPROVED_PUBLIC_NAMES
     assert pkg.ActionResolver is ActionResolver
+    assert pkg.ScenarioStep is ScenarioStep

--- a/tests/scenario/test_scenario_step.py
+++ b/tests/scenario/test_scenario_step.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol, cast, get_args, get_origin, get_type_hints
+
+from abdp.agents import AgentDecision
+from abdp.scenario import ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+
+
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+class _SupportsCopyWith(Protocol):
+    def copy_with(self, params: tuple[object, ...]) -> object: ...
+
+
+def test_scenario_step_is_a_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(ScenarioStep, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(ScenarioStep)
+    assert params.frozen is True
+    assert "__slots__" in ScenarioStep.__dict__
+
+
+def test_scenario_step_declares_expected_field_names() -> None:
+    fields = {field.name for field in dataclasses.fields(ScenarioStep)}
+
+    assert fields == {"state", "decisions", "proposals"}
+
+
+def test_scenario_step_specialization_resolves_type_hints() -> None:
+    specialized = ScenarioStep[SegmentState, ParticipantState, ActionProposal]
+    hints: dict[str, object] = get_type_hints(ScenarioStep)
+    type_args = get_args(specialized)
+
+    assert get_origin(specialized) is ScenarioStep
+    assert type_args == (SegmentState, ParticipantState, ActionProposal)
+    assert len(ScenarioStep.__type_params__) == 3
+
+    state_type = cast(_SupportsCopyWith, hints["state"]).copy_with(type_args)
+    assert get_origin(state_type) is SimulationState
+    assert get_args(state_type) == (SegmentState, ParticipantState, ActionProposal)
+
+    decisions_args = get_args(hints["decisions"])
+    assert get_origin(hints["decisions"]) is tuple
+    assert get_origin(decisions_args[0]) is AgentDecision
+    assert decisions_args[1] is Ellipsis
+
+    proposals_args = get_args(hints["proposals"])
+    assert get_origin(hints["proposals"]) is tuple
+    assert proposals_args[1] is Ellipsis


### PR DESCRIPTION
Closes #97

## Summary
Adds frozen, slot-backed `ScenarioStep[S, P, A]` dataclass capturing one runner iteration's pre-resolution snapshot: `state`, `decisions`, `proposals`. Extends `abdp.scenario` public surface to `(ActionResolver, ScenarioStep)`.

## TDD evidence (3 commits)
- `c88f971` test(scenario): add failing tests for ScenarioStep dataclass (#97)
- `ea46e65` feat(scenario): add ScenarioStep dataclass (#97)
- `ac0a592` refactor(scenario): polish ScenarioStep docs (#97)

## Verification
- `uv run pytest -q` — 439 passed, 100% coverage
- `uv run ruff check .` — All checks passed
- `uv run mypy --strict src tests` — Success: no issues found in 86 source files
- `git log origin/main..HEAD --oneline | wc -l` = 3

## Scope discipline
- Adds: `src/abdp/scenario/step.py`, `tests/scenario/test_scenario_step.py`
- Updates: `src/abdp/scenario/__init__.py`, `tests/scenario/test_scenario_public_surface.py`
- No `ScenarioRun`, no `ScenarioRunner` (out of scope per issue).