### PR TITLE
feat(evidence): add EvidenceStore protocol (#116)

### DIFF
--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -1,28 +1,31 @@
 """Public surface for the ``abdp.evidence`` package.
 
 The evidence package owns the evidence record, claim record, audit log,
-and store contracts. The evidence and claim record stages and the
-audit-log bundle are exposed: :class:`EvidenceRecord` /
-:func:`make_evidence_record` and :class:`ClaimRecord` /
-:func:`make_claim_record` provide deterministic identity for atomic
-facts and conclusions, and :class:`AuditLog` aggregates a scenario run
-with its evaluation summary, evidence, and claims. Further exports are
-added to ``__all__`` issue by issue against the frozen surface test in
+and store contracts. :class:`EvidenceRecord` / :func:`make_evidence_record`
+and :class:`ClaimRecord` / :func:`make_claim_record` provide deterministic
+identity for atomic facts and conclusions; :class:`AuditLog` aggregates a
+scenario run with its evaluation summary, evidence, and claims; and
+:class:`EvidenceStore` is the pluggable persistence contract for assembling
+audit logs from recorded evidence and claims. Further exports are added to
+``__all__`` issue by issue against the frozen surface test in
 ``tests/evidence/test_evidence_public_surface.py``.
 """
 
 from abdp.evidence.audit_log import AuditLog
 from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
+from abdp.evidence.store import EvidenceStore
 
 globals().pop("audit_log", None)
 globals().pop("claim", None)
 globals().pop("record", None)
+globals().pop("store", None)
 
 __all__: tuple[str, ...] = (
     "AuditLog",
     "ClaimRecord",
     "EvidenceRecord",
+    "EvidenceStore",
     "make_claim_record",
     "make_evidence_record",
 )

--- a/src/abdp/evidence/store.py
+++ b/src/abdp/evidence/store.py
@@ -24,7 +24,14 @@ __all__ = ["EvidenceStore"]
 
 @runtime_checkable
 class EvidenceStore[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
-    """Pluggable persistence contract for evidence and claim records."""
+    """Pluggable persistence contract for evidence and claim records.
+
+    Implementations MUST preserve every record passed to :meth:`record`
+    and :meth:`record_claim` so that subsequent calls to :meth:`evidence`
+    and :meth:`claims` can return them as tuples. Ordering, idempotency,
+    and durability semantics are implementation-defined; deterministic
+    ordering for audit logs is the implementation's responsibility.
+    """
 
     def record(self, record: EvidenceRecord) -> None:
         """Persist ``record`` in the store."""

--- a/src/abdp/evidence/store.py
+++ b/src/abdp/evidence/store.py
@@ -1,0 +1,59 @@
+"""``EvidenceStore`` protocol exposed by ``abdp.evidence``.
+
+An :class:`EvidenceStore` is the pluggable persistence contract used by
+the simulation and evaluation pipeline to record evidence and claim
+records and to assemble an :class:`abdp.evidence.AuditLog` once a
+scenario run has been evaluated. The protocol is intentionally minimal:
+implementations decide how to store records (in memory, on disk, in a
+remote service) and how to derive deterministic ordering when
+constructing an audit log.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary
+from abdp.evidence.audit_log import AuditLog
+from abdp.evidence.claim import ClaimRecord
+from abdp.evidence.record import EvidenceRecord
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
+
+__all__ = ["EvidenceStore"]
+
+
+@runtime_checkable
+class EvidenceStore[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
+    """Pluggable persistence contract for evidence and claim records."""
+
+    def record(self, record: EvidenceRecord) -> None:
+        """Persist ``record`` in the store."""
+
+        ...  # pragma: no cover
+
+    def record_claim(self, claim: ClaimRecord) -> None:
+        """Persist ``claim`` in the store."""
+
+        ...  # pragma: no cover
+
+    def evidence(self) -> tuple[EvidenceRecord, ...]:
+        """Return all persisted evidence records."""
+
+        ...  # pragma: no cover
+
+    def claims(self) -> tuple[ClaimRecord, ...]:
+        """Return all persisted claim records."""
+
+        ...  # pragma: no cover
+
+    def build_audit_log(
+        self,
+        *,
+        scenario_key: str,
+        seed: Seed,
+        run: ScenarioRun[S, P, A],
+        summary: EvaluationSummary,
+    ) -> AuditLog[S, P, A]:
+        """Bundle stored records with ``run`` and ``summary`` into an audit log."""
+
+        ...  # pragma: no cover

--- a/tests/evidence/test_evidence_public_surface.py
+++ b/tests/evidence/test_evidence_public_surface.py
@@ -7,11 +7,13 @@ import pytest
 from abdp.evidence.audit_log import AuditLog
 from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
+from abdp.evidence.store import EvidenceStore
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
     "AuditLog",
     "ClaimRecord",
     "EvidenceRecord",
+    "EvidenceStore",
     "make_claim_record",
     "make_evidence_record",
 )
@@ -20,6 +22,7 @@ EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
     "AuditLog": AuditLog,
     "ClaimRecord": ClaimRecord,
     "EvidenceRecord": EvidenceRecord,
+    "EvidenceStore": EvidenceStore,
     "make_claim_record": make_claim_record,
     "make_evidence_record": make_evidence_record,
 }

--- a/tests/evidence/test_evidence_store_protocol.py
+++ b/tests/evidence/test_evidence_store_protocol.py
@@ -1,0 +1,112 @@
+"""Structural tests for ``abdp.evidence.EvidenceStore``."""
+
+from typing import Any, cast, get_type_hints
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary
+from abdp.evidence import (
+    AuditLog,
+    ClaimRecord,
+    EvidenceRecord,
+    EvidenceStore,
+)
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
+
+
+def test_evidence_store_is_protocol() -> None:
+    assert cast(Any, EvidenceStore)._is_protocol is True
+
+
+def test_evidence_store_is_runtime_checkable() -> None:
+    class _Impl:
+        def record(self, record: EvidenceRecord) -> None:
+            return None
+
+        def record_claim(self, claim: ClaimRecord) -> None:
+            return None
+
+        def evidence(self) -> tuple[EvidenceRecord, ...]:
+            return ()
+
+        def claims(self) -> tuple[ClaimRecord, ...]:
+            return ()
+
+        def build_audit_log(
+            self,
+            *,
+            scenario_key: str,
+            seed: Seed,
+            run: ScenarioRun[SegmentState, ParticipantState, ActionProposal],
+            summary: EvaluationSummary,
+        ) -> AuditLog[SegmentState, ParticipantState, ActionProposal]:
+            raise NotImplementedError
+
+    assert isinstance(_Impl(), EvidenceStore)
+
+
+def test_evidence_store_rejects_non_conforming_object_at_runtime() -> None:
+    class _NotStore:
+        pass
+
+    assert not isinstance(_NotStore(), EvidenceStore)
+
+
+def test_evidence_store_rejects_object_missing_one_method_at_runtime() -> None:
+    class _PartialStore:
+        def record(self, record: EvidenceRecord) -> None:
+            return None
+
+        def record_claim(self, claim: ClaimRecord) -> None:
+            return None
+
+        def evidence(self) -> tuple[EvidenceRecord, ...]:
+            return ()
+
+        def claims(self) -> tuple[ClaimRecord, ...]:
+            return ()
+
+        # build_audit_log intentionally missing
+
+    assert not isinstance(_PartialStore(), EvidenceStore)
+
+
+def test_evidence_store_declares_expected_methods() -> None:
+    expected = {
+        "record",
+        "record_claim",
+        "evidence",
+        "claims",
+        "build_audit_log",
+    }
+    for name in expected:
+        assert callable(getattr(EvidenceStore, name))
+
+
+def test_evidence_store_record_signature() -> None:
+    annotations = get_type_hints(EvidenceStore.record)
+    assert annotations["record"] is EvidenceRecord
+    assert annotations["return"] is type(None)
+
+
+def test_evidence_store_record_claim_signature() -> None:
+    annotations = get_type_hints(EvidenceStore.record_claim)
+    assert annotations["claim"] is ClaimRecord
+    assert annotations["return"] is type(None)
+
+
+def test_evidence_store_evidence_returns_tuple_of_records() -> None:
+    annotations = get_type_hints(EvidenceStore.evidence)
+    assert annotations["return"] == tuple[EvidenceRecord, ...]
+
+
+def test_evidence_store_claims_returns_tuple_of_claims() -> None:
+    annotations = get_type_hints(EvidenceStore.claims)
+    assert annotations["return"] == tuple[ClaimRecord, ...]
+
+
+def test_evidence_store_build_audit_log_signature() -> None:
+    annotations = get_type_hints(EvidenceStore.build_audit_log)
+    assert annotations["scenario_key"] is str
+    assert annotations["seed"] is Seed
+    assert annotations["summary"] is EvaluationSummary


### PR DESCRIPTION
## Summary
- Adds `EvidenceStore` Protocol at `src/abdp/evidence/store.py` with five methods: `record`, `record_claim`, `evidence`, `claims`, `build_audit_log`.
- `@runtime_checkable`, generic `[S: SegmentState, P: ParticipantState, A: ActionProposal]`.
- Extends `abdp.evidence.__all__` to 6-symbol surface; updates frozen surface test accordingly.

## TDD cycle
- RED `65871ac` — failing protocol structural tests + surface extension.
- GREEN `684ca90` — implement Protocol, expose via package init.
- REFACTOR `03f7046` — document contract semantics on the class docstring.

## Verification
- `uv run pytest -q`: 665 passed, 100% coverage
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run mypy --strict src tests`: clean

Closes #116