### PR TITLE
feat(evaluation): add EvaluationSummary, evaluate_gates, and aggregate_results (#111)

### DIFF
--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -1,9 +1,10 @@
 """Public surface for the ``abdp.evaluation`` package.
 
-The evaluation package owns the v0.3 metric, gate, and summary contracts.
-The pipeline is :func:`evaluate_metrics` -> tuple of :class:`MetricResult`
--> :class:`Gate` -> :class:`GateResult`. Symbols are added to ``__all__``
-issue by issue against the frozen surface test in
+The evaluation package owns the metric, gate, and summary contracts. The
+pipeline is :func:`evaluate_metrics` -> tuple of :class:`MetricResult` ->
+:func:`evaluate_gates` -> tuple of :class:`GateResult` ->
+:func:`aggregate_results` -> :class:`EvaluationSummary`. Symbols are added
+to ``__all__`` issue by issue against the frozen surface test in
 ``tests/evaluation/test_evaluation_public_surface.py``.
 """
 

--- a/src/abdp/evaluation/__init__.py
+++ b/src/abdp/evaluation/__init__.py
@@ -9,15 +9,20 @@ issue by issue against the frozen surface test in
 
 from abdp.evaluation.gate import Gate, GateResult, GateStatus
 from abdp.evaluation.metric import Metric, MetricResult, evaluate_metrics
+from abdp.evaluation.summary import EvaluationSummary, aggregate_results, evaluate_gates
 
 globals().pop("gate", None)
 globals().pop("metric", None)
+globals().pop("summary", None)
 
 __all__: tuple[str, ...] = (
+    "EvaluationSummary",
     "Gate",
     "GateResult",
     "GateStatus",
     "Metric",
     "MetricResult",
+    "aggregate_results",
+    "evaluate_gates",
     "evaluate_metrics",
 )

--- a/src/abdp/evaluation/summary.py
+++ b/src/abdp/evaluation/summary.py
@@ -1,0 +1,67 @@
+"""``EvaluationSummary`` record and ``evaluate_gates`` / ``aggregate_results`` helpers exposed by ``abdp.evaluation``.
+
+The summary stage closes the metric -> gate -> summary pipeline:
+:func:`evaluate_gates` reduces metric results into gate results, and
+:func:`aggregate_results` folds metrics and gate results into a single
+:class:`EvaluationSummary` whose ``overall_status`` follows the
+``FAIL > WARN > PASS`` precedence (empty gates yield ``PASS``).
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from abdp.evaluation.gate import Gate, GateResult, GateStatus
+from abdp.evaluation.metric import MetricResult
+
+__all__ = ["EvaluationSummary", "aggregate_results", "evaluate_gates"]
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationSummary:
+    """Frozen result of an evaluation run.
+
+    ``metrics`` and ``gates`` preserve the iteration order of their producing
+    helpers (:func:`abdp.evaluation.evaluate_metrics` and
+    :func:`evaluate_gates`); ``overall_status`` is the precedence-reduced
+    status across ``gates``.
+    """
+
+    metrics: tuple[MetricResult, ...]
+    gates: tuple[GateResult, ...]
+    overall_status: GateStatus
+
+
+def evaluate_gates(gates: Iterable[Gate], metrics: Iterable[MetricResult]) -> tuple[GateResult, ...]:
+    """Evaluate ``gates`` against ``metrics`` and return their results in iteration order.
+
+    ``metrics`` is materialized into a tuple once so every gate sees the same
+    sequence; each gate's :meth:`Gate.evaluate` is invoked exactly once with
+    that tuple. The output tuple mirrors the iteration order of ``gates``.
+    The helper does not detect duplicate ``gate_id`` values.
+    """
+
+    materialized = tuple(metrics)
+    return tuple(gate.evaluate(materialized) for gate in gates)
+
+
+def aggregate_results(metrics: Iterable[MetricResult], gate_results: Iterable[GateResult]) -> EvaluationSummary:
+    """Aggregate ``metrics`` and ``gate_results`` into an :class:`EvaluationSummary`.
+
+    Inputs are materialized into tuples so the summary stores stable values.
+    ``overall_status`` follows ``FAIL > WARN > PASS`` precedence over
+    ``gate_results``; an empty ``gate_results`` yields :attr:`GateStatus.PASS`.
+    """
+
+    metrics_tuple = tuple(metrics)
+    gates_tuple = tuple(gate_results)
+    overall_status = _reduce_status(gates_tuple)
+    return EvaluationSummary(metrics=metrics_tuple, gates=gates_tuple, overall_status=overall_status)
+
+
+def _reduce_status(gate_results: tuple[GateResult, ...]) -> GateStatus:
+    statuses = {result.status for result in gate_results}
+    if GateStatus.FAIL in statuses:
+        return GateStatus.FAIL
+    if GateStatus.WARN in statuses:
+        return GateStatus.WARN
+    return GateStatus.PASS

--- a/tests/evaluation/test_evaluation_public_surface.py
+++ b/tests/evaluation/test_evaluation_public_surface.py
@@ -6,22 +6,29 @@ import abdp.evaluation
 import pytest
 from abdp.evaluation.gate import Gate, GateResult, GateStatus
 from abdp.evaluation.metric import Metric, MetricResult, evaluate_metrics
+from abdp.evaluation.summary import EvaluationSummary, aggregate_results, evaluate_gates
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
+    "EvaluationSummary",
     "Gate",
     "GateResult",
     "GateStatus",
     "Metric",
     "MetricResult",
+    "aggregate_results",
+    "evaluate_gates",
     "evaluate_metrics",
 )
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "EvaluationSummary": EvaluationSummary,
     "Gate": Gate,
     "GateResult": GateResult,
     "GateStatus": GateStatus,
     "Metric": Metric,
     "MetricResult": MetricResult,
+    "aggregate_results": aggregate_results,
+    "evaluate_gates": evaluate_gates,
     "evaluate_metrics": evaluate_metrics,
 }
 

--- a/tests/evaluation/test_summary.py
+++ b/tests/evaluation/test_summary.py
@@ -1,0 +1,169 @@
+"""Structural and behavioral tests for ``abdp.evaluation`` summary stage."""
+
+import dataclasses
+from typing import Any, cast, get_type_hints
+
+from abdp.evaluation import (
+    EvaluationSummary,
+    Gate,
+    GateResult,
+    GateStatus,
+    MetricResult,
+    aggregate_results,
+    evaluate_gates,
+)
+
+
+def _metric(metric_id: str = "m") -> MetricResult:
+    return MetricResult(metric_id=metric_id, value=1, details={})
+
+
+def _gate_result(gate_id: str = "g", status: GateStatus = GateStatus.PASS) -> GateResult:
+    return GateResult(gate_id=gate_id, status=status, reason="ok", details={})
+
+
+class _StaticGate:
+    def __init__(self, gate_id: str, status: GateStatus = GateStatus.PASS) -> None:
+        self.gate_id = gate_id
+        self._status = status
+        self.calls = 0
+
+    def evaluate(self, metrics: object) -> GateResult:
+        self.calls += 1
+        return GateResult(gate_id=self.gate_id, status=self._status, reason="ok", details={})
+
+
+def test_evaluation_summary_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(EvaluationSummary)
+    params = cast(Any, EvaluationSummary).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_evaluation_summary_uses_slots() -> None:
+    assert "__slots__" in vars(EvaluationSummary)
+
+
+def test_evaluation_summary_field_order_and_types() -> None:
+    fields = dataclasses.fields(EvaluationSummary)
+    assert [f.name for f in fields] == ["metrics", "gates", "overall_status"]
+    annotations = get_type_hints(EvaluationSummary)
+    assert annotations["overall_status"] is GateStatus
+
+
+def test_evaluation_summary_requires_all_fields() -> None:
+    for field in dataclasses.fields(EvaluationSummary):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_evaluate_gates_returns_tuple_in_input_order() -> None:
+    g1 = _StaticGate("a")
+    g2 = _StaticGate("b")
+    g3 = _StaticGate("c")
+    results = evaluate_gates([g1, g2, g3], [])
+    assert isinstance(results, tuple)
+    assert [r.gate_id for r in results] == ["a", "b", "c"]
+
+
+def test_evaluate_gates_calls_each_gate_exactly_once() -> None:
+    g1 = _StaticGate("a")
+    g2 = _StaticGate("b")
+    evaluate_gates([g1, g2], [])
+    assert g1.calls == 1
+    assert g2.calls == 1
+
+
+def test_evaluate_gates_materializes_metrics_iterable_for_reuse() -> None:
+    metrics_iter = iter([_metric("m1"), _metric("m2")])
+
+    seen: list[tuple[MetricResult, ...]] = []
+
+    class _Recorder:
+        gate_id = "r"
+
+        def evaluate(self, metrics: Any) -> GateResult:
+            seen.append(tuple(metrics))
+            return _gate_result(self.gate_id)
+
+    g1 = _Recorder()
+    g2 = _Recorder()
+    evaluate_gates([g1, g2], metrics_iter)
+    assert len(seen) == 2
+    assert seen[0] == seen[1]
+    assert len(seen[0]) == 2
+
+
+def test_evaluate_gates_accepts_iterable_of_gates() -> None:
+    def gates_iter() -> Any:
+        yield _StaticGate("only")
+
+    results = evaluate_gates(gates_iter(), [])
+    assert [r.gate_id for r in results] == ["only"]
+
+
+def test_evaluate_gates_accepts_empty_inputs() -> None:
+    assert evaluate_gates([], []) == ()
+
+
+def test_evaluate_gates_runtime_signature_satisfies_gate_protocol() -> None:
+    g = _StaticGate("x")
+    assert isinstance(g, Gate)
+
+
+def test_aggregate_results_returns_evaluation_summary() -> None:
+    summary = aggregate_results([_metric("m1")], [_gate_result("g1")])
+    assert isinstance(summary, EvaluationSummary)
+
+
+def test_aggregate_results_materializes_inputs_to_tuples() -> None:
+    summary = aggregate_results(iter([_metric("m1")]), iter([_gate_result("g1")]))
+    assert isinstance(summary.metrics, tuple)
+    assert isinstance(summary.gates, tuple)
+    assert summary.metrics == (_metric("m1"),)
+    assert summary.gates == (_gate_result("g1"),)
+
+
+def test_aggregate_results_preserves_input_order() -> None:
+    metrics = [_metric("m1"), _metric("m2"), _metric("m3")]
+    gates = [_gate_result("g1"), _gate_result("g2")]
+    summary = aggregate_results(metrics, gates)
+    assert [m.metric_id for m in summary.metrics] == ["m1", "m2", "m3"]
+    assert [g.gate_id for g in summary.gates] == ["g1", "g2"]
+
+
+def test_aggregate_results_empty_gates_yields_pass() -> None:
+    summary = aggregate_results([], [])
+    assert summary.overall_status is GateStatus.PASS
+
+
+def test_aggregate_results_all_pass_yields_pass() -> None:
+    summary = aggregate_results(
+        [],
+        [_gate_result("g1", GateStatus.PASS), _gate_result("g2", GateStatus.PASS)],
+    )
+    assert summary.overall_status is GateStatus.PASS
+
+
+def test_aggregate_results_warn_outranks_pass() -> None:
+    summary = aggregate_results(
+        [],
+        [_gate_result("g1", GateStatus.PASS), _gate_result("g2", GateStatus.WARN)],
+    )
+    assert summary.overall_status is GateStatus.WARN
+
+
+def test_aggregate_results_fail_outranks_warn_and_pass() -> None:
+    summary = aggregate_results(
+        [],
+        [
+            _gate_result("g1", GateStatus.PASS),
+            _gate_result("g2", GateStatus.WARN),
+            _gate_result("g3", GateStatus.FAIL),
+        ],
+    )
+    assert summary.overall_status is GateStatus.FAIL
+
+
+def test_aggregate_results_fail_alone_yields_fail() -> None:
+    summary = aggregate_results([], [_gate_result("g1", GateStatus.FAIL)])
+    assert summary.overall_status is GateStatus.FAIL


### PR DESCRIPTION
Closes #111.

## Summary
- Add `EvaluationSummary` (frozen+slots: `metrics`, `gates`, `overall_status`).
- Add `evaluate_gates(gates, metrics) -> tuple[GateResult, ...]` materializing metrics once for safe re-iteration across gates.
- Add `aggregate_results(metrics, gate_results) -> EvaluationSummary` with `FAIL > WARN > PASS` precedence; empty gates yield PASS.
- Extend `abdp.evaluation.__all__` and frozen surface gatekeeper.
- Document the metric -> gate -> summary pipeline in the package docstring.

## TDD Cycle
- RED `a3575b0`: 18 tests covering structure, ordering, exactly-once, materialization, precedence, empty handling.
- GREEN `959933f`: implement `summary.py`, wire into init.
- REFACTOR `b90b24b`: docstring polish only.

## Verification
- `uv run pytest -q` -> 595 passed, 100% coverage.
- `uv run ruff check . && uv run ruff format --check .` -> clean.
- `uv run mypy --strict src tests` -> clean.

Per Oracle design consult (10 APPROVED + 1 partial: docstring scope narrowed).