### PR TITLE
feat(scenario): add ScenarioRunner execution loop (#99)

### DIFF
--- a/src/abdp/scenario/__init__.py
+++ b/src/abdp/scenario/__init__.py
@@ -1,9 +1,11 @@
 from abdp.scenario.resolver import ActionResolver
 from abdp.scenario.run import ScenarioRun
+from abdp.scenario.runner import ScenarioRunner
 from abdp.scenario.step import ScenarioStep
 
 globals().pop("resolver", None)
 globals().pop("run", None)
+globals().pop("runner", None)
 globals().pop("step", None)
 
-__all__ = ("ActionResolver", "ScenarioRun", "ScenarioStep")
+__all__ = ("ActionResolver", "ScenarioRun", "ScenarioRunner", "ScenarioStep")

--- a/src/abdp/scenario/runner.py
+++ b/src/abdp/scenario/runner.py
@@ -1,3 +1,5 @@
+"""Public ``ScenarioRunner`` model exposed by ``abdp.scenario``."""
+
 from dataclasses import dataclass
 
 from abdp.agents import Agent, AgentContext, AgentDecision
@@ -17,11 +19,21 @@ __all__ = ["ScenarioRunner"]
 
 @dataclass(frozen=True, slots=True)
 class ScenarioRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Deterministic execution loop for an agent-based scenario.
+
+    Drives a ``ScenarioSpec`` forward by polling each ``Agent`` in declared
+    tuple order, merging the resulting proposals with any ``pending_actions``
+    carried by the current state, and delegating progression to an
+    ``ActionResolver``. Iteration is bounded by ``max_steps`` and terminates
+    early when no proposals remain to resolve.
+    """
+
     agents: tuple[Agent[S, P, A], ...]
     resolver: ActionResolver[S, P, A]
     max_steps: int
 
     def run(self, spec: ScenarioSpec[S, P, A]) -> ScenarioRun[S, P, A]:
+        """Execute the scenario and return its full ``ScenarioRun`` trace."""
         state: SimulationState[S, P, A] = spec.build_initial_state()
         steps: list[ScenarioStep[S, P, A]] = []
 

--- a/src/abdp/scenario/runner.py
+++ b/src/abdp/scenario/runner.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+
+from abdp.agents import Agent, AgentContext, AgentDecision
+from abdp.scenario.resolver import ActionResolver
+from abdp.scenario.run import ScenarioRun
+from abdp.scenario.step import ScenarioStep
+from abdp.simulation import (
+    ActionProposal,
+    ParticipantState,
+    ScenarioSpec,
+    SegmentState,
+    SimulationState,
+)
+
+__all__ = ["ScenarioRunner"]
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    agents: tuple[Agent[S, P, A], ...]
+    resolver: ActionResolver[S, P, A]
+    max_steps: int
+
+    def run(self, spec: ScenarioSpec[S, P, A]) -> ScenarioRun[S, P, A]:
+        state: SimulationState[S, P, A] = spec.build_initial_state()
+        steps: list[ScenarioStep[S, P, A]] = []
+
+        while state.step_index < self.max_steps:
+            decisions: tuple[AgentDecision[A], ...] = tuple(
+                agent.decide(
+                    AgentContext(
+                        scenario_key=spec.scenario_key,
+                        agent_id=agent.agent_id,
+                        step_index=state.step_index,
+                        seed=state.seed,
+                        state=state,
+                    )
+                )
+                for agent in self.agents
+            )
+            emissions: tuple[A, ...] = tuple(proposal for decision in decisions for proposal in decision.proposals)
+            merged: tuple[A, ...] = state.pending_actions + emissions
+
+            steps.append(ScenarioStep(state=state, decisions=decisions, proposals=merged))
+
+            if not merged:
+                break
+
+            state = self.resolver.resolve(state, merged)
+            if state.step_index >= self.max_steps:
+                break
+
+        return ScenarioRun(
+            scenario_key=spec.scenario_key,
+            seed=spec.seed,
+            steps=tuple(steps),
+            final_state=state,
+        )

--- a/tests/scenario/test_scenario_public_surface.py
+++ b/tests/scenario/test_scenario_public_surface.py
@@ -7,9 +7,10 @@ from types import ModuleType
 
 from abdp.scenario.resolver import ActionResolver
 from abdp.scenario.run import ScenarioRun
+from abdp.scenario.runner import ScenarioRunner
 from abdp.scenario.step import ScenarioStep
 
-_APPROVED_PUBLIC_NAMES = ("ActionResolver", "ScenarioRun", "ScenarioStep")
+_APPROVED_PUBLIC_NAMES = ("ActionResolver", "ScenarioRun", "ScenarioRunner", "ScenarioStep")
 
 
 def _import_fresh_scenario_package() -> ModuleType:
@@ -31,4 +32,5 @@ def test_scenario_package_public_surface_matches_dunder_all() -> None:
     assert tuple(_public_names(pkg)) == _APPROVED_PUBLIC_NAMES
     assert pkg.ActionResolver is ActionResolver
     assert pkg.ScenarioRun is ScenarioRun
+    assert pkg.ScenarioRunner is ScenarioRunner
     assert pkg.ScenarioStep is ScenarioStep

--- a/tests/scenario/test_scenario_runner.py
+++ b/tests/scenario/test_scenario_runner.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Protocol, cast, get_args, get_origin, get_type_hints
+from uuid import UUID
+
+from abdp.agents import Agent, AgentContext, AgentDecision
+from abdp.core import JsonValue, Seed
+from abdp.scenario import ActionResolver, ScenarioRun, ScenarioRunner
+from abdp.simulation import (
+    ParticipantState,
+    SegmentState,
+    SimulationState,
+)
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+def _snapshot_ref(suffix: int = 1) -> SnapshotRef:
+    return SnapshotRef(
+        snapshot_id=UUID(int=suffix),
+        tier="bronze",
+        storage_key=f"snapshots/{suffix}",
+    )
+
+
+def _state(
+    step_index: int = 0,
+    pending: tuple[_Action, ...] = (),
+    snapshot_suffix: int = 1,
+) -> SimulationState[SegmentState, ParticipantState, _Action]:
+    return SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=Seed(7),
+        snapshot_ref=_snapshot_ref(snapshot_suffix),
+        segments=(),
+        participants=(),
+        pending_actions=pending,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _Spec:
+    scenario_key: str
+    seed: Seed
+    initial: SimulationState[SegmentState, ParticipantState, _Action]
+
+    def build_initial_state(
+        self,
+    ) -> SimulationState[SegmentState, ParticipantState, _Action]:
+        return self.initial
+
+
+@dataclass
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+@dataclass
+class _RecordingAgent:
+    agent_id: str
+    proposals_to_emit: tuple[_Action, ...]
+    seen_contexts: list[AgentContext[SegmentState, ParticipantState, _Action]] = dataclasses.field(default_factory=list)
+
+    def decide(
+        self,
+        context: AgentContext[SegmentState, ParticipantState, _Action],
+    ) -> AgentDecision[_Action]:
+        self.seen_contexts.append(context)
+        return _Decision(agent_id=self.agent_id, proposals=self.proposals_to_emit)
+
+
+@dataclass
+class _RecordingResolver:
+    received: list[tuple[int, tuple[_Action, ...]]] = dataclasses.field(default_factory=list)
+
+    def resolve(
+        self,
+        state: SimulationState[SegmentState, ParticipantState, _Action],
+        proposals: tuple[_Action, ...],
+    ) -> SimulationState[SegmentState, ParticipantState, _Action]:
+        self.received.append((state.step_index, proposals))
+        return _state(
+            step_index=state.step_index + 1,
+            pending=(),
+            snapshot_suffix=state.step_index + 2,
+        )
+
+
+def _action(suffix: str) -> _Action:
+    return _Action(
+        proposal_id=f"p-{suffix}",
+        actor_id=f"a-{suffix}",
+        action_key="noop",
+        payload=None,
+    )
+
+
+def test_scenario_runner_is_a_frozen_slot_backed_dataclass_with_expected_fields() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(ScenarioRunner, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(ScenarioRunner)
+    assert params.frozen is True
+    assert "__slots__" in ScenarioRunner.__dict__
+
+    fields = {f.name: f.type for f in dataclasses.fields(ScenarioRunner)}
+    assert set(fields) == {"agents", "resolver", "max_steps"}
+    assert fields["max_steps"] is int
+
+    hints = get_type_hints(ScenarioRunner)
+    agents_args = get_args(hints["agents"])
+    assert get_origin(hints["agents"]) is tuple
+    assert get_origin(agents_args[0]) is Agent
+    assert agents_args[1] is Ellipsis
+    assert get_origin(hints["resolver"]) is ActionResolver
+    assert len(ScenarioRunner.__type_params__) == 3
+
+
+def test_run_invokes_agents_in_order_and_merges_pending_before_emissions() -> None:
+    pending = (_action("pending"),)
+    initial = _state(step_index=0, pending=pending)
+    spec = _Spec(scenario_key="merge-key", seed=Seed(7), initial=initial)
+
+    a1_emit = (_action("a1"),)
+    a2_emit = (_action("a2-x"), _action("a2-y"))
+    agent1 = _RecordingAgent(agent_id="agent-1", proposals_to_emit=a1_emit)
+    agent2 = _RecordingAgent(agent_id="agent-2", proposals_to_emit=a2_emit)
+    resolver = _RecordingResolver()
+
+    runner = ScenarioRunner[SegmentState, ParticipantState, _Action](
+        agents=(agent1, agent2),
+        resolver=resolver,
+        max_steps=1,
+    )
+
+    run = runner.run(spec)
+
+    assert run.scenario_key == "merge-key"
+    assert run.seed == Seed(7)
+    assert run.step_count == 1
+
+    step = run.steps[0]
+    assert tuple(d.agent_id for d in step.decisions) == ("agent-1", "agent-2")
+    assert step.proposals == pending + a1_emit + a2_emit
+
+    assert agent1.seen_contexts[0].agent_id == "agent-1"
+    assert agent1.seen_contexts[0].scenario_key == "merge-key"
+    assert agent1.seen_contexts[0].step_index == 0
+    assert agent1.seen_contexts[0].seed == Seed(7)
+    assert agent1.seen_contexts[0].state is initial
+
+    assert resolver.received == [(0, pending + a1_emit + a2_emit)]
+    assert run.final_state.step_index == 1
+
+
+def test_run_records_empty_terminal_step_and_skips_resolver_when_no_proposals() -> None:
+    initial = _state(step_index=0, pending=())
+    spec = _Spec(scenario_key="quiet", seed=Seed(0), initial=initial)
+    silent = _RecordingAgent(agent_id="silent", proposals_to_emit=())
+    resolver = _RecordingResolver()
+
+    runner = ScenarioRunner[SegmentState, ParticipantState, _Action](
+        agents=(silent,),
+        resolver=resolver,
+        max_steps=5,
+    )
+    run = runner.run(spec)
+
+    assert run.step_count == 1
+    assert run.steps[0].proposals == ()
+    assert run.steps[0].state is initial
+    assert run.steps[0].decisions == (_Decision(agent_id="silent", proposals=()),)
+    assert silent.seen_contexts != []
+    assert silent.seen_contexts[0].agent_id == "silent"
+    assert silent.seen_contexts[0].step_index == 0
+    assert resolver.received == []
+    assert run.final_state is initial
+
+
+def test_run_stops_after_max_steps_resolutions() -> None:
+    initial = _state(step_index=0, pending=())
+    spec = _Spec(scenario_key="bounded", seed=Seed(0), initial=initial)
+    emitter = _RecordingAgent(agent_id="emit", proposals_to_emit=(_action("e"),))
+    resolver = _RecordingResolver()
+
+    runner = ScenarioRunner[SegmentState, ParticipantState, _Action](
+        agents=(emitter,),
+        resolver=resolver,
+        max_steps=2,
+    )
+    run = runner.run(spec)
+
+    assert run.step_count == 2
+    assert len(resolver.received) == 2
+    assert run.final_state.step_index == 2
+    assert run.steps[0].state.step_index == 0
+    assert run.steps[1].state.step_index == 1
+
+
+def test_run_is_deterministic_for_same_spec_agents_and_resolver() -> None:
+    initial = _state(step_index=0, pending=(_action("p"),))
+    spec = _Spec(scenario_key="det", seed=Seed(42), initial=initial)
+
+    def _build_run() -> ScenarioRun[SegmentState, ParticipantState, _Action]:
+        agent = _RecordingAgent(agent_id="a", proposals_to_emit=(_action("x"), _action("y")))
+        resolver = _RecordingResolver()
+        runner = ScenarioRunner[SegmentState, ParticipantState, _Action](
+            agents=(agent,), resolver=resolver, max_steps=3
+        )
+        return runner.run(spec)
+
+    assert _build_run() == _build_run()
+
+
+def test_run_with_zero_max_steps_records_no_steps_and_returns_initial_state() -> None:
+    initial = _state(step_index=0, pending=(_action("ignored"),))
+    spec = _Spec(scenario_key="zero", seed=Seed(0), initial=initial)
+    agent = _RecordingAgent(agent_id="a", proposals_to_emit=(_action("x"),))
+    resolver = _RecordingResolver()
+
+    runner = ScenarioRunner[SegmentState, ParticipantState, _Action](agents=(agent,), resolver=resolver, max_steps=0)
+    run = runner.run(spec)
+
+    assert run.step_count == 0
+    assert run.final_state is initial
+    assert agent.seen_contexts == []
+    assert resolver.received == []


### PR DESCRIPTION
## Summary
- Adds `ScenarioRunner[S, P, A]` — frozen+slots dataclass driving deterministic execution loops over `ScenarioSpec`.
- Polls agents in declared tuple order, merges `state.pending_actions` with new emissions, delegates to `ActionResolver`, bounded by `max_steps`.
- Records empty terminal step and skips resolver when no proposals remain.
- Extends `abdp.scenario` public surface to include `ScenarioRunner`.

## TDD Commits
- RED: `test(scenario): add failing tests for ScenarioRunner execution loop (#99)`
- GREEN: `feat(scenario): add ScenarioRunner execution loop (#99)`
- REFACTOR: `refactor(scenario): document ScenarioRunner public API (#99)`

## Verification
- `uv run pytest -q` → 449 passed, 100% coverage
- `uv run ruff check .` → clean
- `uv run mypy --strict src tests` → clean

Closes #99