### PR TITLE
feat(evaluation): add Gate protocol, GateResult, and GateStatus (#110)

### DIFF
--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -5,8 +5,17 @@ Symbols are added to ``__all__`` issue by issue against the frozen surface
 test in ``tests/evaluation/test_evaluation_public_surface.py``.
 """
 
+from abdp.evaluation.gate import Gate, GateResult, GateStatus
 from abdp.evaluation.metric import Metric, MetricResult, evaluate_metrics
 
+globals().pop("gate", None)
 globals().pop("metric", None)
 
-__all__: tuple[str, ...] = ("Metric", "MetricResult", "evaluate_metrics")
+__all__: tuple[str, ...] = (
+    "Gate",
+    "GateResult",
+    "GateStatus",
+    "Metric",
+    "MetricResult",
+    "evaluate_metrics",
+)

--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -1,8 +1,10 @@
 """Public surface for the ``abdp.evaluation`` package.
 
 The evaluation package owns the v0.3 metric, gate, and summary contracts.
-Symbols are added to ``__all__`` issue by issue against the frozen surface
-test in ``tests/evaluation/test_evaluation_public_surface.py``.
+The pipeline is :func:`evaluate_metrics` -> tuple of :class:`MetricResult`
+-> :class:`Gate` -> :class:`GateResult`. Symbols are added to ``__all__``
+issue by issue against the frozen surface test in
+``tests/evaluation/test_evaluation_public_surface.py``.
 """
 
 from abdp.evaluation.gate import Gate, GateResult, GateStatus

--- a/src/abdp/evaluation/gate.py
+++ b/src/abdp/evaluation/gate.py
@@ -1,0 +1,57 @@
+"""``Gate`` protocol, ``GateResult`` record, and ``GateStatus`` enum exposed by ``abdp.evaluation``.
+
+A ``Gate`` reduces an iterable of :class:`MetricResult` (typically produced by
+:func:`evaluate_metrics`) into a single :class:`GateResult`. The
+``GateResult.details`` field MUST be JSON-serializable per
+``abdp.core.types.JsonValue``; ``GateStatus`` values are lowercase strings
+(``"pass"``/``"fail"``/``"warn"``) so a ``GateResult`` round-trips cleanly
+through JSON. The dataclass itself does not enforce JSON-validity so that
+``GateResult`` stays cheap to build inside hot evaluation loops.
+"""
+
+import enum
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from abdp.core.types import JsonObject
+from abdp.evaluation.metric import MetricResult
+
+__all__ = ["Gate", "GateResult", "GateStatus"]
+
+
+class GateStatus(enum.StrEnum):
+    """Outcome category emitted by a :class:`Gate`.
+
+    Values are lowercase strings to keep :class:`GateResult` JSON-friendly.
+    """
+
+    PASS = "pass"
+    FAIL = "fail"
+    WARN = "warn"
+
+
+@dataclass(frozen=True, slots=True)
+class GateResult:
+    """Outcome of evaluating a single :class:`Gate` against metric results.
+
+    ``details`` MUST be JSON-serializable. ``reason`` is a free-form
+    human-readable string explaining ``status``.
+    """
+
+    gate_id: str
+    status: GateStatus
+    reason: str
+    details: JsonObject
+
+
+@runtime_checkable
+class Gate(Protocol):
+    """Reduces an iterable of :class:`MetricResult` into a :class:`GateResult`."""
+
+    gate_id: str
+
+    def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
+        """Return the gate's :class:`GateResult` for ``metrics``."""
+
+        ...  # pragma: no cover

--- a/tests/evaluation/test_evaluation_public_surface.py
+++ b/tests/evaluation/test_evaluation_public_surface.py
@@ -4,11 +4,22 @@ from __future__ import annotations
 
 import abdp.evaluation
 import pytest
+from abdp.evaluation.gate import Gate, GateResult, GateStatus
 from abdp.evaluation.metric import Metric, MetricResult, evaluate_metrics
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("Metric", "MetricResult", "evaluate_metrics")
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
+    "Gate",
+    "GateResult",
+    "GateStatus",
+    "Metric",
+    "MetricResult",
+    "evaluate_metrics",
+)
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "Gate": Gate,
+    "GateResult": GateResult,
+    "GateStatus": GateStatus,
     "Metric": Metric,
     "MetricResult": MetricResult,
     "evaluate_metrics": evaluate_metrics,

