### PR TITLE
docs: define v0.3 auditable simulation boundary (#106)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,6 +58,40 @@ This roadmap keeps `v0.1` focused on layers 1-3 contracts and points contributor
 - `v0.3` may improve comparison, audit, and reporting workflows that build on earlier contract work.
 - `v0.3` is still a roadmap milestone, not a calendar promise.
 
+## v0.3 milestone scope
+
+The `v0.3` milestone delivers the auditable simulation surface across `abdp.evaluation`, `abdp.evidence`, `abdp.reporting`, and `abdp.cli`, plus end-to-end audit-flow proofs in both example domains. It is locked by the following 20 issues:
+
+- `#106` — `docs: define v0.3 auditable simulation boundary`: lock the v0.3 scope, reserved keys, and non-goals.
+- `#107` — `test(evaluation): freeze evaluation public surface`: lock the `abdp.evaluation` package namespace.
+- `#108` — `feat(evaluation): add metric protocol and result record`: introduce the metric contract.
+- `#109` — `feat(evaluation): add ordered metric evaluation helper`: deterministic metric application.
+- `#110` — `feat(evaluation): add gate protocol and result record`: introduce the gate contract.
+- `#111` — `feat(evaluation): add gate evaluation and summary aggregation`: combine metric and gate outcomes.
+- `#112` — `test(evidence): freeze evidence public surface`: lock the `abdp.evidence` package namespace.
+- `#113` — `feat(evidence): add EvidenceRecord`: minimal evidence row contract.
+- `#114` — `feat(evidence): add ClaimRecord`: claim row referencing evidence rows.
+- `#115` — `feat(evidence): add AuditLog bundle`: deterministic audit-log container.
+- `#116` — `feat(evidence): add EvidenceStore protocol`: abstract storage contract.
+- `#117` — `feat(evidence): add in-memory evidence store`: reference implementation.
+- `#118` — `test(reporting): freeze reporting public surface`: lock the `abdp.reporting` package namespace.
+- `#119` — `feat(reporting): add deterministic JSON renderer`: machine-readable report output.
+- `#120` — `feat(reporting): add deterministic Markdown renderer`: human-readable report output.
+- `#121` — `feat(cli): add CLI entrypoint and import-path loader`: shared `abdp.cli` command surface.
+- `#122` — `feat(cli): add CLI run command`: execute scenarios from the terminal.
+- `#123` — `feat(cli): add CLI report command`: render audit logs from the terminal.
+- `#124` — `test(examples): prove credit underwriting audit flow`: end-to-end evidence and report assertion in the credit underwriting example.
+- `#125` — `test(examples): prove queue scheduling audit flow`: end-to-end evidence and report assertion in the queue scheduling example.
+
+Reserved evidence keys: `evidence_key="selected_proposal"` is the mandatory key recording which proposal a resolver applied at each step; all v0.3 audit flows must emit it and all v0.3 reporting renderers must surface it.
+
+## Explicit non-goals for v0.3
+
+- No remote storage, network adapters, or hosted services belong in `v0.3`; the in-memory evidence store remains the reference.
+- No plugin system, dynamic discovery, or external entry-point registration belongs in `v0.3`; CLI loaders use explicit import paths only.
+- No web UI, dashboard, browser viewer, or HTML output belongs in `v0.3`; reporting stays JSON and Markdown.
+- No domain-specific code belongs under `src/abdp/**` in `v0.3`; example audit flows live only in `examples/` and `tests/`.
+
 ## Explicit non-goals for v0.1
 
 - No implementation work beyond layers 1-3 belongs in `v0.1`; that includes layers 4, 6, 7, and 8.

--- a/tests/docs/test_roadmap_v03_section.py
+++ b/tests/docs/test_roadmap_v03_section.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROADMAP_PATH = REPO_ROOT / "docs" / "roadmap.md"
 
@@ -49,26 +51,24 @@ def test_roadmap_has_v03_section_heading() -> None:
     assert "## v0.3 milestone scope" in _read_roadmap_body()
 
 
-def test_roadmap_v03_section_lists_all_twenty_issue_numbers() -> None:
-    body = _read_roadmap_body()
-    for number in V03_ISSUE_NUMBERS:
-        assert f"#{number}" in body, f"missing roadmap entry for #{number}"
+@pytest.mark.parametrize("number", V03_ISSUE_NUMBERS)
+def test_roadmap_v03_section_lists_issue_number(number: int) -> None:
+    assert f"#{number}" in _read_roadmap_body()
 
 
-def test_roadmap_v03_each_issue_has_individual_bullet_with_one_line_goal() -> None:
+@pytest.mark.parametrize("number", V03_ISSUE_NUMBERS)
+def test_roadmap_v03_each_issue_has_individual_bullet_with_one_line_goal(number: int) -> None:
     bullets = _bullet_lines_by_issue()
-    for number in V03_ISSUE_NUMBERS:
-        assert number in bullets, f"issue #{number} must have its own '- `#{number}` — `<title>`: <goal>.' bullet"
-        match = ISSUE_BULLET_PATTERN.match(bullets[number])
-        assert match is not None
-        goal = match.group("goal").strip()
-        assert len(goal) >= 10, f"issue #{number} goal text is too short: {goal!r}"
+    assert number in bullets, f"issue #{number} must have its own '- `#{number}` — `<title>`: <goal>.' bullet"
+    match = ISSUE_BULLET_PATTERN.match(bullets[number])
+    assert match is not None
+    goal = match.group("goal").strip()
+    assert len(goal) >= 10, f"issue #{number} goal text is too short: {goal!r}"
 
 
-def test_roadmap_v03_section_mentions_each_v03_area() -> None:
-    body = _read_roadmap_body()
-    for area in REQUIRED_AREA_HEADINGS:
-        assert area in body, f"missing v0.3 area: {area}"
+@pytest.mark.parametrize("area", REQUIRED_AREA_HEADINGS)
+def test_roadmap_v03_section_mentions_v03_area(area: str) -> None:
+    assert area in _read_roadmap_body(), f"missing v0.3 area: {area}"
 
 
 def test_roadmap_reserves_selected_proposal_evidence_key() -> None:
@@ -77,8 +77,10 @@ def test_roadmap_reserves_selected_proposal_evidence_key() -> None:
     assert "Reserved evidence keys" in body or "reserved evidence key" in body
 
 
-def test_roadmap_v03_section_has_non_goals_subsection() -> None:
-    body = _read_roadmap_body()
-    assert "## Explicit non-goals for v0.3" in body
-    for term in NON_GOAL_TERMS:
-        assert term in body, f"missing v0.3 non-goal term: {term}"
+def test_roadmap_v03_section_has_non_goals_subsection_heading() -> None:
+    assert "## Explicit non-goals for v0.3" in _read_roadmap_body()
+
+
+@pytest.mark.parametrize("term", NON_GOAL_TERMS)
+def test_roadmap_v03_non_goals_subsection_lists_term(term: str) -> None:
+    assert term in _read_roadmap_body(), f"missing v0.3 non-goal term: {term}"

--- a/tests/docs/test_roadmap_v03_section.py
+++ b/tests/docs/test_roadmap_v03_section.py
@@ -1,0 +1,84 @@
+"""Verification of the v0.3 roadmap section."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROADMAP_PATH = REPO_ROOT / "docs" / "roadmap.md"
+
+V03_ISSUE_NUMBERS: tuple[int, ...] = tuple(range(106, 126))
+
+REQUIRED_AREA_HEADINGS: tuple[str, ...] = (
+    "abdp.evaluation",
+    "abdp.evidence",
+    "abdp.reporting",
+    "abdp.cli",
+)
+
+RESERVED_EVIDENCE_KEY = "selected_proposal"
+
+NON_GOAL_TERMS: tuple[str, ...] = (
+    "remote storage",
+    "plugin system",
+    "web UI",
+    "src/abdp",
+)
+
+ISSUE_BULLET_PATTERN = re.compile(
+    r"^- `#(?P<num>\d+)` — `(?P<title>[^`]+)`: (?P<goal>.+\.)$",
+)
+
+
+def _read_roadmap_body() -> str:
+    return ROADMAP_PATH.read_text(encoding="utf-8")
+
+
+def _bullet_lines_by_issue() -> dict[int, str]:
+    bullets: dict[int, str] = {}
+    for line in _read_roadmap_body().splitlines():
+        match = ISSUE_BULLET_PATTERN.match(line)
+        if match is None:
+            continue
+        bullets[int(match.group("num"))] = line
+    return bullets
+
+
+def test_roadmap_has_v03_section_heading() -> None:
+    assert "## v0.3 milestone scope" in _read_roadmap_body()
+
+
+def test_roadmap_v03_section_lists_all_twenty_issue_numbers() -> None:
+    body = _read_roadmap_body()
+    for number in V03_ISSUE_NUMBERS:
+        assert f"#{number}" in body, f"missing roadmap entry for #{number}"
+
+
+def test_roadmap_v03_each_issue_has_individual_bullet_with_one_line_goal() -> None:
+    bullets = _bullet_lines_by_issue()
+    for number in V03_ISSUE_NUMBERS:
+        assert number in bullets, f"issue #{number} must have its own '- `#{number}` — `<title>`: <goal>.' bullet"
+        match = ISSUE_BULLET_PATTERN.match(bullets[number])
+        assert match is not None
+        goal = match.group("goal").strip()
+        assert len(goal) >= 10, f"issue #{number} goal text is too short: {goal!r}"
+
+
+def test_roadmap_v03_section_mentions_each_v03_area() -> None:
+    body = _read_roadmap_body()
+    for area in REQUIRED_AREA_HEADINGS:
+        assert area in body, f"missing v0.3 area: {area}"
+
+
+def test_roadmap_reserves_selected_proposal_evidence_key() -> None:
+    body = _read_roadmap_body()
+    assert RESERVED_EVIDENCE_KEY in body
+    assert "Reserved evidence keys" in body or "reserved evidence key" in body
+
+
+def test_roadmap_v03_section_has_non_goals_subsection() -> None:
+    body = _read_roadmap_body()
+    assert "## Explicit non-goals for v0.3" in body
+    for term in NON_GOAL_TERMS:
+        assert term in body, f"missing v0.3 non-goal term: {term}"

--- a/tests/meta/test_doc_roadmap.py
+++ b/tests/meta/test_doc_roadmap.py
@@ -7,7 +7,7 @@ ARCHITECTURE_REFERENCE = "[docs/architecture.md](architecture.md)"
 AGENT_MODEL_REFERENCE = "[docs/models/agent-model.md](models/agent-model.md)"
 EVALUATION_REFERENCE = "[docs/evaluation.md](evaluation.md)"
 EVIDENCE_REPORTING_REFERENCE = "[docs/evidence-reporting.md](evidence-reporting.md)"
-MAX_LINE_COUNT = 90
+MAX_LINE_COUNT = 130
 
 REQUIRED_HEADINGS: list[str] = [
     "## Scope and non-goals overview",
@@ -16,6 +16,8 @@ REQUIRED_HEADINGS: list[str] = [
     "## v0.2 modeling toolkit boundary",
     "## Explicit non-goals for v0.2",
     "## v0.3 milestone themes",
+    "## v0.3 milestone scope",
+    "## Explicit non-goals for v0.3",
     "## Explicit non-goals for v0.1",
     "## Revisit triggers for more complex infrastructure",
 ]
@@ -78,6 +80,45 @@ SECTION_ANCHORS: dict[str, list[str]] = {
         "No CLI entry point, run command, or report command belongs in `v0.2`; that work is reserved for `v0.3`.",
         "No persistence backends or storage adapters belong in `v0.2`; the in-memory toolkit must remain sufficient.",
         "No domain-specific code belongs under `src/abdp/**`; domain logic lives only in `examples/` and tests.",
+    ],
+    "## v0.3 milestone scope": [
+        "`v0.3` milestone delivers the auditable simulation surface",
+        "`#106`",
+        "`#107`",
+        "`#108`",
+        "`#109`",
+        "`#110`",
+        "`#111`",
+        "`#112`",
+        "`#113`",
+        "`#114`",
+        "`#115`",
+        "`#116`",
+        "`#117`",
+        "`#118`",
+        "`#119`",
+        "`#120`",
+        "`#121`",
+        "`#122`",
+        "`#123`",
+        "`#124`",
+        "`#125`",
+        'Reserved evidence keys: `evidence_key="selected_proposal"`',
+    ],
+    "## Explicit non-goals for v0.3": [
+        (
+            "No remote storage, network adapters, or hosted services belong in `v0.3`; "
+            "the in-memory evidence store remains the reference."
+        ),
+        (
+            "No plugin system, dynamic discovery, or external entry-point registration "
+            "belongs in `v0.3`; CLI loaders use explicit import paths only."
+        ),
+        "No web UI, dashboard, browser viewer, or HTML output belongs in `v0.3`; reporting stays JSON and Markdown.",
+        (
+            "No domain-specific code belongs under `src/abdp/**` in `v0.3`; "
+            "example audit flows live only in `examples/` and `tests/`."
+        ),
     ],
     "## Explicit non-goals for v0.1": [
         "No implementation work beyond layers 1-3 belongs in `v0.1`; that includes layers 4, 6, 7, and 8.",


### PR DESCRIPTION
## Summary
- Adds `## v0.3 milestone scope` to `docs/roadmap.md` enumerating each of the 20 v0.3 issues (#106-#125) as an individual `- \`#NNN\` — \`type(scope): title\`: goal.` bullet.
- Reserves `evidence_key="selected_proposal"` as the mandatory key emitted by every v0.3 audit flow and surfaced by every reporting renderer.
- Adds `## Explicit non-goals for v0.3` pinning out remote storage, plugin systems, web UI, and any domain-specific code under `src/abdp/**`.
- Updates `tests/docs/test_roadmap_v03_section.py` with regex-anchored, `pytest.parametrize`-d checks that lock the per-issue bullet shape, the four area names, the four non-goal terms, and the reserved evidence key.
- Updates `tests/meta/test_doc_roadmap.py`: extends `REQUIRED_HEADINGS` and `SECTION_ANCHORS` to cover the new v0.3 sections, and bumps `MAX_LINE_COUNT` from 90 to 130 to accommodate the new sections (current roadmap is 108 lines).

## TDD shape
- RED `e7d5817` test(docs): add failing checks for v0.3 roadmap section (#106)
- GREEN `2e9bec8` docs: add v0.3 milestone scope and non-goals (#106)
- REFACTOR `6baddc0` refactor(tests): parametrize v0.3 roadmap checks per issue (#106)

## Verification
- \`uv run pytest -q\` -> 535 passed, 100% coverage
- \`uv run ruff check .\` -> All checks passed
- \`uv run mypy --strict src tests\` -> Success: no issues found in 97 source files

## Oracle review
APPROVE/MERGE 100/100 (Correctness 30 / Tests 25 / API+Docs 20 / Doc quality 10 / Type strictness 10 / TDD shape 5).

Closes #106