### PR TITLE
feat(scenario): add ScenarioRun dataclass (#98)

### DIFF
--- a/src/abdp/scenario/__init__.py
+++ b/src/abdp/scenario/__init__.py
@@ -1,7 +1,9 @@
 from abdp.scenario.resolver import ActionResolver
+from abdp.scenario.run import ScenarioRun
 from abdp.scenario.step import ScenarioStep
 
 globals().pop("resolver", None)
+globals().pop("run", None)
 globals().pop("step", None)
 
-__all__ = ("ActionResolver", "ScenarioStep")
+__all__ = ("ActionResolver", "ScenarioRun", "ScenarioStep")

--- a/src/abdp/scenario/run.py
+++ b/src/abdp/scenario/run.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from abdp.core import Seed
+from abdp.scenario.step import ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+
+__all__ = ["ScenarioRun"]
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioRun[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    scenario_key: str
+    seed: Seed
+    steps: tuple[ScenarioStep[S, P, A], ...]
+    final_state: SimulationState[S, P, A]
+
+    @property
+    def step_count(self) -> int:
+        return len(self.steps)

--- a/src/abdp/scenario/run.py
+++ b/src/abdp/scenario/run.py
@@ -1,3 +1,5 @@
+"""Public ``ScenarioRun`` model exposed by ``abdp.scenario``."""
+
 from dataclasses import dataclass
 
 from abdp.core import Seed
@@ -9,6 +11,13 @@ __all__ = ["ScenarioRun"]
 
 @dataclass(frozen=True, slots=True)
 class ScenarioRun[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Full execution trace of a scenario.
+
+    Carries the deterministic ``scenario_key`` and ``seed``, the ordered
+    sequence of ``steps`` produced by the runner, and the post-resolution
+    ``final_state`` snapshot.
+    """
+
     scenario_key: str
     seed: Seed
     steps: tuple[ScenarioStep[S, P, A], ...]
@@ -16,4 +25,5 @@ class ScenarioRun[S: SegmentState, P: ParticipantState, A: ActionProposal]:
 
     @property
     def step_count(self) -> int:
+        """Return the number of steps in the run."""
         return len(self.steps)

--- a/tests/scenario/test_scenario_public_surface.py
+++ b/tests/scenario/test_scenario_public_surface.py
@@ -6,9 +6,10 @@ import sys
 from types import ModuleType
 
 from abdp.scenario.resolver import ActionResolver
+from abdp.scenario.run import ScenarioRun
 from abdp.scenario.step import ScenarioStep
 
-_APPROVED_PUBLIC_NAMES = ("ActionResolver", "ScenarioStep")
+_APPROVED_PUBLIC_NAMES = ("ActionResolver", "ScenarioRun", "ScenarioStep")
 
 
 def _import_fresh_scenario_package() -> ModuleType:
@@ -29,4 +30,5 @@ def test_scenario_package_public_surface_matches_dunder_all() -> None:
     pkg = _import_fresh_scenario_package()
     assert tuple(_public_names(pkg)) == _APPROVED_PUBLIC_NAMES
     assert pkg.ActionResolver is ActionResolver
+    assert pkg.ScenarioRun is ScenarioRun
     assert pkg.ScenarioStep is ScenarioStep

--- a/tests/scenario/test_scenario_run.py
+++ b/tests/scenario/test_scenario_run.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol, cast, get_args, get_origin, get_type_hints
+from uuid import UUID
+
+from abdp.core import Seed
+from abdp.scenario import ScenarioRun, ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+class _SupportsCopyWith(Protocol):
+    def copy_with(self, params: tuple[object, ...]) -> object: ...
+
+
+def _make_state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=Seed(0),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("00000000-0000-0000-0000-000000000001"),
+            tier="bronze",
+            storage_key="snapshots/run",
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _make_step() -> ScenarioStep[SegmentState, ParticipantState, ActionProposal]:
+    return ScenarioStep[SegmentState, ParticipantState, ActionProposal](
+        state=_make_state(),
+        decisions=(),
+        proposals=(),
+    )
+
+
+def test_scenario_run_is_a_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(ScenarioRun, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(ScenarioRun)
+    assert params.frozen is True
+    assert "__slots__" in ScenarioRun.__dict__
+
+
+def test_scenario_run_declares_expected_fields_and_scalar_types() -> None:
+    fields = {field.name: field.type for field in dataclasses.fields(ScenarioRun)}
+
+    assert set(fields) == {"scenario_key", "seed", "steps", "final_state"}
+    assert fields["scenario_key"] is str
+
+
+def test_scenario_run_specialization_resolves_type_hints() -> None:
+    specialized = ScenarioRun[SegmentState, ParticipantState, ActionProposal]
+    hints: dict[str, object] = get_type_hints(ScenarioRun)
+    type_args = get_args(specialized)
+
+    assert get_origin(specialized) is ScenarioRun
+    assert type_args == (SegmentState, ParticipantState, ActionProposal)
+    assert len(ScenarioRun.__type_params__) == 3
+    assert hints["scenario_key"] is str
+    assert hints["seed"] is Seed
+
+    steps_args = get_args(hints["steps"])
+    assert get_origin(hints["steps"]) is tuple
+    assert get_origin(steps_args[0]) is ScenarioStep
+    assert steps_args[1] is Ellipsis
+
+    final_state_type = cast(_SupportsCopyWith, hints["final_state"]).copy_with(type_args)
+    assert get_origin(final_state_type) is SimulationState
+    assert get_args(final_state_type) == (SegmentState, ParticipantState, ActionProposal)
+
+
+def test_scenario_run_step_count_returns_len_of_steps() -> None:
+    state = _make_state()
+    step = _make_step()
+    run_zero = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        steps=(),
+        final_state=state,
+    )
+    run_two = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        steps=(step, step),
+        final_state=state,
+    )
+
+    assert run_zero.step_count == 0
+    assert run_two.step_count == 2


### PR DESCRIPTION
Closes #98

## Summary
Adds frozen, slot-backed `ScenarioRun[S, P, A]` dataclass capturing the full execution trace of a scenario: `scenario_key`, `seed`, `steps`, `final_state`, plus a `step_count` property. Extends `abdp.scenario` public surface to `(ActionResolver, ScenarioRun, ScenarioStep)`.

## TDD evidence (3 commits)
- `5a91764` test(scenario): add failing tests for ScenarioRun dataclass (#98)
- `fd40c19` feat(scenario): add ScenarioRun dataclass (#98)
- `457fffa` refactor(scenario): polish ScenarioRun docs (#98)

## Verification
- `uv run pytest -q` — 443 passed, 100% coverage
- `uv run ruff check .` — All checks passed
- `uv run mypy --strict src tests` — Success: no issues found in 88 source files
- `git log origin/main..HEAD --oneline | wc -l` = 3

## Scope discipline
- Adds: `src/abdp/scenario/run.py`, `tests/scenario/test_scenario_run.py`
- Updates: `src/abdp/scenario/__init__.py`, `tests/scenario/test_scenario_public_surface.py`
- No runner execution loop (out of scope per issue).