--- a/tests/evaluation/test_gate.py
+++ b/tests/evaluation/test_gate.py
@@ -1,0 +1,90 @@
+"""Structural tests for ``abdp.evaluation.Gate``, ``GateResult``, and ``GateStatus``."""
+
+import dataclasses
+import enum
+from collections.abc import Iterable
+from typing import Any, cast, get_type_hints
+
+import pytest
+
+from abdp.evaluation import Gate, GateResult, GateStatus, MetricResult
+
+
+def test_gate_status_is_str_enum() -> None:
+    assert issubclass(GateStatus, enum.StrEnum)
+
+
+def test_gate_status_has_exactly_pass_fail_warn() -> None:
+    assert {member.name for member in GateStatus} == {"PASS", "FAIL", "WARN"}
+
+
+def test_gate_status_uses_lowercase_string_values() -> None:
+    assert GateStatus.PASS.value == "pass"
+    assert GateStatus.FAIL.value == "fail"
+    assert GateStatus.WARN.value == "warn"
+
+
+def test_gate_is_protocol() -> None:
+    assert cast(Any, Gate)._is_protocol is True
+
+
+def test_gate_is_runtime_checkable() -> None:
+    class _Impl:
+        gate_id: str = "g"
+
+        def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
+            return GateResult(gate_id="g", status=GateStatus.PASS, reason="ok", details={})
+
+    assert isinstance(_Impl(), Gate)
+
+
+def test_gate_rejects_non_conforming_object_at_runtime() -> None:
+    class _NotGate:
+        pass
+
+    assert not isinstance(_NotGate(), Gate)
+
+
+def test_gate_declares_gate_id_and_evaluate() -> None:
+    annotations = get_type_hints(Gate)
+    assert annotations["gate_id"] is str
+    assert callable(Gate.evaluate)
+
+
+def test_gate_result_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(GateResult)
+    params = cast(Any, GateResult).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_gate_result_uses_slots() -> None:
+    assert "__slots__" in vars(GateResult)
+
+
+def test_gate_result_field_order_and_types() -> None:
+    fields = dataclasses.fields(GateResult)
+    assert [f.name for f in fields] == ["gate_id", "status", "reason", "details"]
+    annotations = get_type_hints(GateResult)
+    assert annotations["gate_id"] is str
+    assert annotations["status"] is GateStatus
+    assert annotations["reason"] is str
+
+
+def test_gate_result_requires_all_fields() -> None:
+    for field in dataclasses.fields(GateResult):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_gate_result_is_immutable() -> None:
+    result = GateResult(gate_id="g", status=GateStatus.PASS, reason="ok", details={})
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(result, "gate_id", "other")  # noqa: B010
+
+
+def test_gate_result_equality_is_value_based() -> None:
+    a = GateResult(gate_id="g", status=GateStatus.PASS, reason="ok", details={"k": "v"})
+    b = GateResult(gate_id="g", status=GateStatus.PASS, reason="ok", details={"k": "v"})
+    c = GateResult(gate_id="g", status=GateStatus.FAIL, reason="ok", details={"k": "v"})
+    assert a == b
+    assert a != c


### PR DESCRIPTION
Closes #110.

## Summary
- Add `GateStatus` (StrEnum: PASS/FAIL/WARN with lowercase JSON values).
- Add `GateResult` frozen+slots dataclass: `gate_id`, `status`, `reason`, `details` (all required).
- Add `Gate` runtime-checkable Protocol: `gate_id: str`, `evaluate(metrics: Iterable[MetricResult]) -> GateResult`.
- Extend `abdp.evaluation.__all__` and frozen surface test.
- Document the metric -> gate pipeline in the package docstring.

## TDD Cycle
- RED `b6b9b10`: 13 structural tests + extended surface test.
- GREEN `23b54aa`: implement `gate.py`, wire into package init.
- REFACTOR `90160ef`: docstring polish only.

## Verification
- `uv run pytest -q` -> 574 passed, 100% coverage.
- `uv run ruff check . && uv run ruff format --check .` -> clean.
- `uv run mypy --strict src tests` -> clean.

Per Oracle design consult (10/10 questions APPROVED).