### PR TITLE
feat(evidence): add EvidenceRecord and make_evidence_record (#113)

### DIFF
--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -1,9 +1,11 @@
 """Public surface for the ``abdp.evidence`` package.
 
 The evidence package owns the evidence record, claim record, audit log,
-and store contracts. Exports are added to ``__all__`` issue by issue
-against the frozen surface test in
-``tests/evidence/test_evidence_public_surface.py``.
+and store contracts. The evidence record stage is the first concrete
+export: :class:`EvidenceRecord` and :func:`make_evidence_record` provide
+deterministic identity for atomic facts captured during a run. Further
+exports are added to ``__all__`` issue by issue against the frozen
+surface test in ``tests/evidence/test_evidence_public_surface.py``.
 """
 
 from abdp.evidence.record import EvidenceRecord, make_evidence_record

--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -6,4 +6,8 @@ against the frozen surface test in
 ``tests/evidence/test_evidence_public_surface.py``.
 """
 
-__all__: tuple[str, ...] = ()
+from abdp.evidence.record import EvidenceRecord, make_evidence_record
+
+globals().pop("record", None)
+
+__all__: tuple[str, ...] = ("EvidenceRecord", "make_evidence_record")

--- a/src/abdp/evidence/record.py
+++ b/src/abdp/evidence/record.py
@@ -1,0 +1,69 @@
+"""``EvidenceRecord`` frozen dataclass and ``make_evidence_record`` factory exposed by ``abdp.evidence``.
+
+An ``EvidenceRecord`` is an atomic fact captured during a run. Identity is
+derived deterministically from ``evidence_key`` and ``step_index`` via a
+private namespace UUID, so the same fact captured under the same seed
+always shares an ``evidence_id``. ``created_at`` MUST be a timezone-aware
+UTC ``datetime`` and is validated in ``__post_init__``; ``payload`` MUST
+be JSON-serializable per ``abdp.core.types.JsonValue`` but is not
+runtime-validated.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Final
+from uuid import UUID
+
+from abdp.core.ids import deterministic_uuid
+from abdp.core.types import JsonValue, Seed
+
+__all__ = ["EvidenceRecord", "make_evidence_record"]
+
+_EVIDENCE_NAMESPACE: Final = UUID("6f1f8a78-2c2a-4f3a-8d3a-2b1f0a9e9c01")
+_NAME_SEPARATOR: Final = "\0"
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    """Atomic fact captured during a run."""
+
+    evidence_id: UUID
+    evidence_key: str
+    step_index: int
+    agent_id: str
+    payload: JsonValue
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        tzinfo = self.created_at.tzinfo
+        if tzinfo is None or tzinfo.utcoffset(self.created_at) != timedelta(0):
+            raise ValueError("created_at must be a timezone-aware UTC datetime")
+
+
+def make_evidence_record(
+    *,
+    seed: Seed,
+    evidence_key: str,
+    step_index: int,
+    agent_id: str,
+    payload: JsonValue,
+    created_at: datetime,
+) -> EvidenceRecord:
+    """Build an :class:`EvidenceRecord` with a deterministically derived ``evidence_id``.
+
+    ``evidence_id`` is derived from ``seed``, the private evidence
+    namespace, and ``f"{evidence_key}\\0{step_index}"``; ``agent_id``,
+    ``payload``, and ``created_at`` are metadata and do not influence
+    identity.
+    """
+
+    name = f"{evidence_key}{_NAME_SEPARATOR}{step_index}"
+    evidence_id = deterministic_uuid(seed, _EVIDENCE_NAMESPACE, name)
+    return EvidenceRecord(
+        evidence_id=evidence_id,
+        evidence_key=evidence_key,
+        step_index=step_index,
+        agent_id=agent_id,
+        payload=payload,
+        created_at=created_at,
+    )

--- a/tests/evidence/test_evidence_public_surface.py
+++ b/tests/evidence/test_evidence_public_surface.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import abdp.evidence
 import pytest
+from abdp.evidence.record import EvidenceRecord, make_evidence_record
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("EvidenceRecord", "make_evidence_record")
 
-EXPECTED_SOURCE_IDENTITY: dict[str, object] = {}
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "EvidenceRecord": EvidenceRecord,
+    "make_evidence_record": make_evidence_record,
+}
 
 
 def test_evidence_package_all_lists_exact_expected_symbols() -> None:

