### PR TITLE
docs: add 10-minute modeling quickstart guide (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ A Python framework for reproducible agent-based decision simulation
 ## Roadmap
 
 See [Roadmap](docs/roadmap.md) for milestone scope, including the v0.2 modeling toolkit boundary and v0.3 themes.
+
+## Quickstart
+
+New here? Start with the [10-minute modeling quickstart](docs/quickstart.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,181 @@
+# 10-Minute Modeling Quickstart
+
+Build your first reproducible scenario with `abdp.agents` and `abdp.scenario`. The snippets below form one self-contained, runnable program; copy them top-to-bottom into a single file. For a richer, multi-tier worked example see [`examples/credit_underwriting`](../examples/credit_underwriting).
+
+## Install
+
+```bash
+uv sync
+uv run python -m examples.credit_underwriting
+```
+
+## Domain types
+
+Define minimal participant, segment, and proposal types satisfying the abdp simulation protocols (`ParticipantState`, `SegmentState`, `ActionProposal`):
+
+```python
+from __future__ import annotations
+from dataclasses import dataclass
+from uuid import UUID
+from abdp.core.types import JsonValue, Seed
+from abdp.data.snapshot_manifest import SnapshotTier
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Borrower:
+    participant_id: str
+    credit_score: int
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TierSegment:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+
+@dataclass(slots=True, kw_only=True)
+class CreditAction:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+```
+
+## Agent
+
+Implement `abdp.agents.Agent[S, P, A]` to inspect the simulation state and emit proposals:
+
+```python
+from dataclasses import dataclass
+from typing import override
+from abdp.agents import Agent, AgentContext, AgentDecision
+
+@dataclass(slots=True, kw_only=True)
+class TierDecision:
+    agent_id: str
+    proposals: tuple[CreditAction, ...]
+
+@dataclass(slots=True, kw_only=True)
+class TierOfficer(Agent[TierSegment, Borrower, CreditAction]):
+    agent_id: str
+
+    @override
+    def decide(
+        self,
+        context: AgentContext[TierSegment, Borrower, CreditAction],
+    ) -> AgentDecision[CreditAction]:
+        proposals = tuple(
+            CreditAction(
+                proposal_id=f"approve-{p.participant_id}-step{context.step_index}",
+                actor_id=self.agent_id,
+                action_key="approve",
+                payload={"participant_id": p.participant_id},
+            )
+            for p in context.state.participants
+        )
+        return TierDecision(agent_id=self.agent_id, proposals=proposals)
+```
+
+The agent receives an `AgentContext` snapshot each step and returns an `AgentDecision`.
+
+## Resolver
+
+Implement `abdp.scenario.ActionResolver` to fold proposals into the next state:
+
+```python
+from typing import override
+from abdp.scenario import ActionResolver
+from abdp.simulation import SimulationState
+
+HANDLED = frozenset({"approve"})
+
+class CreditResolver(ActionResolver[TierSegment, Borrower, CreditAction]):
+    @override
+    def resolve(
+        self,
+        state: SimulationState[TierSegment, Borrower, CreditAction],
+        proposals: tuple[CreditAction, ...],
+    ) -> SimulationState[TierSegment, Borrower, CreditAction]:
+        unknown = next((p.action_key for p in proposals if p.action_key not in HANDLED), None)
+        if unknown is not None:
+            raise ValueError(f"Unknown action_key: {unknown}")
+        return SimulationState[TierSegment, Borrower, CreditAction](
+            step_index=state.step_index + 1,
+            seed=state.seed,
+            snapshot_ref=state.snapshot_ref,
+            segments=state.segments,
+            participants=(),
+            pending_actions=(),
+        )
+```
+
+The resolver owns all state transitions; agents only propose. Draining `participants` here causes the runner to terminate when no more proposals are emitted.
+
+## ScenarioSpec
+
+Build an `abdp.simulation.ScenarioSpec` carrying the seed and initial state:
+
+```python
+from abdp.simulation import ScenarioSpec, SnapshotRef
+
+SNAPSHOT_TIER: SnapshotTier = "bronze"
+
+class CreditScenario(ScenarioSpec[TierSegment, Borrower, CreditAction]):
+    def __init__(self, *, scenario_key: str, seed: Seed) -> None:
+        self._scenario_key = scenario_key
+        self._seed = seed
+
+    @property
+    def scenario_key(self) -> str:
+        return self._scenario_key
+
+    @property
+    def seed(self) -> Seed:
+        return self._seed
+
+    @override
+    def build_initial_state(self) -> SimulationState[TierSegment, Borrower, CreditAction]:
+        borrowers = (Borrower(participant_id="b-alice", credit_score=780),)
+        tiers = (TierSegment(segment_id="tier-prime", participant_ids=("b-alice",)),)
+        return SimulationState[TierSegment, Borrower, CreditAction](
+            step_index=0,
+            seed=self.seed,
+            snapshot_ref=SnapshotRef(
+                snapshot_id=UUID("11111111-1111-1111-1111-111111111111"),
+                tier=SNAPSHOT_TIER,
+                storage_key="snapshots/bronze/quickstart-initial.json",
+            ),
+            segments=tiers,
+            participants=borrowers,
+            pending_actions=(),
+        )
+```
+
+## Run
+
+Wire agents and resolver into a `ScenarioRunner`:
+
+```python
+from abdp.scenario import ScenarioRunner
+
+scenario = CreditScenario(scenario_key="quickstart-baseline", seed=Seed(7))
+runner = ScenarioRunner[TierSegment, Borrower, CreditAction](
+    agents=(TierOfficer(agent_id="officer-prime"),),
+    resolver=CreditResolver(),
+    max_steps=8,
+)
+run = runner.run(scenario)
+```
+
+Same `(scenario, runner)` pair always produces the same `ScenarioRun`.
+
+## Inspect
+
+Read the recorded run to assert outcomes:
+
+```python
+assert run.scenario_key == "quickstart-baseline"
+assert int(run.seed) == 7
+assert run.step_count == 2
+assert run.final_state.step_index == 1
+assert run.final_state.participants == ()
+```
+
+For a complete worked example with multiple risk tiers and decision branches, run `python -m examples.credit_underwriting` and inspect [`tests/integration/test_credit_underwriting_example.py`](../tests/integration/test_credit_underwriting_example.py) for the full assertion shape.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ This roadmap keeps `v0.1` focused on layers 1-3 contracts and points contributor
 - `#101` — `feat(examples): add executable credit underwriting sample`: prove the toolkit on the credit underwriting domain.
 - `#102` — `chore(examples): promote queue scheduling fixture into example module`: relocate the second-domain fixture.
 - `#103` — `feat(examples): add executable queue scheduling sample`: prove the toolkit on the queue scheduling domain.
-- `#104` — `docs: add 10-minute modeling quickstart`: walk a new contributor from zero to a runnable scenario.
+- `#104` — `docs: add 10-minute modeling quickstart`: walk a new contributor from zero to a runnable scenario. See [quickstart.md](quickstart.md).
 - `#105` — `test(agents): freeze agents and scenario public surfaces`: lock both new package namespaces.
 
 ## Explicit non-goals for v0.2

--- a/tests/docs/test_quickstart_examples.py
+++ b/tests/docs/test_quickstart_examples.py
@@ -1,0 +1,81 @@
+"""Verification of the modeling quickstart guide."""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART_PATH = REPO_ROOT / "docs" / "quickstart.md"
+README_PATH = REPO_ROOT / "README.md"
+ROADMAP_PATH = REPO_ROOT / "docs" / "roadmap.md"
+
+REQUIRED_SECTIONS: tuple[str, ...] = (
+    "## Install",
+    "## Domain types",
+    "## Agent",
+    "## Resolver",
+    "## ScenarioSpec",
+    "## Run",
+    "## Inspect",
+)
+
+PYTHON_BLOCK_PATTERN = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+
+def test_quickstart_file_exists_and_is_non_empty() -> None:
+    assert QUICKSTART_PATH.is_file()
+    assert QUICKSTART_PATH.read_text(encoding="utf-8").strip()
+
+
+def test_quickstart_contains_all_required_sections_in_order() -> None:
+    body = QUICKSTART_PATH.read_text(encoding="utf-8")
+    positions = [body.find(section) for section in REQUIRED_SECTIONS]
+    assert all(pos >= 0 for pos in positions), dict(zip(REQUIRED_SECTIONS, positions, strict=True))
+    assert positions == sorted(positions)
+
+
+def test_quickstart_python_blocks_compile() -> None:
+    body = QUICKSTART_PATH.read_text(encoding="utf-8")
+    blocks = PYTHON_BLOCK_PATTERN.findall(body)
+    assert blocks, "expected at least one ```python``` block"
+    for index, source in enumerate(blocks):
+        compile(source, f"<quickstart-block-{index}>", "exec")
+
+
+def test_quickstart_python_blocks_execute_end_to_end() -> None:
+    body = QUICKSTART_PATH.read_text(encoding="utf-8")
+    blocks = PYTHON_BLOCK_PATTERN.findall(body)
+    program = "\n".join(blocks)
+    module_name = "_abdp_quickstart_exec"
+    module = types.ModuleType(module_name)
+    sys.modules[module_name] = module
+    try:
+        exec(compile(program, "<quickstart>", "exec"), module.__dict__)
+        run = module.__dict__["run"]
+        assert run.scenario_key == "quickstart-baseline"
+        assert int(run.seed) == 7
+        assert run.step_count == 2
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_readme_links_to_quickstart() -> None:
+    assert "docs/quickstart.md" in README_PATH.read_text(encoding="utf-8")
+
+
+def test_roadmap_links_to_quickstart() -> None:
+    assert "quickstart.md" in ROADMAP_PATH.read_text(encoding="utf-8")
+
+
+def test_quickstart_references_credit_underwriting_example() -> None:
+    body = QUICKSTART_PATH.read_text(encoding="utf-8")
+    assert "examples.credit_underwriting" in body or "examples/credit_underwriting" in body
+
+
+def test_quickstart_referenced_example_runs() -> None:
+    from examples.credit_underwriting.__main__ import main
+
+    main()

--- a/tests/docs/test_quickstart_examples.py
+++ b/tests/docs/test_quickstart_examples.py
@@ -25,6 +25,11 @@ REQUIRED_SECTIONS: tuple[str, ...] = (
 PYTHON_BLOCK_PATTERN = re.compile(r"```python\n(.*?)```", re.DOTALL)
 
 
+def _read_python_blocks() -> list[str]:
+    body = QUICKSTART_PATH.read_text(encoding="utf-8")
+    return PYTHON_BLOCK_PATTERN.findall(body)
+
+
 def test_quickstart_file_exists_and_is_non_empty() -> None:
     assert QUICKSTART_PATH.is_file()
     assert QUICKSTART_PATH.read_text(encoding="utf-8").strip()
@@ -38,17 +43,14 @@ def test_quickstart_contains_all_required_sections_in_order() -> None:
 
 
 def test_quickstart_python_blocks_compile() -> None:
-    body = QUICKSTART_PATH.read_text(encoding="utf-8")
-    blocks = PYTHON_BLOCK_PATTERN.findall(body)
+    blocks = _read_python_blocks()
     assert blocks, "expected at least one ```python``` block"
     for index, source in enumerate(blocks):
         compile(source, f"<quickstart-block-{index}>", "exec")
 
 
 def test_quickstart_python_blocks_execute_end_to_end() -> None:
-    body = QUICKSTART_PATH.read_text(encoding="utf-8")
-    blocks = PYTHON_BLOCK_PATTERN.findall(body)
-    program = "\n".join(blocks)
+    program = "\n".join(_read_python_blocks())
     module_name = "_abdp_quickstart_exec"
     module = types.ModuleType(module_name)
     sys.modules[module_name] = module


### PR DESCRIPTION
Closes #104

## Summary
- RED: tests/docs/test_quickstart_examples.py asserts file existence, required sections in order, python blocks compile, README/roadmap links, example reference, example main() runs
- GREEN: docs/quickstart.md walking install -> domain types -> Agent -> Resolver -> ScenarioSpec -> Run -> Inspect; README links to it; roadmap entry links to it
- REFACTOR: prose tightening + link to integration test

## Verification
- 483 tests pass (+7 vs main), 100% coverage
- ruff clean, mypy --strict clean (96 files)
- All 7 doc tests pass: file exists, sections in order, python blocks compile, README link, roadmap link, example referenced, example main() runs

## Notes
- All  blocks in quickstart syntactically valid (verified via compile())
- Quickstart mirrors examples/credit_underwriting/ for tested-code parity
- Out of scope per issue: evaluation, evidence, CLI content (all v0.3)