### PR TITLE
test(evidence): freeze empty abdp.evidence public surface (#112)

### DIFF
--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -1,0 +1,9 @@
+"""Public surface for the ``abdp.evidence`` package.
+
+The evidence package owns the evidence record, claim record, audit log,
+and store contracts. Symbols are added to ``__all__`` issue by issue
+against the frozen surface test in
+``tests/evidence/test_evidence_public_surface.py``.
+"""
+
+__all__: tuple[str, ...] = ()

--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -1,7 +1,7 @@
 """Public surface for the ``abdp.evidence`` package.
 
 The evidence package owns the evidence record, claim record, audit log,
-and store contracts. Symbols are added to ``__all__`` issue by issue
+and store contracts. Exports are added to ``__all__`` issue by issue
 against the frozen surface test in
 ``tests/evidence/test_evidence_public_surface.py``.
 """

--- a/tests/evidence/test_evidence_public_surface.py
+++ b/tests/evidence/test_evidence_public_surface.py
@@ -1,0 +1,39 @@
+"""Frozen public surface of the ``abdp.evidence`` package."""
+
+from __future__ import annotations
+
+import abdp.evidence
+import pytest
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
+
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {}
+
+
+def test_evidence_package_all_lists_exact_expected_symbols() -> None:
+    assert isinstance(abdp.evidence.__all__, tuple)
+    assert all(isinstance(name, str) for name in abdp.evidence.__all__)
+    assert abdp.evidence.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+@pytest.mark.parametrize("name", EXPECTED_PUBLIC_NAMES)
+def test_evidence_package_exposes_symbol_with_source_identity(name: str) -> None:
+    assert getattr(abdp.evidence, name) is EXPECTED_SOURCE_IDENTITY[name]
+
+
+def test_evidence_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.evidence import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_evidence_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.evidence) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_evidence_package_has_module_docstring() -> None:
+    doc = abdp.evidence.__doc__
+    assert isinstance(doc, str)
+    assert doc.strip()


### PR DESCRIPTION
Closes #112.

## Summary
- Create empty `abdp.evidence` package with module docstring + `__all__: tuple[str, ...] = ()`.
- Add 5-test surface gatekeeper mirroring `test_evaluation_public_surface.py`.
- Add `tests/evidence/__init__.py` per repo convention.

## TDD Cycle
- RED: failing surface tests (ModuleNotFoundError).
- GREEN: package skeleton with frozen empty surface.
- REFACTOR: docstring wording alignment.

## Verification
- 599 passed, 1 skipped (empty parametrize), 100% coverage, ruff/mypy clean.
- CI awaiting.

Per Oracle design consult: APPROVED 4/5 (Q2 rejected — no future-symbol listing in skeleton docstring).