--- a/tests/evidence/test_evidence_record.py
+++ b/tests/evidence/test_evidence_record.py
@@ -1,0 +1,183 @@
+"""Tests for ``abdp.evidence.EvidenceRecord`` and ``make_evidence_record``."""
+
+import dataclasses
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any, cast, get_type_hints
+from uuid import UUID
+
+import pytest
+
+from abdp.core.types import Seed
+from abdp.evidence import EvidenceRecord, make_evidence_record
+
+
+def _record(**overrides: Any) -> EvidenceRecord:
+    base: dict[str, Any] = {
+        "evidence_id": UUID("00000000-0000-0000-0000-000000000001"),
+        "evidence_key": "k",
+        "step_index": 0,
+        "agent_id": "agent",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    base.update(overrides)
+    return EvidenceRecord(**base)
+
+
+def test_evidence_record_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(EvidenceRecord)
+    params = cast(Any, EvidenceRecord).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_evidence_record_uses_slots() -> None:
+    assert "__slots__" in vars(EvidenceRecord)
+
+
+def test_evidence_record_field_order_and_types() -> None:
+    fields = dataclasses.fields(EvidenceRecord)
+    assert [f.name for f in fields] == [
+        "evidence_id",
+        "evidence_key",
+        "step_index",
+        "agent_id",
+        "payload",
+        "created_at",
+    ]
+    annotations = get_type_hints(EvidenceRecord)
+    assert annotations["evidence_id"] is UUID
+    assert annotations["evidence_key"] is str
+    assert annotations["step_index"] is int
+    assert annotations["agent_id"] is str
+    assert annotations["created_at"] is datetime
+
+
+def test_evidence_record_requires_all_fields() -> None:
+    for field in dataclasses.fields(EvidenceRecord):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_evidence_record_is_immutable() -> None:
+    rec = _record()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(rec, "evidence_key", "other")  # noqa: B010
+
+
+def test_evidence_record_equality_is_value_based() -> None:
+    a = _record()
+    b = _record()
+    c = _record(evidence_key="other")
+    assert a == b
+    assert a != c
+
+
+def test_evidence_record_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="UTC"):
+        _record(created_at=datetime(2026, 1, 1))
+
+
+def test_evidence_record_rejects_non_utc_timezone() -> None:
+    with pytest.raises(ValueError, match="UTC"):
+        _record(created_at=datetime(2026, 1, 1, tzinfo=timezone(timedelta(hours=9))))
+
+
+def test_evidence_record_accepts_utc_datetime() -> None:
+    rec = _record(created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    assert rec.created_at.tzinfo is UTC
+
+
+def test_make_evidence_record_returns_evidence_record() -> None:
+    rec = make_evidence_record(
+        seed=Seed(0),
+        evidence_key="k",
+        step_index=0,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    assert isinstance(rec, EvidenceRecord)
+    assert isinstance(rec.evidence_id, UUID)
+
+
+def test_make_evidence_record_is_deterministic_for_same_inputs() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(7),
+        "evidence_key": "k",
+        "step_index": 3,
+        "agent_id": "agent",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    a = make_evidence_record(**args)
+    b = make_evidence_record(**args)
+    assert a.evidence_id == b.evidence_id
+
+
+def test_make_evidence_record_changes_id_when_evidence_key_changes() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "evidence_key": "k1",
+        "step_index": 0,
+        "agent_id": "agent",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    a = make_evidence_record(**args)
+    b = make_evidence_record(**{**args, "evidence_key": "k2"})
+    assert a.evidence_id != b.evidence_id
+
+
+def test_make_evidence_record_changes_id_when_step_index_changes() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "evidence_key": "k",
+        "step_index": 0,
+        "agent_id": "agent",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    a = make_evidence_record(**args)
+    b = make_evidence_record(**{**args, "step_index": 1})
+    assert a.evidence_id != b.evidence_id
+
+
+def test_make_evidence_record_id_does_not_depend_on_agent_id() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "evidence_key": "k",
+        "step_index": 0,
+        "agent_id": "agent_a",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    a = make_evidence_record(**args)
+    b = make_evidence_record(**{**args, "agent_id": "agent_b"})
+    assert a.evidence_id == b.evidence_id
+
+
+def test_make_evidence_record_id_does_not_depend_on_payload_or_created_at() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "evidence_key": "k",
+        "step_index": 0,
+        "agent_id": "agent",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    a = make_evidence_record(**args)
+    b = make_evidence_record(**{**args, "payload": {"x": 2}, "created_at": datetime(2026, 6, 1, tzinfo=UTC)})
+    assert a.evidence_id == b.evidence_id
+
+
+def test_make_evidence_record_id_changes_with_seed() -> None:
+    args: dict[str, Any] = {
+        "evidence_key": "k",
+        "step_index": 0,
+        "agent_id": "agent",
+        "payload": {"x": 1},
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    a = make_evidence_record(seed=Seed(0), **args)
+    b = make_evidence_record(seed=Seed(1), **args)
+    assert a.evidence_id != b.evidence_id

--- a/tests/evidence/test_evidence_record.py
+++ b/tests/evidence/test_evidence_record.py
@@ -181,3 +181,15 @@ def test_make_evidence_record_id_changes_with_seed() -> None:
     a = make_evidence_record(seed=Seed(0), **args)
     b = make_evidence_record(seed=Seed(1), **args)
     assert a.evidence_id != b.evidence_id
+
+
+def test_make_evidence_record_pins_golden_vector() -> None:
+    record = make_evidence_record(
+        seed=Seed(42),
+        evidence_key="risk-score",
+        step_index=3,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    assert record.evidence_id == UUID("0049a686-a794-5e86-b3ef-04a9b549324b")


### PR DESCRIPTION
## Summary
- Adds `EvidenceRecord` (frozen, slots) with UTC-tz validation in `__post_init__`.
- Adds `make_evidence_record(*, seed, evidence_key, step_index, agent_id, payload, created_at)` factory deriving `evidence_id` deterministically via `deterministic_uuid(seed, _EVIDENCE_NAMESPACE, f"{evidence_key}\0{step_index}")`.
- Extends `abdp.evidence` public surface to `("EvidenceRecord", "make_evidence_record")`.

## TDD
- RED `5bce770`: 16 failing tests (structural, UTC validation, determinism).
- GREEN `1eeb5e8`: implementation.
- REFACTOR `7a76438`: package docstring polish noting the evidence record stage.

## Verification
- 617 tests pass, 100% coverage, ruff/format/mypy --strict clean.

Closes #113