### PR TITLE
feat(evidence): add AuditLog bundle (#115)

### DIFF
--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -1,22 +1,26 @@
 """Public surface for the ``abdp.evidence`` package.
 
 The evidence package owns the evidence record, claim record, audit log,
-and store contracts. The evidence and claim record stages are exposed:
-:class:`EvidenceRecord` / :func:`make_evidence_record` provide
-deterministic identity for atomic facts, and :class:`ClaimRecord` /
-:func:`make_claim_record` provide deterministic identity for
-higher-level conclusions backed by evidence. Further exports are added
-to ``__all__`` issue by issue against the frozen surface test in
+and store contracts. The evidence and claim record stages and the
+audit-log bundle are exposed: :class:`EvidenceRecord` /
+:func:`make_evidence_record` and :class:`ClaimRecord` /
+:func:`make_claim_record` provide deterministic identity for atomic
+facts and conclusions, and :class:`AuditLog` aggregates a scenario run
+with its evaluation summary, evidence, and claims. Further exports are
+added to ``__all__`` issue by issue against the frozen surface test in
 ``tests/evidence/test_evidence_public_surface.py``.
 """
 
+from abdp.evidence.audit_log import AuditLog
 from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
 
+globals().pop("audit_log", None)
 globals().pop("claim", None)
 globals().pop("record", None)
 
 __all__: tuple[str, ...] = (
+    "AuditLog",
     "ClaimRecord",
     "EvidenceRecord",
     "make_claim_record",

--- a/src/abdp/evidence/audit_log.py
+++ b/src/abdp/evidence/audit_log.py
@@ -1,0 +1,44 @@
+"""``AuditLog`` aggregate exposed by ``abdp.evidence``.
+
+An :class:`AuditLog` bundles a completed scenario run with its
+evaluation summary and the evidence and claim records produced during
+that run. ``scenario_key`` and ``seed`` are kept as first-class fields
+and validated against ``run`` in ``__post_init__`` to guarantee that
+the bundle describes a single coherent execution. ``evidence`` and
+``claims`` are stored as tuples and preserve caller-supplied order;
+``AuditLog`` does not impose canonical ordering.
+"""
+
+from dataclasses import dataclass
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary
+from abdp.evidence.claim import ClaimRecord
+from abdp.evidence.record import EvidenceRecord
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
+
+__all__ = ["AuditLog"]
+
+
+@dataclass(frozen=True, slots=True)
+class AuditLog[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Auditable bundle of a scenario run, its evaluation, and supporting facts.
+
+    ``__post_init__`` enforces that ``scenario_key`` and ``seed`` match
+    the corresponding fields on ``run``; collection ordering for
+    ``evidence`` and ``claims`` is preserved exactly as supplied.
+    """
+
+    scenario_key: str
+    seed: Seed
+    run: ScenarioRun[S, P, A]
+    summary: EvaluationSummary
+    evidence: tuple[EvidenceRecord, ...]
+    claims: tuple[ClaimRecord, ...]
+
+    def __post_init__(self) -> None:
+        if self.scenario_key != self.run.scenario_key:
+            raise ValueError("scenario_key must match run.scenario_key")
+        if self.seed != self.run.seed:
+            raise ValueError("seed must match run.seed")

--- a/src/abdp/evidence/audit_log.py
+++ b/src/abdp/evidence/audit_log.py
@@ -26,8 +26,10 @@ class AuditLog[S: SegmentState, P: ParticipantState, A: ActionProposal]:
     """Auditable bundle of a scenario run, its evaluation, and supporting facts.
 
     ``__post_init__`` enforces that ``scenario_key`` and ``seed`` match
-    the corresponding fields on ``run``; collection ordering for
-    ``evidence`` and ``claims`` is preserved exactly as supplied.
+    the corresponding fields on ``run``. ``evidence`` and ``claims``
+    are stored as tuples and preserve caller-supplied order; the
+    bundle does not impose canonical ordering, so deterministic
+    ordering is the caller's responsibility.
     """
 
     scenario_key: str

--- a/tests/evidence/test_audit_log.py
+++ b/tests/evidence/test_audit_log.py
@@ -1,0 +1,156 @@
+"""Tests for ``abdp.evidence.AuditLog``."""
+
+import dataclasses
+from datetime import UTC, datetime
+from typing import Any, cast, get_type_hints
+from uuid import UUID
+
+import pytest
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+def _state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=Seed(0),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("00000000-0000-0000-0000-000000000001"),
+            tier="bronze",
+            storage_key="snapshots/run",
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _run(
+    scenario_key: str = "k",
+    seed: Seed = Seed(0),
+) -> ScenarioRun[SegmentState, ParticipantState, ActionProposal]:
+    return ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key=scenario_key,
+        seed=seed,
+        steps=(),
+        final_state=_state(),
+    )
+
+
+def _summary() -> EvaluationSummary:
+    return EvaluationSummary(metrics=(), gates=(), overall_status=GateStatus.PASS)
+
+
+def _evidence(uuid_int: int = 1) -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_id=UUID(int=uuid_int),
+        evidence_key="k",
+        step_index=0,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _claim(uuid_int: int = 100) -> ClaimRecord:
+    return ClaimRecord(
+        claim_id=UUID(int=uuid_int),
+        statement="s",
+        evidence_ids=(UUID(int=1),),
+        confidence=0.5,
+        metadata={},
+    )
+
+
+def _audit(**overrides: Any) -> AuditLog[SegmentState, ParticipantState, ActionProposal]:
+    base: dict[str, Any] = {
+        "scenario_key": "k",
+        "seed": Seed(0),
+        "run": _run(),
+        "summary": _summary(),
+        "evidence": (_evidence(),),
+        "claims": (_claim(),),
+    }
+    base.update(overrides)
+    return AuditLog[SegmentState, ParticipantState, ActionProposal](**base)
+
+
+def test_audit_log_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(AuditLog)
+    params = cast(Any, AuditLog).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_audit_log_uses_slots() -> None:
+    assert "__slots__" in vars(AuditLog)
+
+
+def test_audit_log_field_order() -> None:
+    fields = dataclasses.fields(AuditLog)
+    assert [f.name for f in fields] == [
+        "scenario_key",
+        "seed",
+        "run",
+        "summary",
+        "evidence",
+        "claims",
+    ]
+
+
+def test_audit_log_field_types_resolve() -> None:
+    annotations = get_type_hints(AuditLog)
+    assert annotations["scenario_key"] is str
+    assert annotations["summary"] is EvaluationSummary
+
+
+def test_audit_log_requires_all_fields() -> None:
+    for field in dataclasses.fields(AuditLog):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_audit_log_is_immutable() -> None:
+    rec = _audit()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(rec, "scenario_key", "other")  # noqa: B010
+
+
+def test_audit_log_equality_is_value_based() -> None:
+    a = _audit()
+    b = _audit()
+    assert a == b
+
+
+def test_audit_log_preserves_evidence_order() -> None:
+    e1 = _evidence(uuid_int=1)
+    e2 = _evidence(uuid_int=2)
+    rec = _audit(evidence=(e2, e1))
+    assert rec.evidence == (e2, e1)
+
+
+def test_audit_log_preserves_claims_order() -> None:
+    c1 = _claim(uuid_int=100)
+    c2 = _claim(uuid_int=200)
+    rec = _audit(claims=(c2, c1))
+    assert rec.claims == (c2, c1)
+
+
+def test_audit_log_rejects_scenario_key_mismatch_with_run() -> None:
+    with pytest.raises(ValueError, match="scenario_key"):
+        _audit(scenario_key="other", run=_run(scenario_key="k"))
+
+
+def test_audit_log_rejects_seed_mismatch_with_run() -> None:
+    with pytest.raises(ValueError, match="seed"):
+        _audit(seed=Seed(7), run=_run(seed=Seed(0)))
+
+
+def test_audit_log_accepts_consistent_scenario_key_and_seed() -> None:
+    rec = _audit(scenario_key="ok", seed=Seed(3), run=_run(scenario_key="ok", seed=Seed(3)))
+    assert rec.scenario_key == "ok"
+    assert rec.seed == Seed(3)

--- a/tests/evidence/test_audit_log.py
+++ b/tests/evidence/test_audit_log.py
@@ -30,9 +30,12 @@ def _state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
     )
 
 
+_DEFAULT_SEED: Seed = Seed(0)
+
+
 def _run(
     scenario_key: str = "k",
-    seed: Seed = Seed(0),
+    seed: Seed = _DEFAULT_SEED,
 ) -> ScenarioRun[SegmentState, ParticipantState, ActionProposal]:
     return ScenarioRun[SegmentState, ParticipantState, ActionProposal](
         scenario_key=scenario_key,

--- a/tests/evidence/test_evidence_public_surface.py
+++ b/tests/evidence/test_evidence_public_surface.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import abdp.evidence
 import pytest
+from abdp.evidence.audit_log import AuditLog
 from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
+    "AuditLog",
     "ClaimRecord",
     "EvidenceRecord",
     "make_claim_record",
@@ -15,6 +17,7 @@ EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
 )
 
 EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "AuditLog": AuditLog,
     "ClaimRecord": ClaimRecord,
     "EvidenceRecord": EvidenceRecord,
     "make_claim_record": make_claim_record,


### PR DESCRIPTION
## Summary
- Adds generic `AuditLog[S, P, A]` (frozen, slots) bundling `scenario_key`, `seed`, `run: ScenarioRun[S,P,A]`, `summary: EvaluationSummary`, `evidence: tuple[EvidenceRecord, ...]`, `claims: tuple[ClaimRecord, ...]`.
- `__post_init__` enforces `scenario_key`/`seed` consistency with `run`.
- Collection ordering preserved as caller contract per Oracle Q8 guidance.
- Extends `abdp.evidence` public surface to include `AuditLog`.

## Design
Oracle 11/12 APPROVED (session ses_24b16c8a0ffetEfYBNeVqFWwHE). Adjustment: do not enforce sortedness, trust caller-supplied tuple order.

## TDD
- RED `9cb5103`: 12 failing tests.
- GREEN `9c2b5cd`: implementation.
- REFACTOR `79639ff`: clarify ordering contract in class docstring.

## Verification
- 654 tests pass, 100% coverage, ruff/format/mypy --strict clean.

Closes #115