### PR TITLE
feat(evaluation): add Metric protocol and MetricResult record (#108)

### DIFF
--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -1,9 +1,12 @@
 """Public surface for the ``abdp.evaluation`` package.
 
 The evaluation package owns the v0.3 metric, gate, and summary contracts.
-The surface is intentionally empty in #107 so subsequent v0.3 issues can
-extend ``__all__`` symbol-by-symbol against the frozen surface test in
-``tests/evaluation/test_evaluation_public_surface.py``.
+Symbols are added to ``__all__`` issue by issue against the frozen surface
+test in ``tests/evaluation/test_evaluation_public_surface.py``.
 """
 
-__all__: tuple[str, ...] = ()
+from abdp.evaluation.metric import Metric, MetricResult
+
+globals().pop("metric", None)
+
+__all__: tuple[str, ...] = ("Metric", "MetricResult")

--- a/src/abdp/evaluation/metric.py
+++ b/src/abdp/evaluation/metric.py
@@ -1,0 +1,36 @@
+"""``Metric`` protocol and ``MetricResult`` record exposed by ``abdp.evaluation``.
+
+A ``Metric`` reduces a run record (whose concrete type is supplied by the
+caller via the ``R`` type parameter) into a single ``MetricResult``. The
+``value`` field of ``MetricResult`` MUST be JSON-serializable per
+``abdp.core.types.JsonValue``; ``details`` is a JSON object carrying optional
+auxiliary evidence such as per-segment breakdowns.
+"""
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from abdp.core.types import JsonObject, JsonValue
+
+__all__ = ["Metric", "MetricResult"]
+
+
+@dataclass(frozen=True, slots=True)
+class MetricResult:
+    """Outcome of evaluating a single :class:`Metric` against a run."""
+
+    metric_id: str
+    value: JsonValue
+    details: JsonObject
+
+
+@runtime_checkable
+class Metric[R](Protocol):
+    """Reduces a run record of type ``R`` into a :class:`MetricResult`."""
+
+    metric_id: str
+
+    def evaluate(self, run: R) -> MetricResult:
+        """Return the metric's :class:`MetricResult` for ``run``."""
+
+        ...  # pragma: no cover

--- a/src/abdp/evaluation/metric.py
+++ b/src/abdp/evaluation/metric.py
@@ -17,7 +17,13 @@ __all__ = ["Metric", "MetricResult"]
 
 @dataclass(frozen=True, slots=True)
 class MetricResult:
-    """Outcome of evaluating a single :class:`Metric` against a run."""
+    """Outcome of evaluating a single :class:`Metric` against a run.
+
+    ``value`` and ``details`` MUST be JSON-serializable. Callers can verify
+    a candidate ``value`` with :func:`abdp.core.types.is_json_value` before
+    constructing the result; the dataclass itself does not enforce this so
+    that ``MetricResult`` stays cheap to build inside hot evaluation loops.
+    """
 
     metric_id: str
     value: JsonValue

--- a/tests/evaluation/test_evaluation_public_surface.py
+++ b/tests/evaluation/test_evaluation_public_surface.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import abdp.evaluation
 import pytest
+from abdp.evaluation.metric import Metric, MetricResult
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("Metric", "MetricResult")
 
-EXPECTED_SOURCE_IDENTITY: dict[str, object] = {}
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "Metric": Metric,
+    "MetricResult": MetricResult,
+}
 
 
 def test_evaluation_package_all_lists_exact_expected_symbols() -> None:

--- a/tests/evaluation/test_metric.py
+++ b/tests/evaluation/test_metric.py
@@ -1,0 +1,73 @@
+"""Structural tests for ``abdp.evaluation.Metric`` and ``MetricResult``."""
+
+import dataclasses
+from typing import Any, cast, get_type_hints
+
+import pytest
+
+from abdp.evaluation import Metric, MetricResult
+
+
+def test_metric_is_protocol() -> None:
+    assert cast(Any, Metric)._is_protocol is True
+
+
+def test_metric_is_runtime_checkable() -> None:
+    class _Impl:
+        agent_id: str = "ignored"
+        metric_id: str = "m"
+
+        def evaluate(self, run: object) -> MetricResult:
+            return MetricResult(metric_id="m", value=0, details={})
+
+    assert isinstance(_Impl(), Metric)
+
+
+def test_metric_rejects_non_conforming_object_at_runtime() -> None:
+    class _NotMetric:
+        pass
+
+    assert not isinstance(_NotMetric(), Metric)
+
+
+def test_metric_declares_metric_id_and_evaluate() -> None:
+    annotations = get_type_hints(Metric)
+    assert annotations["metric_id"] is str
+    assert callable(Metric.evaluate)
+
+
+def test_metric_result_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(MetricResult)
+    params = cast(Any, MetricResult).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_metric_result_uses_slots() -> None:
+    assert "__slots__" in vars(MetricResult)
+
+
+def test_metric_result_field_order_and_types() -> None:
+    fields = dataclasses.fields(MetricResult)
+    assert [f.name for f in fields] == ["metric_id", "value", "details"]
+    annotations = get_type_hints(MetricResult)
+    assert annotations["metric_id"] is str
+
+
+def test_metric_result_requires_all_fields() -> None:
+    for field in dataclasses.fields(MetricResult):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_metric_result_is_immutable() -> None:
+    result = MetricResult(metric_id="m", value=1, details={})
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(result, "metric_id", "other")  # noqa: B010
+
+
+def test_metric_result_equality_is_value_based() -> None:
+    a = MetricResult(metric_id="m", value=1, details={"k": "v"})
+    b = MetricResult(metric_id="m", value=1, details={"k": "v"})
+    c = MetricResult(metric_id="m", value=2, details={"k": "v"})
+    assert a == b
+    assert a != c


### PR DESCRIPTION
Closes #108

## Summary

Adds the first concrete v0.3 evaluation symbols on top of the surface frozen in #107: a runtime-checkable `Metric[R]` protocol and a frozen `MetricResult` record.

## Design (per Oracle consult)

- `Metric[R]` is generic over the run-record type `R`, deferring binding to later issues that introduce concrete run records — no `Any`, no premature coupling, no later churn.
- `MetricResult` is `@dataclass(frozen=True, slots=True)` with `metric_id: str`, `value: JsonValue`, `details: JsonObject`. All fields required (no defaults).
- JSON-serializability is documented as a caller-side contract; no `__post_init__` validation, keeping construction cheap inside hot evaluation loops. Callers may use `abdp.core.types.is_json_value` to validate.
- Hashability is intentionally not asserted — `JsonObject` carries dicts/lists, which are not safely hashable.

## TDD Cycle

- **RED** `58f06ba` — adds `tests/evaluation/test_metric.py` (10 structural tests) and extends `EXPECTED_PUBLIC_NAMES` / `EXPECTED_SOURCE_IDENTITY` in the surface freeze.
- **GREEN** `36737c3` — adds `src/abdp/evaluation/metric.py` and exports both symbols via `src/abdp/evaluation/__init__.py` following the established package-init pattern.
- **REFACTOR** `218f3f9` — strengthens the `MetricResult` class docstring with the JSON-serializability contract and a pointer to `is_json_value`.

## Verification

- `uv run pytest -q` → 551 passed, 100% coverage
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 114 files already formatted
- `uv run mypy --strict src tests` → Success