### PR TITLE
feat(evidence): add ClaimRecord and make_claim_record (#114)

### DIFF
--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -1,15 +1,24 @@
 """Public surface for the ``abdp.evidence`` package.
 
 The evidence package owns the evidence record, claim record, audit log,
-and store contracts. The evidence record stage is the first concrete
-export: :class:`EvidenceRecord` and :func:`make_evidence_record` provide
-deterministic identity for atomic facts captured during a run. Further
-exports are added to ``__all__`` issue by issue against the frozen
-surface test in ``tests/evidence/test_evidence_public_surface.py``.
+and store contracts. The evidence and claim record stages are exposed:
+:class:`EvidenceRecord` / :func:`make_evidence_record` provide
+deterministic identity for atomic facts, and :class:`ClaimRecord` /
+:func:`make_claim_record` provide deterministic identity for
+higher-level conclusions backed by evidence. Further exports are added
+to ``__all__`` issue by issue against the frozen surface test in
+``tests/evidence/test_evidence_public_surface.py``.
 """
 
+from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
 
+globals().pop("claim", None)
 globals().pop("record", None)
 
-__all__: tuple[str, ...] = ("EvidenceRecord", "make_evidence_record")
+__all__: tuple[str, ...] = (
+    "ClaimRecord",
+    "EvidenceRecord",
+    "make_claim_record",
+    "make_evidence_record",
+)

--- a/src/abdp/evidence/claim.py
+++ b/src/abdp/evidence/claim.py
@@ -1,0 +1,69 @@
+"""``ClaimRecord`` frozen dataclass and ``make_claim_record`` factory exposed by ``abdp.evidence``.
+
+A ``ClaimRecord`` represents a higher-level conclusion backed by one or
+more :class:`~abdp.evidence.EvidenceRecord` instances. ``claim_id`` is
+derived deterministically from ``statement`` and the ordered
+``evidence_ids`` via a private namespace UUID, so the same claim
+composition under the same seed always shares a ``claim_id``;
+``confidence`` and ``metadata`` are attributes of the claim and do not
+affect identity. ``confidence`` MUST be a finite ``float`` in
+``[0.0, 1.0]`` and ``evidence_ids`` MUST be non-empty; both invariants
+are validated in ``__post_init__``.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+from abdp.core.ids import deterministic_uuid
+from abdp.core.types import JsonObject, Seed
+
+__all__ = ["ClaimRecord", "make_claim_record"]
+
+_CLAIM_NAMESPACE: Final = UUID("8b4e6c20-1f3a-4b7d-9c2e-7f5d8a4b1c3e")
+_NAME_SEPARATOR: Final = "\0"
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimRecord:
+    """Higher-level conclusion backed by one or more evidence records."""
+
+    claim_id: UUID
+    statement: str
+    evidence_ids: tuple[UUID, ...]
+    confidence: float
+    metadata: JsonObject
+
+    def __post_init__(self) -> None:
+        if len(self.evidence_ids) < 1:
+            raise ValueError("evidence_ids must contain at least one UUID")
+        if not math.isfinite(self.confidence) or not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be finite and between 0.0 and 1.0")
+
+
+def make_claim_record(
+    *,
+    seed: Seed,
+    statement: str,
+    evidence_ids: tuple[UUID, ...],
+    confidence: float,
+    metadata: JsonObject,
+) -> ClaimRecord:
+    """Build a :class:`ClaimRecord` with a deterministically derived ``claim_id``.
+
+    ``claim_id`` is derived from ``seed``, the private claim namespace,
+    and ``statement`` joined to each evidence id by NUL separators in
+    the supplied order; ``confidence`` and ``metadata`` are attributes
+    of the claim and do not influence identity.
+    """
+    parts = [statement, *(str(evidence_id) for evidence_id in evidence_ids)]
+    name = _NAME_SEPARATOR.join(parts)
+    claim_id = deterministic_uuid(seed, _CLAIM_NAMESPACE, name)
+    return ClaimRecord(
+        claim_id=claim_id,
+        statement=statement,
+        evidence_ids=evidence_ids,
+        confidence=confidence,
+        metadata=metadata,
+    )

--- a/src/abdp/evidence/claim.py
+++ b/src/abdp/evidence/claim.py
@@ -27,7 +27,12 @@ _NAME_SEPARATOR: Final = "\0"
 
 @dataclass(frozen=True, slots=True)
 class ClaimRecord:
-    """Higher-level conclusion backed by one or more evidence records."""
+    """Higher-level conclusion backed by one or more evidence records.
+
+    Invariants enforced in ``__post_init__``: ``evidence_ids`` MUST be
+    non-empty and ``confidence`` MUST be a finite ``float`` in
+    ``[0.0, 1.0]``.
+    """
 
     claim_id: UUID
     statement: str

--- a/tests/evidence/test_claim_record.py
+++ b/tests/evidence/test_claim_record.py
@@ -1,0 +1,204 @@
+"""Tests for ``abdp.evidence.ClaimRecord`` and ``make_claim_record``."""
+
+import dataclasses
+import math
+from typing import Any, cast, get_type_hints
+from uuid import UUID
+
+import pytest
+
+from abdp.core.types import Seed
+from abdp.evidence import ClaimRecord, make_claim_record
+
+
+def _claim(**overrides: Any) -> ClaimRecord:
+    base: dict[str, Any] = {
+        "claim_id": UUID("00000000-0000-0000-0000-000000000001"),
+        "statement": "s",
+        "evidence_ids": (UUID("00000000-0000-0000-0000-000000000010"),),
+        "confidence": 0.5,
+        "metadata": {"k": "v"},
+    }
+    base.update(overrides)
+    return ClaimRecord(**base)
+
+
+def test_claim_record_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(ClaimRecord)
+    params = cast(Any, ClaimRecord).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_claim_record_uses_slots() -> None:
+    assert "__slots__" in vars(ClaimRecord)
+
+
+def test_claim_record_field_order_and_types() -> None:
+    fields = dataclasses.fields(ClaimRecord)
+    assert [f.name for f in fields] == [
+        "claim_id",
+        "statement",
+        "evidence_ids",
+        "confidence",
+        "metadata",
+    ]
+    annotations = get_type_hints(ClaimRecord)
+    assert annotations["claim_id"] is UUID
+    assert annotations["statement"] is str
+    assert annotations["confidence"] is float
+
+
+def test_claim_record_requires_all_fields() -> None:
+    for field in dataclasses.fields(ClaimRecord):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_claim_record_is_immutable() -> None:
+    rec = _claim()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(rec, "statement", "other")  # noqa: B010
+
+
+def test_claim_record_equality_is_value_based() -> None:
+    a = _claim()
+    b = _claim()
+    c = _claim(statement="other")
+    assert a == b
+    assert a != c
+
+
+def test_claim_record_rejects_empty_evidence_ids() -> None:
+    with pytest.raises(ValueError, match="evidence_ids"):
+        _claim(evidence_ids=())
+
+
+def test_claim_record_rejects_confidence_below_zero() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        _claim(confidence=-0.1)
+
+
+def test_claim_record_rejects_confidence_above_one() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        _claim(confidence=1.1)
+
+
+def test_claim_record_rejects_nan_confidence() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        _claim(confidence=math.nan)
+
+
+def test_claim_record_rejects_inf_confidence() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        _claim(confidence=math.inf)
+
+
+def test_claim_record_accepts_zero_confidence() -> None:
+    rec = _claim(confidence=0.0)
+    assert rec.confidence == 0.0
+
+
+def test_claim_record_accepts_one_confidence() -> None:
+    rec = _claim(confidence=1.0)
+    assert rec.confidence == 1.0
+
+
+def test_make_claim_record_returns_claim_record() -> None:
+    rec = make_claim_record(
+        seed=Seed(0),
+        statement="s",
+        evidence_ids=(UUID("00000000-0000-0000-0000-000000000010"),),
+        confidence=0.5,
+        metadata={"k": "v"},
+    )
+    assert isinstance(rec, ClaimRecord)
+    assert isinstance(rec.claim_id, UUID)
+
+
+def test_make_claim_record_is_deterministic_for_same_inputs() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(7),
+        "statement": "s",
+        "evidence_ids": (UUID("00000000-0000-0000-0000-000000000010"),),
+        "confidence": 0.5,
+        "metadata": {"k": "v"},
+    }
+    a = make_claim_record(**args)
+    b = make_claim_record(**args)
+    assert a.claim_id == b.claim_id
+
+
+def test_make_claim_record_changes_id_when_statement_changes() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "statement": "s1",
+        "evidence_ids": (UUID("00000000-0000-0000-0000-000000000010"),),
+        "confidence": 0.5,
+        "metadata": {},
+    }
+    a = make_claim_record(**args)
+    b = make_claim_record(**{**args, "statement": "s2"})
+    assert a.claim_id != b.claim_id
+
+
+def test_make_claim_record_changes_id_when_evidence_ids_change() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "statement": "s",
+        "evidence_ids": (UUID("00000000-0000-0000-0000-000000000010"),),
+        "confidence": 0.5,
+        "metadata": {},
+    }
+    a = make_claim_record(**args)
+    b = make_claim_record(**{**args, "evidence_ids": (UUID("00000000-0000-0000-0000-000000000011"),)})
+    assert a.claim_id != b.claim_id
+
+
+def test_make_claim_record_id_does_not_depend_on_confidence_or_metadata() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "statement": "s",
+        "evidence_ids": (UUID("00000000-0000-0000-0000-000000000010"),),
+        "confidence": 0.5,
+        "metadata": {"k": "v"},
+    }
+    a = make_claim_record(**args)
+    b = make_claim_record(**{**args, "confidence": 0.9, "metadata": {"x": "y"}})
+    assert a.claim_id == b.claim_id
+
+
+def test_make_claim_record_id_changes_with_seed() -> None:
+    args: dict[str, Any] = {
+        "statement": "s",
+        "evidence_ids": (UUID("00000000-0000-0000-0000-000000000010"),),
+        "confidence": 0.5,
+        "metadata": {},
+    }
+    a = make_claim_record(seed=Seed(0), **args)
+    b = make_claim_record(seed=Seed(1), **args)
+    assert a.claim_id != b.claim_id
+
+
+def test_make_claim_record_changes_id_when_evidence_ids_reorder() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "statement": "s",
+        "evidence_ids": (
+            UUID("00000000-0000-0000-0000-000000000010"),
+            UUID("00000000-0000-0000-0000-000000000011"),
+        ),
+        "confidence": 0.5,
+        "metadata": {},
+    }
+    a = make_claim_record(**args)
+    b = make_claim_record(
+        **{
+            **args,
+            "evidence_ids": (
+                UUID("00000000-0000-0000-0000-000000000011"),
+                UUID("00000000-0000-0000-0000-000000000010"),
+            ),
+        }
+    )
+    assert a.claim_id != b.claim_id
+    assert rec.claim_id == UUID("00000000-0000-0000-0000-000000000000") or isinstance(rec.claim_id, UUID)

--- a/tests/evidence/test_claim_record.py
+++ b/tests/evidence/test_claim_record.py
@@ -201,4 +201,17 @@ def test_make_claim_record_changes_id_when_evidence_ids_reorder() -> None:
         }
     )
     assert a.claim_id != b.claim_id
-    assert rec.claim_id == UUID("00000000-0000-0000-0000-000000000000") or isinstance(rec.claim_id, UUID)
+
+
+def test_make_claim_record_pins_golden_vector() -> None:
+    rec = make_claim_record(
+        seed=Seed(42),
+        statement="risk-acceptable",
+        evidence_ids=(
+            UUID("11111111-1111-1111-1111-111111111111"),
+            UUID("22222222-2222-2222-2222-222222222222"),
+        ),
+        confidence=0.75,
+        metadata={"k": "v"},
+    )
+    assert rec.claim_id == UUID("b5d6768f-02c4-5b3e-a393-f1fc4d43a4ba")

--- a/tests/evidence/test_evidence_public_surface.py
+++ b/tests/evidence/test_evidence_public_surface.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import abdp.evidence
 import pytest
+from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("EvidenceRecord", "make_evidence_record")
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
+    "ClaimRecord",
+    "EvidenceRecord",
+    "make_claim_record",
+    "make_evidence_record",
+)
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "ClaimRecord": ClaimRecord,
     "EvidenceRecord": EvidenceRecord,
+    "make_claim_record": make_claim_record,
     "make_evidence_record": make_evidence_record,
 }
 


### PR DESCRIPTION
## Summary
- Adds `ClaimRecord` (frozen, slots) with `__post_init__` validating non-empty `evidence_ids` and finite `confidence` in [0.0, 1.0].
- Adds `make_claim_record(*, seed, statement, evidence_ids, confidence, metadata)` factory deriving `claim_id` deterministically via `deterministic_uuid(seed, _CLAIM_NAMESPACE, statement + "\0" + "\0".join(str(e) for e in evidence_ids))`.
- Extends `abdp.evidence` public surface to `("ClaimRecord", "EvidenceRecord", "make_claim_record", "make_evidence_record")`.

## Design
Oracle 12/12 APPROVED (session ses_24b1fbce0ffesUmezeOIsxMIJQ): tuple `evidence_ids`, `JsonObject` metadata, finite-range `confidence` validation, factory included for symmetry with `EvidenceRecord`, identity excludes confidence/metadata, ordered `evidence_ids` are identity-relevant.

## TDD
- RED `71be52b`: 19 failing tests (structural, validation incl. NaN/inf, factory determinism + ordering sensitivity).
- GREEN `e1b5402`: implementation + golden vector pin (`b5d6768f-02c4-5b3e-a393-f1fc4d43a4ba`).
- REFACTOR `4b5f490`: class docstring documents invariants.

## Verification
- 641 tests pass, 100% coverage, ruff/format/mypy --strict clean.

Closes #114