### PR TITLE
feat(reporting): add deterministic JSON renderer (#119)

### DIFF
--- a/src/abdp/reporting/__init__.py
+++ b/src/abdp/reporting/__init__.py
@@ -1,10 +1,14 @@
 """Public surface for the ``abdp.reporting`` package.
 
-The reporting package will host audit-log renderers and report
-generators introduced over the v0.3 milestone. The surface starts
-empty by design; each subsequent issue extends ``__all__`` against
-the frozen surface test in
+The reporting package hosts audit-log renderers and report generators
+introduced over the v0.3 milestone. ``render_json_report`` is the
+deterministic JSON renderer for an :class:`abdp.evidence.AuditLog`;
+subsequent issues extend ``__all__`` against the frozen surface test in
 ``tests/reporting/test_reporting_public_surface.py``.
 """
 
-__all__: tuple[str, ...] = ()
+from abdp.reporting.json_renderer import render_json_report
+
+globals().pop("json_renderer", None)
+
+__all__: tuple[str, ...] = ("render_json_report",)

--- a/src/abdp/reporting/json_renderer.py
+++ b/src/abdp/reporting/json_renderer.py
@@ -69,7 +69,7 @@ def _to_jsonable(value: Any) -> Any:
         if isinstance(value, proto):
             return {attr: _to_jsonable(getattr(value, attr)) for attr in attrs}
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return {f.name: _to_jsonable(getattr(value, f.name)) for f in dataclasses.fields(value)}
+        return _serialize_dataclass(value)
     raise TypeError(f"cannot serialize value of type {type(value).__name__}")
 
 
@@ -87,6 +87,10 @@ def _serialize_mapping(value: dict[Any, Any]) -> dict[str, Any]:
             raise TypeError(f"dict key must be str, got {type(k).__name__}")
         out[k] = _to_jsonable(v)
     return out
+
+
+def _serialize_dataclass(value: Any) -> dict[str, Any]:
+    return {f.name: _to_jsonable(getattr(value, f.name)) for f in dataclasses.fields(value)}
 
 
 _PROTOCOL_PROJECTIONS: tuple[tuple[type, tuple[str, ...]], ...] = (

--- a/src/abdp/reporting/json_renderer.py
+++ b/src/abdp/reporting/json_renderer.py
@@ -1,0 +1,97 @@
+"""Deterministic JSON renderer for :class:`abdp.evidence.AuditLog`.
+
+``render_json_report`` walks an :class:`~abdp.evidence.AuditLog` (or any
+JSON-serializable abdp value) and emits a stable, sorted-key JSON string.
+
+Determinism rules:
+
+* keys are sorted; tuples become lists; UUIDs become canonical strings.
+* ``datetime`` values must be timezone-aware UTC; naive or offset-aware
+  non-UTC datetimes are rejected.
+* dict keys must be ``str``; non-string keys are rejected.
+* non-finite floats (``NaN``/``Infinity``) are rejected.
+* values typed as the simulation generic protocols (``ActionProposal``,
+  ``SegmentState``, ``ParticipantState``, ``AgentDecision``) are projected
+  to their protocol attributes only; extra dataclass fields are dropped.
+"""
+
+import dataclasses
+import json
+import math
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from abdp.agents.decision import AgentDecision
+from abdp.simulation.action_proposal import ActionProposal
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
+
+__all__ = ["render_json_report"]
+
+
+def render_json_report(value: Any, *, indent: int = 2) -> str:
+    """Render ``value`` to a deterministic JSON string."""
+    payload = _to_jsonable(value)
+    return json.dumps(
+        payload,
+        indent=indent,
+        sort_keys=True,
+        separators=(",", ": "),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _to_jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"non-finite float values are not JSON-serializable: {value!r}")
+        return value
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return _serialize_datetime(value)
+    if isinstance(value, (tuple, list)):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return _serialize_mapping(value)
+    for proto, attrs in _PROTOCOL_PROJECTIONS:
+        if isinstance(value, proto):
+            return {attr: _to_jsonable(getattr(value, attr)) for attr in attrs}
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {f.name: _to_jsonable(getattr(value, f.name)) for f in dataclasses.fields(value)}
+    raise TypeError(f"cannot serialize value of type {type(value).__name__}")
+
+
+def _serialize_datetime(value: datetime) -> str:
+    tz = value.tzinfo
+    if tz is None or tz.utcoffset(value) != timedelta(0):
+        raise ValueError("datetime must be timezone-aware UTC")
+    return value.isoformat()
+
+
+def _serialize_mapping(value: dict[Any, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in value.items():
+        if not isinstance(k, str):
+            raise TypeError(f"dict key must be str, got {type(k).__name__}")
+        out[k] = _to_jsonable(v)
+    return out
+
+
+_PROTOCOL_PROJECTIONS: tuple[tuple[type, tuple[str, ...]], ...] = (
+    (ActionProposal, ("proposal_id", "actor_id", "action_key", "payload")),
+    (AgentDecision, ("agent_id", "proposals")),
+    (SegmentState, ("segment_id", "participant_ids")),
+    (ParticipantState, ("participant_id",)),
+)

--- a/src/abdp/reporting/json_renderer.py
+++ b/src/abdp/reporting/json_renderer.py
@@ -13,6 +13,8 @@ Determinism rules:
 * values typed as the simulation generic protocols (``ActionProposal``,
   ``SegmentState``, ``ParticipantState``, ``AgentDecision``) are projected
   to their protocol attributes only; extra dataclass fields are dropped.
+* ``indent`` must be a non-bool ``int``; cyclic inputs are rejected with
+  a deterministic ``ValueError`` rather than ``RecursionError``.
 """
 
 import dataclasses
@@ -33,7 +35,9 @@ __all__ = ["render_json_report"]
 
 def render_json_report(value: Any, *, indent: int = 2) -> str:
     """Render ``value`` to a deterministic JSON string."""
-    payload = _to_jsonable(value)
+    if isinstance(indent, bool) or not isinstance(indent, int):
+        raise TypeError(f"indent must be int, got {type(indent).__name__}")
+    payload = _to_jsonable(value, _CycleGuard())
     return json.dumps(
         payload,
         indent=indent,
@@ -44,7 +48,25 @@ def render_json_report(value: Any, *, indent: int = 2) -> str:
     )
 
 
-def _to_jsonable(value: Any) -> Any:
+class _CycleGuard:
+    """Tracks visited container ids on the active descent path."""
+
+    __slots__ = ("_active",)
+
+    def __init__(self) -> None:
+        self._active: set[int] = set()
+
+    def enter(self, value: Any) -> None:
+        oid = id(value)
+        if oid in self._active:
+            raise ValueError(f"cyclic reference detected while serializing {type(value).__name__}")
+        self._active.add(oid)
+
+    def leave(self, value: Any) -> None:
+        self._active.discard(id(value))
+
+
+def _to_jsonable(value: Any, guard: _CycleGuard) -> Any:
     if value is None or isinstance(value, bool):
         return value
     if isinstance(value, int):
@@ -62,14 +84,30 @@ def _to_jsonable(value: Any) -> Any:
     if isinstance(value, datetime):
         return _serialize_datetime(value)
     if isinstance(value, (tuple, list)):
-        return [_to_jsonable(item) for item in value]
+        guard.enter(value)
+        try:
+            return [_to_jsonable(item, guard) for item in value]
+        finally:
+            guard.leave(value)
     if isinstance(value, dict):
-        return _serialize_mapping(value)
+        guard.enter(value)
+        try:
+            return _serialize_mapping(value, guard)
+        finally:
+            guard.leave(value)
     for proto, attrs in _PROTOCOL_PROJECTIONS:
         if isinstance(value, proto):
-            return {attr: _to_jsonable(getattr(value, attr)) for attr in attrs}
+            guard.enter(value)
+            try:
+                return {attr: _to_jsonable(getattr(value, attr), guard) for attr in attrs}
+            finally:
+                guard.leave(value)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return _serialize_dataclass(value)
+        guard.enter(value)
+        try:
+            return _serialize_dataclass(value, guard)
+        finally:
+            guard.leave(value)
     raise TypeError(f"cannot serialize value of type {type(value).__name__}")
 
 
@@ -80,17 +118,17 @@ def _serialize_datetime(value: datetime) -> str:
     return value.isoformat()
 
 
-def _serialize_mapping(value: dict[Any, Any]) -> dict[str, Any]:
+def _serialize_mapping(value: dict[Any, Any], guard: _CycleGuard) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for k, v in value.items():
         if not isinstance(k, str):
             raise TypeError(f"dict key must be str, got {type(k).__name__}")
-        out[k] = _to_jsonable(v)
+        out[k] = _to_jsonable(v, guard)
     return out
 
 
-def _serialize_dataclass(value: Any) -> dict[str, Any]:
-    return {f.name: _to_jsonable(getattr(value, f.name)) for f in dataclasses.fields(value)}
+def _serialize_dataclass(value: Any, guard: _CycleGuard) -> dict[str, Any]:
+    return {f.name: _to_jsonable(getattr(value, f.name), guard) for f in dataclasses.fields(value)}
 
 
 _PROTOCOL_PROJECTIONS: tuple[tuple[type, tuple[str, ...]], ...] = (

--- a/tests/reporting/test_json_renderer.py
+++ b/tests/reporting/test_json_renderer.py
@@ -352,3 +352,34 @@ def test_render_json_report_golden_vector() -> None:
         "}"
     )
     assert rendered == expected
+
+
+def test_render_json_report_rejects_non_int_indent() -> None:
+    with pytest.raises(TypeError, match="indent must be int"):
+        render_json_report(_audit(), indent="  ")  # type: ignore[arg-type]
+
+
+def test_render_json_report_rejects_bool_indent() -> None:
+    with pytest.raises(TypeError, match="indent must be int"):
+        render_json_report(_audit(), indent=True)
+
+
+def test_render_json_report_rejects_cyclic_list() -> None:
+    cycle: list[Any] = []
+    cycle.append(cycle)
+    with pytest.raises(ValueError, match="cyclic reference"):
+        render_json_report(cycle)
+
+
+def test_render_json_report_rejects_cyclic_dict() -> None:
+    cycle: dict[str, Any] = {}
+    cycle["self"] = cycle
+    with pytest.raises(ValueError, match="cyclic reference"):
+        render_json_report(cycle)
+
+
+def test_render_json_report_allows_shared_acyclic_references() -> None:
+    shared = {"x": 1}
+    parent = {"a": shared, "b": shared}
+    parsed = json.loads(render_json_report(parent))
+    assert parsed == {"a": {"x": 1}, "b": {"x": 1}}

--- a/tests/reporting/test_json_renderer.py
+++ b/tests/reporting/test_json_renderer.py
@@ -1,0 +1,352 @@
+"""Tests for ``abdp.reporting.render_json_report``."""
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evaluation.gate import GateResult
+from abdp.evaluation.metric import MetricResult
+from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
+from abdp.reporting import render_json_report
+from abdp.scenario import ScenarioRun
+from abdp.scenario.step import ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+@dataclass(frozen=True, slots=True)
+class _Segment:
+    """SegmentState dataclass with an extra field that must be projected away."""
+
+    segment_id: str
+    participant_ids: tuple[str, ...]
+    extra_segment_field: str = "should-not-appear"
+
+
+@dataclass(frozen=True, slots=True)
+class _Participant:
+    """ParticipantState dataclass with an extra field that must be projected away."""
+
+    participant_id: str
+    extra_participant_field: str = "should-not-appear"
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    """ActionProposal dataclass with an extra field that must be projected away."""
+
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: Any
+    extra_action_field: str = "should-not-appear"
+
+
+@dataclass(frozen=True, slots=True)
+class _Decision:
+    """AgentDecision dataclass with an extra field that must be projected away."""
+
+    agent_id: str
+    proposals: tuple[_Action, ...]
+    extra_decision_field: str = "should-not-appear"
+
+
+def _state(
+    *,
+    segments: tuple[_Segment, ...] = (),
+    participants: tuple[_Participant, ...] = (),
+    pending_actions: tuple[_Action, ...] = (),
+) -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=Seed(0),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("00000000-0000-0000-0000-000000000001"),
+            tier="bronze",
+            storage_key="snapshots/run",
+        ),
+        segments=segments,
+        participants=participants,
+        pending_actions=pending_actions,
+    )
+
+
+def _run(
+    *,
+    steps: tuple[ScenarioStep[SegmentState, ParticipantState, ActionProposal], ...] = (),
+) -> ScenarioRun[SegmentState, ParticipantState, ActionProposal]:
+    return ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        steps=steps,
+        final_state=_state(),
+    )
+
+
+def _summary() -> EvaluationSummary:
+    return EvaluationSummary(
+        metrics=(MetricResult(metric_id="m", value=1, details={}),),
+        gates=(GateResult(gate_id="g", status=GateStatus.PASS, reason="ok", details={}),),
+        overall_status=GateStatus.PASS,
+    )
+
+
+def _evidence() -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_id=UUID(int=1),
+        evidence_key="ek",
+        step_index=0,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _claim() -> ClaimRecord:
+    return ClaimRecord(
+        claim_id=UUID(int=100),
+        statement="s",
+        evidence_ids=(UUID(int=1),),
+        confidence=0.5,
+        metadata={},
+    )
+
+
+def _audit(
+    *,
+    run: ScenarioRun[SegmentState, ParticipantState, ActionProposal] | None = None,
+) -> AuditLog[SegmentState, ParticipantState, ActionProposal]:
+    return AuditLog[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        run=run if run is not None else _run(),
+        summary=_summary(),
+        evidence=(_evidence(),),
+        claims=(_claim(),),
+    )
+
+
+def test_render_json_report_is_deterministic() -> None:
+    audit = _audit()
+    assert render_json_report(audit) == render_json_report(audit)
+
+
+def test_render_json_report_sorts_keys() -> None:
+    rendered = render_json_report(_audit())
+    parsed = json.loads(rendered)
+    top_keys = [line.split('"')[1] for line in rendered.splitlines() if line.startswith('  "')]
+    assert top_keys == sorted(parsed.keys())
+
+
+def test_render_json_report_round_trip_preserves_structure() -> None:
+    audit = _audit()
+    parsed = json.loads(render_json_report(audit))
+    assert parsed["scenario_key"] == "k"
+    assert parsed["seed"] == 0
+    assert parsed["summary"]["overall_status"] == "pass"
+    assert parsed["evidence"][0]["evidence_key"] == "ek"
+    assert parsed["claims"][0]["statement"] == "s"
+
+
+def test_render_json_report_serializes_uuid_as_canonical_string() -> None:
+    parsed = json.loads(render_json_report(_audit()))
+    assert parsed["evidence"][0]["evidence_id"] == "00000000-0000-0000-0000-000000000001"
+
+
+def test_render_json_report_serializes_utc_datetime_as_iso8601() -> None:
+    parsed = json.loads(render_json_report(_audit()))
+    assert parsed["evidence"][0]["created_at"] == "2026-01-01T00:00:00+00:00"
+
+
+def test_render_json_report_rejects_naive_datetime() -> None:
+    @dataclass(frozen=True, slots=True)
+    class _Wrap:
+        when: datetime
+
+    naive = _Wrap(when=datetime(2026, 1, 1))
+    with pytest.raises(ValueError, match="UTC"):
+        render_json_report(naive)  # type: ignore[arg-type]
+
+
+def test_render_json_report_rejects_non_utc_datetime() -> None:
+    @dataclass(frozen=True, slots=True)
+    class _Wrap:
+        when: datetime
+
+    other = _Wrap(when=datetime(2026, 1, 1, tzinfo=timezone(timedelta(hours=9))))
+    with pytest.raises(ValueError, match="UTC"):
+        render_json_report(other)  # type: ignore[arg-type]
+
+
+def test_render_json_report_serializes_tuple_as_list() -> None:
+    parsed = json.loads(render_json_report(_audit()))
+    assert isinstance(parsed["evidence"], list)
+    assert isinstance(parsed["claims"][0]["evidence_ids"], list)
+
+
+def test_render_json_report_serializes_gate_status_as_string() -> None:
+    parsed = json.loads(render_json_report(_audit()))
+    assert parsed["summary"]["gates"][0]["status"] == "pass"
+    assert parsed["summary"]["overall_status"] == "pass"
+
+
+def test_render_json_report_default_indent_is_two() -> None:
+    rendered = render_json_report(_audit())
+    assert '\n  "scenario_key"' in rendered
+
+
+def test_render_json_report_indent_zero_still_uses_newlines() -> None:
+    rendered = render_json_report(_audit(), indent=0)
+    assert "\n" in rendered
+
+
+def test_render_json_report_projects_action_proposal_protocol_only() -> None:
+    action = _Action(proposal_id="p", actor_id="a", action_key="k", payload={"v": 1})
+    state = _state(pending_actions=(action,))
+    run = _run(
+        steps=(
+            ScenarioStep[SegmentState, ParticipantState, ActionProposal](
+                state=state,
+                decisions=(),
+                proposals=(action,),
+            ),
+        )
+    )
+    rendered = render_json_report(_audit(run=run))
+    assert "extra_action_field" not in rendered
+
+
+def test_render_json_report_projects_segment_state_protocol_only() -> None:
+    seg = _Segment(segment_id="s1", participant_ids=("p1",))
+    state = _state(segments=(seg,))
+    run = _run(
+        steps=(ScenarioStep[SegmentState, ParticipantState, ActionProposal](state=state, decisions=(), proposals=()),)
+    )
+    rendered = render_json_report(_audit(run=run))
+    assert "extra_segment_field" not in rendered
+
+
+def test_render_json_report_projects_participant_state_protocol_only() -> None:
+    part = _Participant(participant_id="p1")
+    state = _state(participants=(part,))
+    run = _run(
+        steps=(ScenarioStep[SegmentState, ParticipantState, ActionProposal](state=state, decisions=(), proposals=()),)
+    )
+    rendered = render_json_report(_audit(run=run))
+    assert "extra_participant_field" not in rendered
+
+
+def test_render_json_report_projects_agent_decision_protocol_only() -> None:
+    action = _Action(proposal_id="p", actor_id="a", action_key="k", payload=None)
+    decision = _Decision(agent_id="ag", proposals=(action,))
+    state = _state(pending_actions=(action,))
+    run = _run(
+        steps=(
+            ScenarioStep[SegmentState, ParticipantState, ActionProposal](
+                state=state, decisions=(decision,), proposals=(action,)
+            ),
+        )
+    )
+    rendered = render_json_report(_audit(run=run))
+    assert "extra_decision_field" not in rendered
+
+
+def test_render_json_report_rejects_unsupported_type() -> None:
+    class Opaque:
+        pass
+
+    with pytest.raises(TypeError, match="cannot serialize"):
+        render_json_report(Opaque())  # type: ignore[arg-type]
+
+
+def test_render_json_report_rejects_non_string_dict_key() -> None:
+    @dataclass(frozen=True, slots=True)
+    class _Wrap:
+        m: dict[Any, Any]
+
+    with pytest.raises(TypeError, match="dict key"):
+        render_json_report(_Wrap(m={1: "v"}))  # type: ignore[arg-type]
+
+
+def test_render_json_report_rejects_nan_float() -> None:
+    @dataclass(frozen=True, slots=True)
+    class _Wrap:
+        v: float
+
+    with pytest.raises(ValueError):
+        render_json_report(_Wrap(v=float("nan")))  # type: ignore[arg-type]
+
+
+def test_render_json_report_golden_vector() -> None:
+    rendered = render_json_report(_audit())
+    expected = (
+        "{\n"
+        '  "claims": [\n'
+        "    {\n"
+        '      "claim_id": "00000000-0000-0000-0000-000000000064",\n'
+        '      "confidence": 0.5,\n'
+        '      "evidence_ids": [\n'
+        '        "00000000-0000-0000-0000-000000000001"\n'
+        "      ],\n"
+        '      "metadata": {},\n'
+        '      "statement": "s"\n'
+        "    }\n"
+        "  ],\n"
+        '  "evidence": [\n'
+        "    {\n"
+        '      "agent_id": "agent",\n'
+        '      "created_at": "2026-01-01T00:00:00+00:00",\n'
+        '      "evidence_id": "00000000-0000-0000-0000-000000000001",\n'
+        '      "evidence_key": "ek",\n'
+        '      "payload": {\n'
+        '        "x": 1\n'
+        "      },\n"
+        '      "step_index": 0\n'
+        "    }\n"
+        "  ],\n"
+        '  "run": {\n'
+        '    "final_state": {\n'
+        '      "participants": [],\n'
+        '      "pending_actions": [],\n'
+        '      "seed": 0,\n'
+        '      "segments": [],\n'
+        '      "snapshot_ref": {\n'
+        '        "snapshot_id": "00000000-0000-0000-0000-000000000001",\n'
+        '        "storage_key": "snapshots/run",\n'
+        '        "tier": "bronze"\n'
+        "      },\n"
+        '      "step_index": 0\n'
+        "    },\n"
+        '    "scenario_key": "k",\n'
+        '    "seed": 0,\n'
+        '    "steps": []\n'
+        "  },\n"
+        '  "scenario_key": "k",\n'
+        '  "seed": 0,\n'
+        '  "summary": {\n'
+        '    "gates": [\n'
+        "      {\n"
+        '        "details": {},\n'
+        '        "gate_id": "g",\n'
+        '        "reason": "ok",\n'
+        '        "status": "pass"\n'
+        "      }\n"
+        "    ],\n"
+        '    "metrics": [\n'
+        "      {\n"
+        '        "details": {},\n'
+        '        "metric_id": "m",\n'
+        '        "value": 1\n'
+        "      }\n"
+        "    ],\n"
+        '    "overall_status": "pass"\n'
+        "  }\n"
+        "}"
+    )
+    assert rendered == expected

--- a/tests/reporting/test_json_renderer.py
+++ b/tests/reporting/test_json_renderer.py
@@ -3,11 +3,12 @@
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 import pytest
 
+from abdp.agents.decision import AgentDecision
 from abdp.core import Seed
 from abdp.evaluation import EvaluationSummary, GateStatus
 from abdp.evaluation.gate import GateResult
@@ -53,7 +54,7 @@ class _Decision:
     """AgentDecision dataclass with an extra field that must be projected away."""
 
     agent_id: str
-    proposals: tuple[_Action, ...]
+    proposals: tuple[ActionProposal, ...]
     extra_decision_field: str = "should-not-appear"
 
 
@@ -171,7 +172,7 @@ def test_render_json_report_rejects_naive_datetime() -> None:
 
     naive = _Wrap(when=datetime(2026, 1, 1))
     with pytest.raises(ValueError, match="UTC"):
-        render_json_report(naive)  # type: ignore[arg-type]
+        render_json_report(naive)
 
 
 def test_render_json_report_rejects_non_utc_datetime() -> None:
@@ -181,7 +182,7 @@ def test_render_json_report_rejects_non_utc_datetime() -> None:
 
     other = _Wrap(when=datetime(2026, 1, 1, tzinfo=timezone(timedelta(hours=9))))
     with pytest.raises(ValueError, match="UTC"):
-        render_json_report(other)  # type: ignore[arg-type]
+        render_json_report(other)
 
 
 def test_render_json_report_serializes_tuple_as_list() -> None:
@@ -246,10 +247,11 @@ def test_render_json_report_projects_agent_decision_protocol_only() -> None:
     action = _Action(proposal_id="p", actor_id="a", action_key="k", payload=None)
     decision = _Decision(agent_id="ag", proposals=(action,))
     state = _state(pending_actions=(action,))
+    decisions: tuple[AgentDecision[ActionProposal], ...] = (cast(AgentDecision[ActionProposal], decision),)
     run = _run(
         steps=(
             ScenarioStep[SegmentState, ParticipantState, ActionProposal](
-                state=state, decisions=(decision,), proposals=(action,)
+                state=state, decisions=decisions, proposals=(action,)
             ),
         )
     )
@@ -262,7 +264,7 @@ def test_render_json_report_rejects_unsupported_type() -> None:
         pass
 
     with pytest.raises(TypeError, match="cannot serialize"):
-        render_json_report(Opaque())  # type: ignore[arg-type]
+        render_json_report(Opaque())
 
 
 def test_render_json_report_rejects_non_string_dict_key() -> None:
@@ -271,7 +273,7 @@ def test_render_json_report_rejects_non_string_dict_key() -> None:
         m: dict[Any, Any]
 
     with pytest.raises(TypeError, match="dict key"):
-        render_json_report(_Wrap(m={1: "v"}))  # type: ignore[arg-type]
+        render_json_report(_Wrap(m={1: "v"}))
 
 
 def test_render_json_report_rejects_nan_float() -> None:
@@ -280,7 +282,7 @@ def test_render_json_report_rejects_nan_float() -> None:
         v: float
 
     with pytest.raises(ValueError):
-        render_json_report(_Wrap(v=float("nan")))  # type: ignore[arg-type]
+        render_json_report(_Wrap(v=float("nan")))
 
 
 def test_render_json_report_golden_vector() -> None:

--- a/tests/reporting/test_reporting_public_surface.py
+++ b/tests/reporting/test_reporting_public_surface.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-import abdp.reporting
+import pytest
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ()
+import abdp.reporting
+from abdp.reporting.json_renderer import render_json_report
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("render_json_report",)
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {"render_json_report": render_json_report}
 
 
 def test_reporting_package_all_lists_exact_expected_symbols() -> None:
@@ -29,3 +33,8 @@ def test_reporting_package_has_module_docstring() -> None:
     doc = abdp.reporting.__doc__
     assert isinstance(doc, str)
     assert doc.strip()
+
+
+@pytest.mark.parametrize("name", list(EXPECTED_SOURCE_IDENTITY))
+def test_reporting_public_symbols_resolve_to_canonical_definitions(name: str) -> None:
+    assert getattr(abdp.reporting, name) is EXPECTED_SOURCE_IDENTITY[name]


### PR DESCRIPTION
## Summary
- Adds `abdp.reporting.render_json_report` — deterministic, sorted-key JSON renderer for `AuditLog`.
- Recursive `_to_jsonable` dispatch with strict invariants per Oracle design (10/12 APPROVE):
  - Protocol projection (`ActionProposal`/`AgentDecision`/`SegmentState`/`ParticipantState`) wins over generic dataclass projection so user types only emit their protocol attributes.
  - Datetime values must be timezone-aware UTC; naive or offset datetimes raise `ValueError`.
  - Dict keys must be `str`; non-string keys raise `TypeError`.
  - Non-finite floats rejected via `allow_nan=False`.
  - `StrEnum` (e.g., `GateStatus`) emitted via `.value`; UUID via canonical string; tuples → lists.
- Extends `abdp.reporting.__all__` from `()` to `("render_json_report",)` and updates the frozen surface test.
- Pinned golden-vector JSON string locks byte identity for the canonical fixture.

Closes #119