### PR TITLE
test(agents): freeze agents and scenario public surfaces (#105)

### DIFF
--- a/src/abdp/scenario/__init__.py
+++ b/src/abdp/scenario/__init__.py
@@ -1,3 +1,5 @@
+"""Public scenario-runner contracts exported by ``abdp.scenario``."""
+
 from abdp.scenario.resolver import ActionResolver
 from abdp.scenario.run import ScenarioRun
 from abdp.scenario.runner import ScenarioRunner

--- a/tests/agents/test_agents_public_surface.py
+++ b/tests/agents/test_agents_public_surface.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+import sys
+
 import abdp.agents
-from abdp.agents.agent import Agent as SourceAgent
-from abdp.agents.context import AgentContext as SourceAgentContext
-from abdp.agents.decision import AgentDecision as SourceAgentDecision
+import abdp.agents.agent  # noqa: F401
+import abdp.agents.context  # noqa: F401
+import abdp.agents.decision  # noqa: F401
+
+agent_module = sys.modules["abdp.agents.agent"]
+context_module = sys.modules["abdp.agents.context"]
+decision_module = sys.modules["abdp.agents.decision"]
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("Agent", "AgentContext", "AgentDecision")
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
-    "Agent": SourceAgent,
-    "AgentContext": SourceAgentContext,
-    "AgentDecision": SourceAgentDecision,
+    "Agent": agent_module.Agent,
+    "AgentContext": context_module.AgentContext,
+    "AgentDecision": decision_module.AgentDecision,
 }
 
 REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["agent", "context", "decision"]
@@ -23,9 +29,9 @@ def test_agents_package_all_lists_exact_expected_symbols() -> None:
 
 
 def test_agents_package_exposes_each_listed_symbol_with_source_identity() -> None:
-    assert abdp.agents.Agent is EXPECTED_SOURCE_IDENTITY["Agent"]
-    assert abdp.agents.AgentContext is EXPECTED_SOURCE_IDENTITY["AgentContext"]
-    assert abdp.agents.AgentDecision is EXPECTED_SOURCE_IDENTITY["AgentDecision"]
+    for name in EXPECTED_PUBLIC_NAMES:
+        attr = getattr(abdp.agents, name)
+        assert attr is EXPECTED_SOURCE_IDENTITY[name]
 
 
 def test_agents_package_does_not_leak_representative_internal_helpers() -> None:
@@ -36,7 +42,7 @@ def test_agents_package_does_not_leak_representative_internal_helpers() -> None:
 def test_agents_package_star_import_yields_exactly_the_public_surface() -> None:
     namespace: dict[str, object] = {}
     exec("from abdp.agents import *", namespace)
-    _ = namespace.pop("__builtins__", None)
+    namespace.pop("__builtins__", None)
     assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
 
 

--- a/tests/agents/test_agents_public_surface.py
+++ b/tests/agents/test_agents_public_surface.py
@@ -1,3 +1,5 @@
+"""Frozen public surface of the ``abdp.agents`` package."""
+
 from __future__ import annotations
 
 import abdp.agents
@@ -41,3 +43,9 @@ def test_agents_package_star_import_yields_exactly_the_public_surface() -> None:
 def test_agents_package_namespace_exposes_only_approved_public_names() -> None:
     public_attrs = sorted(name for name in vars(abdp.agents) if not name.startswith("_"))
     assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_agents_package_has_module_docstring() -> None:
+    doc = abdp.agents.__doc__
+    assert isinstance(doc, str)
+    assert doc.strip()

--- a/tests/scenario/test_scenario_public_surface.py
+++ b/tests/scenario/test_scenario_public_surface.py
@@ -1,36 +1,65 @@
+"""Frozen public surface of the ``abdp.scenario`` package."""
+
 from __future__ import annotations
 
-import importlib
-import inspect
 import sys
-from types import ModuleType
 
