### PR TITLE
test(evaluation): freeze empty abdp.evaluation public surface (#107)

### DIFF
--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -1,0 +1,9 @@
+"""Public surface for the ``abdp.evaluation`` package.
+
+The evaluation package owns the v0.3 metric, gate, and summary contracts.
+The surface is intentionally empty in #107 so subsequent v0.3 issues can
+extend ``__all__`` symbol-by-symbol against the frozen surface test in
+``tests/evaluation/test_evaluation_public_surface.py``.
+"""
+
+__all__: tuple[str, ...] = ()

--- a/tests/evaluation/test_evaluation_public_surface.py
+++ b/tests/evaluation/test_evaluation_public_surface.py
@@ -1,0 +1,39 @@
+"""Frozen public surface of the ``abdp.evaluation`` package."""
+
+from __future__ import annotations
+
+import abdp.evaluation
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
+
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {}
+
+
+def test_evaluation_package_all_lists_exact_expected_symbols() -> None:
+    assert isinstance(abdp.evaluation.__all__, tuple)
+    assert all(isinstance(name, str) for name in abdp.evaluation.__all__)
+    assert abdp.evaluation.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+def test_evaluation_package_exposes_each_listed_symbol_with_source_identity() -> None:
+    for name in EXPECTED_PUBLIC_NAMES:
+        attr = getattr(abdp.evaluation, name)
+        assert attr is EXPECTED_SOURCE_IDENTITY[name]
+
+
+def test_evaluation_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.evaluation import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_evaluation_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.evaluation) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_evaluation_package_has_module_docstring() -> None:
+    doc = abdp.evaluation.__doc__
+    assert isinstance(doc, str)
+    assert doc.strip()

--- a/tests/evaluation/test_evaluation_public_surface.py
+++ b/tests/evaluation/test_evaluation_public_surface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abdp.evaluation
+import pytest
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
 
@@ -15,10 +16,9 @@ def test_evaluation_package_all_lists_exact_expected_symbols() -> None:
     assert abdp.evaluation.__all__ == EXPECTED_PUBLIC_NAMES
 
 
-def test_evaluation_package_exposes_each_listed_symbol_with_source_identity() -> None:
-    for name in EXPECTED_PUBLIC_NAMES:
-        attr = getattr(abdp.evaluation, name)
-        assert attr is EXPECTED_SOURCE_IDENTITY[name]
+@pytest.mark.parametrize("name", EXPECTED_PUBLIC_NAMES)
+def test_evaluation_package_exposes_symbol_with_source_identity(name: str) -> None:
+    assert getattr(abdp.evaluation, name) is EXPECTED_SOURCE_IDENTITY[name]
 
 
 def test_evaluation_package_star_import_yields_exactly_the_public_surface() -> None:


### PR DESCRIPTION
Closes #107

## Summary

Installs the structural-invariant gatekeeper (test framework + empty package skeleton) for `abdp.evaluation`, following the Oracle-recommended **Living Boundary** design: lock the namespace now, extend `EXPECTED_PUBLIC_NAMES` / `EXPECTED_SOURCE_IDENTITY` / `__all__` per symbol in #108–#111.

## TDD Cycle (3 commits)

- **RED** `7493a87` — adds `tests/evaluation/test_evaluation_public_surface.py` with 5 structural-invariant tests over `EXPECTED_PUBLIC_NAMES = ()`.
- **GREEN** `8823a15` — adds `src/abdp/evaluation/__init__.py` (module docstring + `__all__: tuple[str, ...] = ()`). Omits `from __future__ import annotations` to avoid leaking `annotations` into the namespace (Python 3.14 supports `tuple[...]` natively).
- **REFACTOR** `d3147d0` — parametrizes the source-identity test for parity with the agents/scenario surface tests.

## Verification

- `uv run pytest -q` → 539 passed, 1 skipped (empty parametrize), 100% coverage
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 112 files already formatted
- `uv run mypy --strict src tests` → Success