### PR TITLE
test(reporting): freeze reporting public surface (#118)

### DIFF
--- a/src/abdp/reporting/__init__.py
+++ b/src/abdp/reporting/__init__.py
@@ -1,8 +1,9 @@
 """Public surface for the ``abdp.reporting`` package.
 
-The reporting package will expose audit-log renderers and report
-generators in subsequent issues. The surface starts empty and is
-extended issue by issue against the frozen surface test in
+The reporting package will host audit-log renderers and report
+generators introduced over the v0.3 milestone. The surface starts
+empty by design; each subsequent issue extends ``__all__`` against
+the frozen surface test in
 ``tests/reporting/test_reporting_public_surface.py``.
 """
 

--- a/src/abdp/reporting/__init__.py
+++ b/src/abdp/reporting/__init__.py
@@ -1,0 +1,9 @@
+"""Public surface for the ``abdp.reporting`` package.
+
+The reporting package will expose audit-log renderers and report
+generators in subsequent issues. The surface starts empty and is
+extended issue by issue against the frozen surface test in
+``tests/reporting/test_reporting_public_surface.py``.
+"""
+
+__all__: tuple[str, ...] = ()

--- a/tests/reporting/test_reporting_public_surface.py
+++ b/tests/reporting/test_reporting_public_surface.py
@@ -1,0 +1,31 @@
+"""Frozen public surface of the ``abdp.reporting`` package."""
+
+from __future__ import annotations
+
+import abdp.reporting
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
+
+
+def test_reporting_package_all_lists_exact_expected_symbols() -> None:
+    assert isinstance(abdp.reporting.__all__, tuple)
+    assert all(isinstance(name, str) for name in abdp.reporting.__all__)
+    assert abdp.reporting.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+def test_reporting_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.reporting import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_reporting_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.reporting) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_reporting_package_has_module_docstring() -> None:
+    doc = abdp.reporting.__doc__
+    assert isinstance(doc, str)
+    assert doc.strip()


### PR DESCRIPTION
## Summary
- Skeleton-first scaffold for `abdp.reporting`. Empty `__all__`; frozen surface test in place ready for #119–#120 to extend per-symbol.

## TDD cycle
- RED `f607d69` — failing surface test (`ModuleNotFoundError`).
- GREEN `6371e1f` — empty `src/abdp/reporting/__init__.py` with module docstring + `__all__: tuple[str, ...] = ()`.
- REFACTOR `ca3c456` — tighten skeleton docstring wording.

## Oracle design consult
- Score 11/12 APPROVE (session ses_24afbf6bdffe3B4A5ExYJ5xnEW). Pattern matches established Living Boundary skeleton-first style.

## Verification
- `uv run pytest -q`: 683 passed, 100% coverage
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run mypy --strict src tests`: clean

Closes #118