### PR TITLE
feat(examples): add executable credit underwriting sample (#101)

### DIFF
--- a/examples/credit_underwriting/__init__.py
+++ b/examples/credit_underwriting/__init__.py
@@ -1,0 +1,16 @@
+"""Credit underwriting example package mapping a second domain onto abdp v0.2."""
+
+from .agents import CreditDecision, TierOfficer
+from .domain import Borrower, CreditAction, RiskTier
+from .resolver import CreditResolver
+from .scenario import CreditScenario
+
+__all__ = (
+    "Borrower",
+    "CreditAction",
+    "CreditDecision",
+    "CreditResolver",
+    "CreditScenario",
+    "RiskTier",
+    "TierOfficer",
+)

--- a/examples/credit_underwriting/__main__.py
+++ b/examples/credit_underwriting/__main__.py
@@ -1,0 +1,32 @@
+"""Runnable entrypoint for the credit underwriting example."""
+
+from __future__ import annotations
+
+from abdp.core.types import Seed
+from abdp.scenario import ScenarioRunner
+
+from examples.credit_underwriting.agents import TierOfficer
+from examples.credit_underwriting.domain import Borrower, CreditAction, RiskTier
+from examples.credit_underwriting.resolver import CreditResolver
+from examples.credit_underwriting.scenario import CreditScenario
+
+
+def main() -> None:
+    scenario = CreditScenario(seed=Seed(7))
+    runner = ScenarioRunner[RiskTier, Borrower, CreditAction](
+        agents=(
+            TierOfficer(agent_id="officer-prime", tier_key="prime"),
+            TierOfficer(agent_id="officer-subprime", tier_key="subprime"),
+        ),
+        resolver=CreditResolver(),
+        max_steps=8,
+    )
+    run = runner.run(scenario)
+    print(f"scenario_key={run.scenario_key}")
+    print(f"seed={int(run.seed)}")
+    print(f"step_count={run.step_count}")
+    print(f"final_step_index={run.final_state.step_index}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/credit_underwriting/agents.py
+++ b/examples/credit_underwriting/agents.py
@@ -1,0 +1,62 @@
+"""Credit underwriting agents that emit per-borrower disposition proposals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from abdp.agents import Agent, AgentContext, AgentDecision
+
+from examples.credit_underwriting.domain import (
+    ACTION_APPROVE,
+    ACTION_DECLINE,
+    ACTION_REQUEST_INFO,
+    Borrower,
+    CreditAction,
+    RiskTier,
+)
+
+
+@dataclass(slots=True, kw_only=True)
+class CreditDecision:
+    agent_id: str
+    proposals: tuple[CreditAction, ...]
+
+
+@dataclass(slots=True, kw_only=True)
+class TierOfficer(Agent[RiskTier, Borrower, CreditAction]):
+    agent_id: str
+    tier_key: str
+
+    @override
+    def decide(
+        self,
+        context: AgentContext[RiskTier, Borrower, CreditAction],
+    ) -> AgentDecision[CreditAction]:
+        state = context.state
+        tier = next((t for t in state.segments if t.tier_key == self.tier_key), None)
+        if tier is None or not tier.participant_ids:
+            return CreditDecision(agent_id=self.agent_id, proposals=())
+        borrowers_by_id = {b.participant_id: b for b in state.participants}
+        proposals = tuple(
+            CreditAction(
+                proposal_id=f"decision-{self.tier_key}-{borrower_id}-step{context.step_index}",
+                actor_id=self.agent_id,
+                action_key=_classify(borrowers_by_id[borrower_id], tier),
+                payload={
+                    "borrower_id": borrower_id,
+                    "credit_score": borrowers_by_id[borrower_id].credit_score,
+                    "requested_amount_cents": borrowers_by_id[borrower_id].requested_amount_cents,
+                },
+            )
+            for borrower_id in tier.participant_ids
+        )
+        return CreditDecision(agent_id=self.agent_id, proposals=proposals)
+
+
+def _classify(borrower: Borrower, tier: RiskTier) -> str:
+    if borrower.credit_score < tier.min_credit_score:
+        return ACTION_DECLINE
+    if borrower.requested_amount_cents > tier.max_amount_cents:
+        return ACTION_REQUEST_INFO
+    return ACTION_APPROVE

--- a/examples/credit_underwriting/agents.py
+++ b/examples/credit_underwriting/agents.py
@@ -39,19 +39,22 @@ class TierOfficer(Agent[RiskTier, Borrower, CreditAction]):
             return CreditDecision(agent_id=self.agent_id, proposals=())
         borrowers_by_id = {b.participant_id: b for b in state.participants}
         proposals = tuple(
-            CreditAction(
-                proposal_id=f"decision-{self.tier_key}-{borrower_id}-step{context.step_index}",
-                actor_id=self.agent_id,
-                action_key=_classify(borrowers_by_id[borrower_id], tier),
-                payload={
-                    "borrower_id": borrower_id,
-                    "credit_score": borrowers_by_id[borrower_id].credit_score,
-                    "requested_amount_cents": borrowers_by_id[borrower_id].requested_amount_cents,
-                },
-            )
+            self._propose(borrowers_by_id[borrower_id], tier, context.step_index)
             for borrower_id in tier.participant_ids
         )
         return CreditDecision(agent_id=self.agent_id, proposals=proposals)
+
+    def _propose(self, borrower: Borrower, tier: RiskTier, step_index: int) -> CreditAction:
+        return CreditAction(
+            proposal_id=f"decision-{self.tier_key}-{borrower.participant_id}-step{step_index}",
+            actor_id=self.agent_id,
+            action_key=_classify(borrower, tier),
+            payload={
+                "borrower_id": borrower.participant_id,
+                "credit_score": borrower.credit_score,
+                "requested_amount_cents": borrower.requested_amount_cents,
+            },
+        )
 
 
 def _classify(borrower: Borrower, tier: RiskTier) -> str:

--- a/examples/credit_underwriting/domain.py
+++ b/examples/credit_underwriting/domain.py
@@ -1,0 +1,37 @@
+"""Credit underwriting domain types for the abdp v0.2 example."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from abdp.core.types import JsonValue
+
+ACTION_APPROVE = "approve"
+ACTION_DECLINE = "decline"
+ACTION_REQUEST_INFO = "request_info"
+ACTION_ESCALATE = "escalate"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Borrower:
+    participant_id: str
+    credit_score: int
+    requested_amount_cents: int
+    debt_to_income_bps: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RiskTier:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+    tier_key: str
+    min_credit_score: int
+    max_amount_cents: int
+
+
+@dataclass(slots=True, kw_only=True)
+class CreditAction:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue

--- a/examples/credit_underwriting/resolver.py
+++ b/examples/credit_underwriting/resolver.py
@@ -29,44 +29,47 @@ class CreditResolver(ActionResolver[RiskTier, Borrower, CreditAction]):
         removed_ids: set[str] = set()
         next_pending: list[CreditAction] = []
         for proposal in proposals:
-            if proposal.action_key in {ACTION_APPROVE, ACTION_DECLINE}:
-                removed_ids.add(_borrower_id(proposal))
-            elif proposal.action_key == ACTION_REQUEST_INFO:
-                borrower_id = _borrower_id(proposal)
-                removed_ids.add(borrower_id)
-                next_pending.append(
-                    CreditAction(
-                        proposal_id=f"escalate-{borrower_id}-step{state.step_index + 1}",
-                        actor_id=proposal.actor_id,
-                        action_key=ACTION_ESCALATE,
-                        payload={
-                            "case_id": f"case-{borrower_id}",
-                            "reason": "borderline_request_info",
-                        },
-                    )
-                )
-            elif proposal.action_key == ACTION_ESCALATE:
-                continue
-            else:
-                raise ValueError(f"Unknown action_key: {proposal.action_key}")
-        new_segments = tuple(
-            RiskTier(
-                segment_id=tier.segment_id,
-                participant_ids=tuple(pid for pid in tier.participant_ids if pid not in removed_ids),
-                tier_key=tier.tier_key,
-                min_credit_score=tier.min_credit_score,
-                max_amount_cents=tier.max_amount_cents,
-            )
-            for tier in state.segments
-        )
+            match proposal.action_key:
+                case k if k == ACTION_APPROVE or k == ACTION_DECLINE:
+                    removed_ids.add(_borrower_id(proposal))
+                case k if k == ACTION_REQUEST_INFO:
+                    borrower_id = _borrower_id(proposal)
+                    removed_ids.add(borrower_id)
+                    next_pending.append(_escalation_for(borrower_id, proposal, state.step_index + 1))
+                case k if k == ACTION_ESCALATE:
+                    continue
+                case unknown:
+                    raise ValueError(f"Unknown action_key: {unknown}")
         return SimulationState[RiskTier, Borrower, CreditAction](
             step_index=state.step_index + 1,
             seed=state.seed,
             snapshot_ref=state.snapshot_ref,
-            segments=new_segments,
+            segments=tuple(_drop_members(tier, removed_ids) for tier in state.segments),
             participants=state.participants,
             pending_actions=tuple(next_pending),
         )
+
+
+def _drop_members(tier: RiskTier, removed_ids: set[str]) -> RiskTier:
+    return RiskTier(
+        segment_id=tier.segment_id,
+        participant_ids=tuple(pid for pid in tier.participant_ids if pid not in removed_ids),
+        tier_key=tier.tier_key,
+        min_credit_score=tier.min_credit_score,
+        max_amount_cents=tier.max_amount_cents,
+    )
+
+
+def _escalation_for(borrower_id: str, source: CreditAction, next_step_index: int) -> CreditAction:
+    return CreditAction(
+        proposal_id=f"escalate-{borrower_id}-step{next_step_index}",
+        actor_id=source.actor_id,
+        action_key=ACTION_ESCALATE,
+        payload={
+            "case_id": f"case-{borrower_id}",
+            "reason": "borderline_request_info",
+        },
+    )
 
 
 def _borrower_id(proposal: CreditAction) -> str:

--- a/examples/credit_underwriting/resolver.py
+++ b/examples/credit_underwriting/resolver.py
@@ -1,0 +1,74 @@
+"""Credit underwriting resolver that progresses tier membership and pending escalations."""
+
+from __future__ import annotations
+
+from typing import cast, override
+
+from abdp.core.types import JsonValue
+from abdp.scenario import ActionResolver
+from abdp.simulation import SimulationState
+
+from examples.credit_underwriting.domain import (
+    ACTION_APPROVE,
+    ACTION_DECLINE,
+    ACTION_ESCALATE,
+    ACTION_REQUEST_INFO,
+    Borrower,
+    CreditAction,
+    RiskTier,
+)
+
+
+class CreditResolver(ActionResolver[RiskTier, Borrower, CreditAction]):
+    @override
+    def resolve(
+        self,
+        state: SimulationState[RiskTier, Borrower, CreditAction],
+        proposals: tuple[CreditAction, ...],
+    ) -> SimulationState[RiskTier, Borrower, CreditAction]:
+        removed_ids: set[str] = set()
+        next_pending: list[CreditAction] = []
+        for proposal in proposals:
+            if proposal.action_key in {ACTION_APPROVE, ACTION_DECLINE}:
+                removed_ids.add(_borrower_id(proposal))
+            elif proposal.action_key == ACTION_REQUEST_INFO:
+                borrower_id = _borrower_id(proposal)
+                removed_ids.add(borrower_id)
+                next_pending.append(
+                    CreditAction(
+                        proposal_id=f"escalate-{borrower_id}-step{state.step_index + 1}",
+                        actor_id=proposal.actor_id,
+                        action_key=ACTION_ESCALATE,
+                        payload={
+                            "case_id": f"case-{borrower_id}",
+                            "reason": "borderline_request_info",
+                        },
+                    )
+                )
+            elif proposal.action_key == ACTION_ESCALATE:
+                continue
+            else:
+                raise ValueError(f"Unknown action_key: {proposal.action_key}")
+        new_segments = tuple(
+            RiskTier(
+                segment_id=tier.segment_id,
+                participant_ids=tuple(pid for pid in tier.participant_ids if pid not in removed_ids),
+                tier_key=tier.tier_key,
+                min_credit_score=tier.min_credit_score,
+                max_amount_cents=tier.max_amount_cents,
+            )
+            for tier in state.segments
+        )
+        return SimulationState[RiskTier, Borrower, CreditAction](
+            step_index=state.step_index + 1,
+            seed=state.seed,
+            snapshot_ref=state.snapshot_ref,
+            segments=new_segments,
+            participants=state.participants,
+            pending_actions=tuple(next_pending),
+        )
+
+
+def _borrower_id(proposal: CreditAction) -> str:
+    payload = cast(dict[str, JsonValue], proposal.payload)
+    return cast(str, payload["borrower_id"])

--- a/examples/credit_underwriting/scenario.py
+++ b/examples/credit_underwriting/scenario.py
@@ -1,0 +1,113 @@
+"""Credit underwriting scenario builder over the abdp v0.2 simulation contracts."""
+
+from __future__ import annotations
+
+from typing import override
+from uuid import UUID
+
+from abdp.core.types import Seed
+from abdp.data.snapshot_manifest import SnapshotTier
+from abdp.simulation import ScenarioSpec, SimulationState, SnapshotRef
+
+from examples.credit_underwriting.domain import (
+    ACTION_ESCALATE,
+    Borrower,
+    CreditAction,
+    RiskTier,
+)
+
+SCENARIO_KEY = "credit-underwriting-baseline"
+SNAPSHOT_UUID = UUID("33333333-3333-3333-3333-333333333333")
+SNAPSHOT_TIER: SnapshotTier = "bronze"
+SNAPSHOT_STORAGE_KEY = "snapshots/bronze/credit-underwriting-initial.json"
+
+
+class CreditScenario(ScenarioSpec[RiskTier, Borrower, CreditAction]):
+    def __init__(self, *, scenario_key: str = SCENARIO_KEY, seed: Seed) -> None:
+        self._scenario_key = scenario_key
+        self._seed = seed
+
+    @property
+    def scenario_key(self) -> str:
+        return self._scenario_key
+
+    @property
+    def seed(self) -> Seed:
+        return self._seed
+
+    @override
+    def build_initial_state(self) -> SimulationState[RiskTier, Borrower, CreditAction]:
+        borrowers = (
+            Borrower(
+                participant_id="borrower-alice",
+                credit_score=780,
+                requested_amount_cents=3_000_000,
+                debt_to_income_bps=2500,
+            ),
+            Borrower(
+                participant_id="borrower-bob",
+                credit_score=700,
+                requested_amount_cents=4_000_000,
+                debt_to_income_bps=3500,
+            ),
+            Borrower(
+                participant_id="borrower-frank",
+                credit_score=750,
+                requested_amount_cents=6_000_000,
+                debt_to_income_bps=3000,
+            ),
+            Borrower(
+                participant_id="borrower-carol",
+                credit_score=620,
+                requested_amount_cents=800_000,
+                debt_to_income_bps=4000,
+            ),
+            Borrower(
+                participant_id="borrower-dave",
+                credit_score=550,
+                requested_amount_cents=1_200_000,
+                debt_to_income_bps=4500,
+            ),
+            Borrower(
+                participant_id="borrower-grace",
+                credit_score=600,
+                requested_amount_cents=1_500_000,
+                debt_to_income_bps=4200,
+            ),
+        )
+        tiers = (
+            RiskTier(
+                segment_id="tier-prime",
+                participant_ids=("borrower-alice", "borrower-bob", "borrower-frank"),
+                tier_key="prime",
+                min_credit_score=720,
+                max_amount_cents=5_000_000,
+            ),
+            RiskTier(
+                segment_id="tier-subprime",
+                participant_ids=("borrower-carol", "borrower-dave", "borrower-grace"),
+                tier_key="subprime",
+                min_credit_score=580,
+                max_amount_cents=1_000_000,
+            ),
+        )
+        pending = (
+            CreditAction(
+                proposal_id="escalate-prior-001",
+                actor_id="officer-prime",
+                action_key=ACTION_ESCALATE,
+                payload={"case_id": "case-prior-001", "reason": "carry_over_review"},
+            ),
+        )
+        return SimulationState[RiskTier, Borrower, CreditAction](
+            step_index=0,
+            seed=self.seed,
+            snapshot_ref=SnapshotRef(
+                snapshot_id=SNAPSHOT_UUID,
+                tier=SNAPSHOT_TIER,
+                storage_key=SNAPSHOT_STORAGE_KEY,
+            ),
+            segments=tiers,
+            participants=borrowers,
+            pending_actions=pending,
+        )

--- a/tests/integration/test_credit_underwriting_example.py
+++ b/tests/integration/test_credit_underwriting_example.py
@@ -1,0 +1,174 @@
+"""Integration test for the credit underwriting example (#101).
+
+Verifies that the example wires together domain types, agents, resolver, and
+scenario builder against the public ``abdp`` v0.2 surface, runs deterministically
+under ``ScenarioRunner`` for a fixed seed, and exposes a ``main()`` entrypoint.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import assert_type
+
+import pytest
+
+import abdp
+from abdp.agents import Agent
+from abdp.core.types import Seed, is_json_value
+from abdp.scenario import ActionResolver, ScenarioRun, ScenarioRunner
+from abdp.simulation import (
+    ActionProposal,
+    ParticipantState,
+    ScenarioSpec,
+    SegmentState,
+    SimulationState,
+)
+from examples.credit_underwriting import (
+    Borrower,
+    CreditAction,
+    CreditResolver,
+    CreditScenario,
+    RiskTier,
+    TierOfficer,
+)
+from examples.credit_underwriting.__main__ import main as credit_main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEED = Seed(7)
+SCENARIO_KEY = "credit-underwriting-baseline"
+
+
+def _build_runner() -> ScenarioRunner[RiskTier, Borrower, CreditAction]:
+    return ScenarioRunner[RiskTier, Borrower, CreditAction](
+        agents=(
+            TierOfficer(agent_id="officer-prime", tier_key="prime"),
+            TierOfficer(agent_id="officer-subprime", tier_key="subprime"),
+        ),
+        resolver=CreditResolver(),
+        max_steps=8,
+    )
+
+
+def test_borrower_satisfies_participant_state_protocol() -> None:
+    borrower = Borrower(
+        participant_id="borrower-alice",
+        credit_score=780,
+        requested_amount_cents=3_000_000,
+        debt_to_income_bps=2500,
+    )
+    assert isinstance(borrower, ParticipantState)
+    assert borrower.participant_id == "borrower-alice"
+
+
+def test_risk_tier_satisfies_segment_state_protocol() -> None:
+    tier = RiskTier(
+        segment_id="tier-prime",
+        participant_ids=("borrower-alice",),
+        tier_key="prime",
+        min_credit_score=720,
+        max_amount_cents=5_000_000,
+    )
+    assert isinstance(tier, SegmentState)
+    assert tier.segment_id == "tier-prime"
+    assert tier.participant_ids == ("borrower-alice",)
+
+
+def test_credit_action_satisfies_action_proposal_protocol() -> None:
+    action = CreditAction(
+        proposal_id="p-001",
+        actor_id="officer-prime",
+        action_key="approve",
+        payload={"borrower_id": "borrower-alice"},
+    )
+    assert isinstance(action, ActionProposal)
+    assert is_json_value(action.payload)
+
+
+def test_credit_scenario_satisfies_scenario_spec_protocol() -> None:
+    scenario = CreditScenario(seed=SEED)
+    assert isinstance(scenario, ScenarioSpec)
+    assert scenario.scenario_key == SCENARIO_KEY
+    assert scenario.seed == SEED
+    state = scenario.build_initial_state()
+    _ = assert_type(state, SimulationState[RiskTier, Borrower, CreditAction])
+    assert isinstance(state, SimulationState)
+
+
+def test_tier_officer_satisfies_agent_protocol() -> None:
+    officer = TierOfficer(agent_id="officer-prime", tier_key="prime")
+    assert isinstance(officer, Agent)
+    assert officer.agent_id == "officer-prime"
+
+
+def test_credit_resolver_satisfies_action_resolver_protocol() -> None:
+    resolver = CreditResolver()
+    assert isinstance(resolver, ActionResolver)
+
+
+def test_run_is_deterministic_for_fixed_seed() -> None:
+    runner = _build_runner()
+    run_a = runner.run(CreditScenario(seed=SEED))
+    run_b = runner.run(CreditScenario(seed=SEED))
+    assert run_a == run_b
+
+
+def test_run_produces_expected_terminal_shape() -> None:
+    run = _build_runner().run(CreditScenario(seed=SEED))
+    _ = assert_type(run, ScenarioRun[RiskTier, Borrower, CreditAction])
+    assert run.scenario_key == SCENARIO_KEY
+    assert run.seed == SEED
+    assert run.step_count == 3
+    assert run.final_state.step_index == 2
+    assert run.final_state.pending_actions == ()
+    for tier in run.final_state.segments:
+        assert tier.participant_ids == ()
+
+
+def test_run_exercises_all_credit_action_keys_across_steps() -> None:
+    run = _build_runner().run(CreditScenario(seed=SEED))
+    step0_keys = sorted(p.action_key for p in run.steps[0].proposals)
+    assert step0_keys == [
+        "approve",
+        "approve",
+        "decline",
+        "decline",
+        "escalate",
+        "request_info",
+        "request_info",
+    ]
+    step1_keys = sorted(p.action_key for p in run.steps[1].proposals)
+    assert step1_keys == ["escalate", "escalate"]
+    assert run.steps[2].proposals == ()
+
+
+def test_resolver_rejects_unknown_action_key() -> None:
+    resolver = CreditResolver()
+    state = CreditScenario(seed=SEED).build_initial_state()
+    bad = CreditAction(
+        proposal_id="bad-001",
+        actor_id="officer-prime",
+        action_key="mystery",
+        payload={"borrower_id": "borrower-alice"},
+    )
+    with pytest.raises(ValueError, match="Unknown action_key"):
+        resolver.resolve(state, (bad,))
+
+
+def test_main_entrypoint_prints_deterministic_summary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    credit_main()
+    captured = capsys.readouterr()
+    assert "scenario_key=credit-underwriting-baseline" in captured.out
+    assert "seed=7" in captured.out
+    assert "step_count=3" in captured.out
+    assert "final_step_index=2" in captured.out
+
+
+def test_no_abdp_source_files_modified_by_example() -> None:
+    fixture_path = Path(inspect.getfile(CreditScenario)).resolve()
+    abdp_pkg_path = Path(inspect.getfile(abdp)).resolve().parent
+    assert fixture_path.is_relative_to(REPO_ROOT / "examples")
+    assert not fixture_path.is_relative_to(REPO_ROOT / "src")
+    assert abdp_pkg_path == REPO_ROOT / "src" / "abdp"


### PR DESCRIPTION
## Summary
- Adds `examples/credit_underwriting/` package implementing the abdp v0.2 contracts (`SegmentState`, `ParticipantState`, `ActionProposal`, `ScenarioSpec`, `Agent`, `ActionResolver`) for a credit underwriting domain.
- 2 `TierOfficer` agents (prime, subprime) deterministically classify each borrower as `approve`/`decline`/`request_info` from the segment + participant state. `CreditResolver` drains decisions, re-enqueues escalations from `request_info`, and drops carried-over `escalate` proposals.
- `python -m examples.credit_underwriting` runs end-to-end and prints a deterministic summary.
- Integration test asserts deterministic `ScenarioRun` equality across two runs for `Seed(7)`, exact step shape (3 steps, terminal state with empty pending and drained tiers), all 4 action keys exercised across steps 0 and 1, and that no `src/abdp/**` files are touched.

## TDD trail
- RED `3ee8b80` test(examples): failing integration test
- GREEN `0e28580` feat(examples): minimal implementation
- REFACTOR `6e6346f` refactor(examples): extract resolver/agent helpers

## Verification
- `uv run pytest -q` → 462 passed, 100% coverage
- `uv run ruff check .` → clean
- `uv run mypy --strict src tests` → clean

Closes #101