### PR TITLE
feat(evaluation): add ordered evaluate_metrics helper (#109)

### DIFF
--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -5,8 +5,8 @@ Symbols are added to ``__all__`` issue by issue against the frozen surface
 test in ``tests/evaluation/test_evaluation_public_surface.py``.
 """
 
-from abdp.evaluation.metric import Metric, MetricResult
+from abdp.evaluation.metric import Metric, MetricResult, evaluate_metrics
 
 globals().pop("metric", None)
 
-__all__: tuple[str, ...] = ("Metric", "MetricResult")
+__all__: tuple[str, ...] = ("Metric", "MetricResult", "evaluate_metrics")

--- a/src/abdp/evaluation/metric.py
+++ b/src/abdp/evaluation/metric.py
@@ -7,12 +7,13 @@ caller via the ``R`` type parameter) into a single ``MetricResult``. The
 auxiliary evidence such as per-segment breakdowns.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from abdp.core.types import JsonObject, JsonValue
 
-__all__ = ["Metric", "MetricResult"]
+__all__ = ["Metric", "MetricResult", "evaluate_metrics"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,3 +41,15 @@ class Metric[R](Protocol):
         """Return the metric's :class:`MetricResult` for ``run``."""
 
         ...  # pragma: no cover
+
+
+def evaluate_metrics[R](metrics: Iterable[Metric[R]], run: R) -> tuple[MetricResult, ...]:
+    """Evaluate ``metrics`` against ``run`` and return their results in iteration order.
+
+    The output tuple's order matches the iteration order of ``metrics``; results
+    are deterministic when both the iterable and each metric's ``evaluate``
+    are deterministic for the same ``run``. The helper does not detect
+    duplicate ``metric_id`` values.
+    """
+
+    return tuple(metric.evaluate(run) for metric in metrics)

--- a/src/abdp/evaluation/metric.py
+++ b/src/abdp/evaluation/metric.py
@@ -46,10 +46,11 @@ class Metric[R](Protocol):
 def evaluate_metrics[R](metrics: Iterable[Metric[R]], run: R) -> tuple[MetricResult, ...]:
     """Evaluate ``metrics`` against ``run`` and return their results in iteration order.
 
-    The output tuple's order matches the iteration order of ``metrics``; results
-    are deterministic when both the iterable and each metric's ``evaluate``
-    are deterministic for the same ``run``. The helper does not detect
-    duplicate ``metric_id`` values.
+    Each metric's :meth:`Metric.evaluate` is invoked exactly once with ``run``,
+    in the order produced by iterating ``metrics``. The output tuple mirrors
+    that order, so results are deterministic when both the iterable and each
+    metric's ``evaluate`` are deterministic for the same ``run``. The helper
+    does not detect duplicate ``metric_id`` values.
     """
 
     return tuple(metric.evaluate(run) for metric in metrics)

--- a/tests/evaluation/test_evaluate_metrics.py
+++ b/tests/evaluation/test_evaluate_metrics.py
@@ -1,0 +1,77 @@
+"""Tests for ``abdp.evaluation.evaluate_metrics`` ordered helper."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+from abdp.evaluation import MetricResult, evaluate_metrics
+
+
+@dataclass
+class _RecordingMetric:
+    metric_id: str
+    value: int
+    calls: list[object] = field(default_factory=list)
+
+    def evaluate(self, run: object) -> MetricResult:
+        self.calls.append(run)
+        return MetricResult(metric_id=self.metric_id, value=self.value, details={})
+
+
+def _expected(metrics: list[_RecordingMetric]) -> tuple[MetricResult, ...]:
+    return tuple(MetricResult(metric_id=m.metric_id, value=m.value, details={}) for m in metrics)
+
+
+def test_evaluate_metrics_returns_tuple() -> None:
+    result = evaluate_metrics([], run=object())
+    assert isinstance(result, tuple)
+
+
+def test_evaluate_metrics_empty_input_returns_empty_tuple() -> None:
+    assert evaluate_metrics([], run=object()) == ()
+
+
+def test_evaluate_metrics_preserves_input_order() -> None:
+    metrics = [
+        _RecordingMetric(metric_id="b", value=2),
+        _RecordingMetric(metric_id="a", value=1),
+        _RecordingMetric(metric_id="c", value=3),
+    ]
+    run = object()
+    assert evaluate_metrics(metrics, run=run) == _expected(metrics)
+
+
+def test_evaluate_metrics_calls_each_metric_exactly_once() -> None:
+    metrics = [
+        _RecordingMetric(metric_id="a", value=1),
+        _RecordingMetric(metric_id="b", value=2),
+    ]
+    run = object()
+    evaluate_metrics(metrics, run=run)
+    for m in metrics:
+        assert m.calls == [run]
+
+
+def test_evaluate_metrics_accepts_generator_input() -> None:
+    metrics = [
+        _RecordingMetric(metric_id="a", value=1),
+        _RecordingMetric(metric_id="b", value=2),
+    ]
+    run = object()
+
+    def gen() -> Iterator[_RecordingMetric]:
+        yield from metrics
+
+    assert evaluate_metrics(gen(), run=run) == _expected(metrics)
+
+
+def test_evaluate_metrics_is_deterministic_across_repeated_calls() -> None:
+    def make_metrics() -> list[_RecordingMetric]:
+        return [
+            _RecordingMetric(metric_id="a", value=1),
+            _RecordingMetric(metric_id="b", value=2),
+        ]
+
+    run = object()
+    first = evaluate_metrics(make_metrics(), run=run)
+    second = evaluate_metrics(make_metrics(), run=run)
+    assert first == second

--- a/tests/evaluation/test_evaluation_public_surface.py
+++ b/tests/evaluation/test_evaluation_public_surface.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import abdp.evaluation
 import pytest
-from abdp.evaluation.metric import Metric, MetricResult
+from abdp.evaluation.metric import Metric, MetricResult, evaluate_metrics
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("Metric", "MetricResult")
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("Metric", "MetricResult", "evaluate_metrics")
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
     "Metric": Metric,
     "MetricResult": MetricResult,
+    "evaluate_metrics": evaluate_metrics,
 }
 
 


### PR DESCRIPTION
Closes #109

## Summary

Adds `evaluate_metrics(metrics, run) -> tuple[MetricResult, ...]` to `abdp.evaluation`. The helper centralizes the ordered, exactly-once evaluation contract so downstream consumers (gates, summaries, evidence) get a stable tuple shape without duplicating loop semantics.

## Design (per Oracle consult)

- Signature: `def evaluate_metrics[R](metrics: Iterable[Metric[R]], run: R) -> tuple[MetricResult, ...]` — `Iterable` is the smallest contract that supports generator inputs.
- Order: output mirrors the iteration order of `metrics`.
- Determinism: holds when the iterable and each metric's `evaluate` are deterministic for the same `run`. No randomness, no parallelism.
- Empty input → `()`.
- No duplicate-`metric_id` detection (separable concern; deferred).
- No `__post_init__`-style validation; helper stays cheap inside hot loops.

## TDD Cycle

- **RED** `7236e81` — adds `tests/evaluation/test_evaluate_metrics.py` (6 tests: tuple return, empty input, order preservation, exactly-once invocation, generator acceptance, repeated-call determinism) and extends the surface freeze.
- **GREEN** `fee42cf` — adds `evaluate_metrics` to `src/abdp/evaluation/metric.py` and re-exports via `src/abdp/evaluation/__init__.py`.
- **REFACTOR** — strengthens helper docstring with the exactly-once-evaluation guarantee.

## Verification

- `uv run pytest -q` → 558 passed, 100% coverage
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 115 files already formatted
- `uv run mypy --strict src tests` → Success