-from abdp.scenario.resolver import ActionResolver
-from abdp.scenario.run import ScenarioRun
-from abdp.scenario.runner import ScenarioRunner
-from abdp.scenario.step import ScenarioStep
+import abdp.scenario
+import abdp.scenario.resolver  # noqa: F401
+import abdp.scenario.run  # noqa: F401
+import abdp.scenario.runner  # noqa: F401
+import abdp.scenario.step  # noqa: F401
 
-_APPROVED_PUBLIC_NAMES = ("ActionResolver", "ScenarioRun", "ScenarioRunner", "ScenarioStep")
+resolver_module = sys.modules["abdp.scenario.resolver"]
+run_module = sys.modules["abdp.scenario.run"]
+runner_module = sys.modules["abdp.scenario.runner"]
+step_module = sys.modules["abdp.scenario.step"]
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
+    "ActionResolver",
+    "ScenarioRun",
+    "ScenarioRunner",
+    "ScenarioStep",
+)
+
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "ActionResolver": resolver_module.ActionResolver,
+    "ScenarioRun": run_module.ScenarioRun,
+    "ScenarioRunner": runner_module.ScenarioRunner,
+    "ScenarioStep": step_module.ScenarioStep,
+}
+
+REPRESENTATIVE_INTERNAL_NAMES: list[str] = ["resolver", "run", "runner", "step"]
 
 
-def _import_fresh_scenario_package() -> ModuleType:
-    sys.modules.pop("abdp.scenario", None)
-    return importlib.import_module("abdp.scenario")
+def test_scenario_package_all_lists_exact_expected_symbols() -> None:
+    assert abdp.scenario.__all__ == EXPECTED_PUBLIC_NAMES
 
 
-def _public_names(module: ModuleType) -> list[str]:
-    return [name for name, _ in inspect.getmembers(module) if not name.startswith("_")]
+def test_scenario_package_exposes_each_listed_symbol_with_source_identity() -> None:
+    for name in EXPECTED_PUBLIC_NAMES:
+        attr = getattr(abdp.scenario, name)
+        assert attr is EXPECTED_SOURCE_IDENTITY[name]
 
 
-def test_scenario_package_dunder_all_matches_approved_public_surface() -> None:
-    pkg = _import_fresh_scenario_package()
-    assert pkg.__all__ == _APPROVED_PUBLIC_NAMES
+def test_scenario_package_does_not_leak_representative_internal_helpers() -> None:
+    for name in REPRESENTATIVE_INTERNAL_NAMES:
+        assert not hasattr(abdp.scenario, name)
 
 
-def test_scenario_package_public_surface_matches_dunder_all() -> None:
-    pkg = _import_fresh_scenario_package()
-    assert tuple(_public_names(pkg)) == _APPROVED_PUBLIC_NAMES
-    assert pkg.ActionResolver is ActionResolver
-    assert pkg.ScenarioRun is ScenarioRun
-    assert pkg.ScenarioRunner is ScenarioRunner
-    assert pkg.ScenarioStep is ScenarioStep
+def test_scenario_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.scenario import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_scenario_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.scenario) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_scenario_package_has_module_docstring() -> None:
+    doc = abdp.scenario.__doc__
+    assert isinstance(doc, str)
+    assert doc.strip()


### PR DESCRIPTION
Closes #105

## Summary
- RED: stricter scenario freeze test mirroring core/agents pattern + new docstring assertion (1 fail: scenario __init__ missing docstring)
- GREEN: add module docstring to abdp.scenario.__init__
- REFACTOR: convert agents test to sys.modules source-identity pattern for parity with core test

## Verification
- 476 tests pass (+5 vs main), 100% coverage
- ruff clean, mypy --strict clean (94 files)

## Notes
- Both surface tests now structurally identical (same 6 assertions, same source-identity pattern)
- Hits issue acceptance: 'Tests style-match the core/data/simulation freeze tests'