### PR TITLE
feat(evidence): add InMemoryEvidenceStore (#117)

### DIFF
--- a/src/abdp/evidence/__init__.py
+++ b/src/abdp/evidence/__init__.py
@@ -4,17 +4,17 @@ The evidence package owns the evidence record, claim record, audit log,
 and store contracts. :class:`EvidenceRecord` / :func:`make_evidence_record`
 and :class:`ClaimRecord` / :func:`make_claim_record` provide deterministic
 identity for atomic facts and conclusions; :class:`AuditLog` aggregates a
-scenario run with its evaluation summary, evidence, and claims; and
-:class:`EvidenceStore` is the pluggable persistence contract for assembling
-audit logs from recorded evidence and claims. Further exports are added to
-``__all__`` issue by issue against the frozen surface test in
-``tests/evidence/test_evidence_public_surface.py``.
+scenario run with its evaluation summary, evidence, and claims;
+:class:`EvidenceStore` is the pluggable persistence contract; and
+:class:`InMemoryEvidenceStore` is the reference in-memory implementation.
+Further exports are added to ``__all__`` issue by issue against the
+frozen surface test in ``tests/evidence/test_evidence_public_surface.py``.
 """
 
 from abdp.evidence.audit_log import AuditLog
 from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
-from abdp.evidence.store import EvidenceStore
+from abdp.evidence.store import EvidenceStore, InMemoryEvidenceStore
 
 globals().pop("audit_log", None)
 globals().pop("claim", None)
@@ -26,6 +26,7 @@ __all__: tuple[str, ...] = (
     "ClaimRecord",
     "EvidenceRecord",
     "EvidenceStore",
+    "InMemoryEvidenceStore",
     "make_claim_record",
     "make_evidence_record",
 )

--- a/src/abdp/evidence/store.py
+++ b/src/abdp/evidence/store.py
@@ -1,4 +1,4 @@
-"""``EvidenceStore`` protocol exposed by ``abdp.evidence``.
+"""``EvidenceStore`` protocol and in-memory implementation exposed by ``abdp.evidence``.
 
 An :class:`EvidenceStore` is the pluggable persistence contract used by
 the simulation and evaluation pipeline to record evidence and claim
@@ -6,10 +6,12 @@ records and to assemble an :class:`abdp.evidence.AuditLog` once a
 scenario run has been evaluated. The protocol is intentionally minimal:
 implementations decide how to store records (in memory, on disk, in a
 remote service) and how to derive deterministic ordering when
-constructing an audit log.
+constructing an audit log. :class:`InMemoryEvidenceStore` is the
+reference implementation backed by insertion-ordered dictionaries.
 """
 
 from typing import Protocol, runtime_checkable
+from uuid import UUID
 
 from abdp.core import Seed
 from abdp.evaluation import EvaluationSummary
@@ -19,7 +21,7 @@ from abdp.evidence.record import EvidenceRecord
 from abdp.scenario import ScenarioRun
 from abdp.simulation import ActionProposal, ParticipantState, SegmentState
 
-__all__ = ["EvidenceStore"]
+__all__ = ["EvidenceStore", "InMemoryEvidenceStore"]
 
 
 @runtime_checkable
@@ -64,3 +66,55 @@ class EvidenceStore[S: SegmentState, P: ParticipantState, A: ActionProposal](Pro
         """Bundle stored records with ``run`` and ``summary`` into an audit log."""
 
         ...  # pragma: no cover
+
+
+class InMemoryEvidenceStore[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Insertion-ordered, in-memory implementation of :class:`EvidenceStore`.
+
+    Records are kept in insertion order using ``dict`` storage, which
+    provides duplicate-id detection and membership lookup in one
+    structure. ``record`` and ``record_claim`` validate inputs before
+    mutating state, so a rejected write leaves the store unchanged.
+    Returned tuples are snapshots: subsequent writes do not affect
+    previously returned tuples. Not thread-safe.
+    """
+
+    def __init__(self) -> None:
+        self._evidence: dict[UUID, EvidenceRecord] = {}
+        self._claims: dict[UUID, ClaimRecord] = {}
+
+    def record(self, record: EvidenceRecord) -> None:
+        if record.evidence_id in self._evidence:
+            raise ValueError(f"duplicate evidence_id: {record.evidence_id}")
+        self._evidence[record.evidence_id] = record
+
+    def record_claim(self, claim: ClaimRecord) -> None:
+        if claim.claim_id in self._claims:
+            raise ValueError(f"duplicate claim_id: {claim.claim_id}")
+        missing = tuple(eid for eid in claim.evidence_ids if eid not in self._evidence)
+        if missing:
+            raise ValueError(f"claim references unknown evidence_ids: {missing}")
+        self._claims[claim.claim_id] = claim
+
+    def evidence(self) -> tuple[EvidenceRecord, ...]:
+        return tuple(self._evidence.values())
+
+    def claims(self) -> tuple[ClaimRecord, ...]:
+        return tuple(self._claims.values())
+
+    def build_audit_log(
+        self,
+        *,
+        scenario_key: str,
+        seed: Seed,
+        run: ScenarioRun[S, P, A],
+        summary: EvaluationSummary,
+    ) -> AuditLog[S, P, A]:
+        return AuditLog[S, P, A](
+            scenario_key=scenario_key,
+            seed=seed,
+            run=run,
+            summary=summary,
+            evidence=self.evidence(),
+            claims=self.claims(),
+        )

--- a/src/abdp/evidence/store.py
+++ b/src/abdp/evidence/store.py
@@ -93,7 +93,8 @@ class InMemoryEvidenceStore[S: SegmentState, P: ParticipantState, A: ActionPropo
             raise ValueError(f"duplicate claim_id: {claim.claim_id}")
         missing = tuple(eid for eid in claim.evidence_ids if eid not in self._evidence)
         if missing:
-            raise ValueError(f"claim references unknown evidence_ids: {missing}")
+            joined = ", ".join(str(eid) for eid in missing)
+            raise ValueError(f"claim references unknown evidence_ids: {joined}")
         self._claims[claim.claim_id] = claim
 
     def evidence(self) -> tuple[EvidenceRecord, ...]:

--- a/tests/evidence/test_evidence_public_surface.py
+++ b/tests/evidence/test_evidence_public_surface.py
@@ -7,13 +7,14 @@ import pytest
 from abdp.evidence.audit_log import AuditLog
 from abdp.evidence.claim import ClaimRecord, make_claim_record
 from abdp.evidence.record import EvidenceRecord, make_evidence_record
-from abdp.evidence.store import EvidenceStore
+from abdp.evidence.store import EvidenceStore, InMemoryEvidenceStore
 
 EXPECTED_PUBLIC_NAMES: tuple[str, ...] = (
     "AuditLog",
     "ClaimRecord",
     "EvidenceRecord",
     "EvidenceStore",
+    "InMemoryEvidenceStore",
     "make_claim_record",
     "make_evidence_record",
 )
@@ -23,6 +24,7 @@ EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
     "ClaimRecord": ClaimRecord,
     "EvidenceRecord": EvidenceRecord,
     "EvidenceStore": EvidenceStore,
+    "InMemoryEvidenceStore": InMemoryEvidenceStore,
     "make_claim_record": make_claim_record,
     "make_evidence_record": make_evidence_record,
 }

--- a/tests/evidence/test_in_memory_store.py
+++ b/tests/evidence/test_in_memory_store.py
@@ -1,0 +1,191 @@
+"""Tests for ``abdp.evidence.InMemoryEvidenceStore``."""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evidence import (
+    AuditLog,
+    ClaimRecord,
+    EvidenceRecord,
+    EvidenceStore,
+    InMemoryEvidenceStore,
+)
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+def _state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=Seed(0),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("00000000-0000-0000-0000-000000000001"),
+            tier="bronze",
+            storage_key="snapshots/run",
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _run() -> ScenarioRun[SegmentState, ParticipantState, ActionProposal]:
+    return ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        steps=(),
+        final_state=_state(),
+    )
+
+
+def _summary() -> EvaluationSummary:
+    return EvaluationSummary(metrics=(), gates=(), overall_status=GateStatus.PASS)
+
+
+def _evidence(uuid_int: int = 1) -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_id=UUID(int=uuid_int),
+        evidence_key="k",
+        step_index=0,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _claim(uuid_int: int = 100, evidence_ids: tuple[UUID, ...] = (UUID(int=1),)) -> ClaimRecord:
+    return ClaimRecord(
+        claim_id=UUID(int=uuid_int),
+        statement="s",
+        evidence_ids=evidence_ids,
+        confidence=0.5,
+        metadata={},
+    )
+
+
+def test_in_memory_store_starts_empty() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    assert store.evidence() == ()
+    assert store.claims() == ()
+
+
+def test_in_memory_store_conforms_to_evidence_store_protocol() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    assert isinstance(store, EvidenceStore)
+
+
+def test_in_memory_store_preserves_evidence_insertion_order() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    e1 = _evidence(uuid_int=1)
+    e2 = _evidence(uuid_int=2)
+    e3 = _evidence(uuid_int=3)
+    store.record(e2)
+    store.record(e1)
+    store.record(e3)
+    assert store.evidence() == (e2, e1, e3)
+
+
+def test_in_memory_store_preserves_claim_insertion_order() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=1))
+    c1 = _claim(uuid_int=100)
+    c2 = _claim(uuid_int=200)
+    store.record_claim(c2)
+    store.record_claim(c1)
+    assert store.claims() == (c2, c1)
+
+
+def test_in_memory_store_rejects_duplicate_evidence_id() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=1))
+    with pytest.raises(ValueError, match="00000000-0000-0000-0000-000000000001"):
+        store.record(_evidence(uuid_int=1))
+
+
+def test_in_memory_store_duplicate_evidence_does_not_mutate_state() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    e = _evidence(uuid_int=1)
+    store.record(e)
+    with pytest.raises(ValueError):
+        store.record(_evidence(uuid_int=1))
+    assert store.evidence() == (e,)
+
+
+def test_in_memory_store_rejects_duplicate_claim_id() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=1))
+    store.record_claim(_claim(uuid_int=100))
+    with pytest.raises(ValueError, match="00000000-0000-0000-0000-000000000064"):
+        store.record_claim(_claim(uuid_int=100))
+
+
+def test_in_memory_store_rejects_claim_referencing_unknown_evidence() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=1))
+    with pytest.raises(ValueError, match="00000000-0000-0000-0000-000000000009"):
+        store.record_claim(_claim(uuid_int=100, evidence_ids=(UUID(int=1), UUID(int=9))))
+
+
+def test_in_memory_store_unknown_evidence_error_preserves_claim_order() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=5))
+    missing_a = UUID(int=99)
+    missing_b = UUID(int=7)
+    with pytest.raises(ValueError) as excinfo:
+        store.record_claim(
+            _claim(uuid_int=100, evidence_ids=(missing_a, UUID(int=5), missing_b)),
+        )
+    msg = str(excinfo.value)
+    assert msg.index(str(missing_a)) < msg.index(str(missing_b))
+
+
+def test_in_memory_store_failed_claim_does_not_reserve_claim_id() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=1))
+    with pytest.raises(ValueError):
+        store.record_claim(_claim(uuid_int=100, evidence_ids=(UUID(int=99),)))
+    assert store.claims() == ()
+    valid = _claim(uuid_int=100, evidence_ids=(UUID(int=1),))
+    store.record_claim(valid)
+    assert store.claims() == (valid,)
+
+
+def test_in_memory_store_accepts_claim_with_all_known_evidence_ids() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    store.record(_evidence(uuid_int=1))
+    store.record(_evidence(uuid_int=2))
+    claim = _claim(uuid_int=100, evidence_ids=(UUID(int=2), UUID(int=1)))
+    store.record_claim(claim)
+    assert store.claims() == (claim,)
+
+
+def test_in_memory_store_evidence_returns_snapshot_unaffected_by_later_writes() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    e1 = _evidence(uuid_int=1)
+    store.record(e1)
+    snapshot = store.evidence()
+    store.record(_evidence(uuid_int=2))
+    assert snapshot == (e1,)
+
+
+def test_in_memory_store_build_audit_log_returns_insertion_ordered_bundle() -> None:
+    store: InMemoryEvidenceStore[SegmentState, ParticipantState, ActionProposal] = InMemoryEvidenceStore()
+    e1 = _evidence(uuid_int=1)
+    e2 = _evidence(uuid_int=2)
+    store.record(e1)
+    store.record(e2)
+    c1 = _claim(uuid_int=100, evidence_ids=(UUID(int=1),))
+    c2 = _claim(uuid_int=200, evidence_ids=(UUID(int=2),))
+    store.record_claim(c1)
+    store.record_claim(c2)
+    audit = store.build_audit_log(scenario_key="k", seed=Seed(0), run=_run(), summary=_summary())
+    assert isinstance(audit, AuditLog)
+    assert audit.scenario_key == "k"
+    assert audit.seed == Seed(0)
+    assert audit.evidence == (e1, e2)
+    assert audit.claims == (c1, c2)


### PR DESCRIPTION
## Summary
- Adds `InMemoryEvidenceStore` to `src/abdp/evidence/store.py` — insertion-ordered, dict-backed reference implementation of the `EvidenceStore` Protocol.
- Validates inputs before mutating state (rejected writes leave the store unchanged); preserves original claim ordering in unknown-evidence error messages.
- Extends public surface to 7 symbols.

## TDD cycle
- RED `52b5949` — 13 failing behavior tests (insertion order, duplicate id rejection, unknown-evidence rejection with order preservation, snapshot isolation, audit-log assembly, failed-write state isolation).
- GREEN `7d91a68` — implement class with two ordered dicts; validate before mutate.
- REFACTOR `9207529` — humanize unknown-evidence error message (comma-joined UUIDs instead of tuple repr).

## Oracle design consult
- Score 10/12 APPROVE (session ses_24b04c12effeIhLm13aSqH1Ghx). Overrides applied: in-place in `store.py` (option A), ordered dicts over list+set, ValueError, added rejected-claim-state-isolation test.

## Verification
- `uv run pytest -q`: 679 passed, 100% coverage
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run mypy --strict src tests`: clean

Closes #117