### PR TITLE
feat(reporting): add deterministic Markdown renderer (#120)

### DIFF
--- a/src/abdp/reporting/__init__.py
+++ b/src/abdp/reporting/__init__.py
@@ -2,13 +2,17 @@
 
 The reporting package hosts audit-log renderers and report generators
 introduced over the v0.3 milestone. ``render_json_report`` is the
-deterministic JSON renderer for an :class:`abdp.evidence.AuditLog`;
-subsequent issues extend ``__all__`` against the frozen surface test in
+deterministic JSON renderer; ``render_markdown_report`` is the
+deterministic Markdown renderer for an :class:`abdp.evidence.AuditLog`.
+Subsequent issues extend ``__all__`` against the frozen surface test in
 ``tests/reporting/test_reporting_public_surface.py``.
 """
 
 from abdp.reporting.json_renderer import render_json_report
+from abdp.reporting.markdown_renderer import render_markdown_report
 
 globals().pop("json_renderer", None)
+globals().pop("markdown_renderer", None)
+globals().pop("_normalize", None)
 
-__all__: tuple[str, ...] = ("render_json_report",)
+__all__: tuple[str, ...] = ("render_json_report", "render_markdown_report")

--- a/src/abdp/reporting/_normalize.py
+++ b/src/abdp/reporting/_normalize.py
@@ -1,0 +1,124 @@
+"""Shared deterministic value normalization for ``abdp.reporting``.
+
+Both :func:`abdp.reporting.render_json_report` and
+:func:`abdp.reporting.render_markdown_report` consume :func:`to_jsonable`
+so JSON-serializable abdp values are normalized through one set of
+invariants:
+
+* primitives, ``StrEnum`` (via ``.value``), ``UUID`` (canonical string),
+  and timezone-aware UTC ``datetime`` (ISO 8601);
+* tuples and lists become lists; dicts require ``str`` keys;
+* non-finite floats are rejected;
+* values typed as the simulation generic protocols
+  (``ActionProposal``/``SegmentState``/``ParticipantState``/``AgentDecision``)
+  are projected to their protocol attributes only;
+* dataclasses are projected by ``dataclasses.fields`` order;
+* cyclic inputs raise a deterministic ``ValueError`` instead of
+  ``RecursionError``.
+"""
+
+import dataclasses
+import math
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from abdp.agents.decision import AgentDecision
+from abdp.simulation.action_proposal import ActionProposal
+from abdp.simulation.participant_state import ParticipantState
+from abdp.simulation.segment_state import SegmentState
+
+__all__ = ["CycleGuard", "to_jsonable"]
+
+
+class CycleGuard:
+    """Tracks visited container ids on the active descent path."""
+
+    __slots__ = ("_active",)
+
+    def __init__(self) -> None:
+        self._active: set[int] = set()
+
+    def enter(self, value: Any) -> None:
+        oid = id(value)
+        if oid in self._active:
+            raise ValueError(f"cyclic reference detected while serializing {type(value).__name__}")
+        self._active.add(oid)
+
+    def leave(self, value: Any) -> None:
+        self._active.discard(id(value))
+
+
+def to_jsonable(value: Any, guard: CycleGuard | None = None) -> Any:
+    """Normalize ``value`` to a JSON-compatible Python value."""
+    return _to_jsonable(value, guard if guard is not None else CycleGuard())
+
+
+def _to_jsonable(value: Any, guard: CycleGuard) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"non-finite float values are not JSON-serializable: {value!r}")
+        return value
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return _serialize_datetime(value)
+    if isinstance(value, (tuple, list)):
+        guard.enter(value)
+        try:
+            return [_to_jsonable(item, guard) for item in value]
+        finally:
+            guard.leave(value)
+    if isinstance(value, dict):
+        guard.enter(value)
+        try:
+            return _serialize_mapping(value, guard)
+        finally:
+            guard.leave(value)
+    for proto, attrs in _PROTOCOL_PROJECTIONS:
+        if isinstance(value, proto):
+            guard.enter(value)
+            try:
+                return {attr: _to_jsonable(getattr(value, attr), guard) for attr in attrs}
+            finally:
+                guard.leave(value)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        guard.enter(value)
+        try:
+            return {f.name: _to_jsonable(getattr(value, f.name), guard) for f in dataclasses.fields(value)}
+        finally:
+            guard.leave(value)
+    raise TypeError(f"cannot serialize value of type {type(value).__name__}")
+
+
+def _serialize_datetime(value: datetime) -> str:
+    tz = value.tzinfo
+    if tz is None or tz.utcoffset(value) != timedelta(0):
+        raise ValueError("datetime must be timezone-aware UTC")
+    return value.isoformat()
+
+
+def _serialize_mapping(value: dict[Any, Any], guard: CycleGuard) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in value.items():
+        if not isinstance(k, str):
+            raise TypeError(f"dict key must be str, got {type(k).__name__}")
+        out[k] = _to_jsonable(v, guard)
+    return out
+
+
+_PROTOCOL_PROJECTIONS: tuple[tuple[type, tuple[str, ...]], ...] = (
+    (ActionProposal, ("proposal_id", "actor_id", "action_key", "payload")),
+    (AgentDecision, ("agent_id", "proposals")),
+    (SegmentState, ("segment_id", "participant_ids")),
+    (ParticipantState, ("participant_id",)),
+)

--- a/src/abdp/reporting/json_renderer.py
+++ b/src/abdp/reporting/json_renderer.py
@@ -1,34 +1,15 @@
 """Deterministic JSON renderer for :class:`abdp.evidence.AuditLog`.
 
 ``render_json_report`` walks an :class:`~abdp.evidence.AuditLog` (or any
-JSON-serializable abdp value) and emits a stable, sorted-key JSON string.
-
-Determinism rules:
-
-* keys are sorted; tuples become lists; UUIDs become canonical strings.
-* ``datetime`` values must be timezone-aware UTC; naive or offset-aware
-  non-UTC datetimes are rejected.
-* dict keys must be ``str``; non-string keys are rejected.
-* non-finite floats (``NaN``/``Infinity``) are rejected.
-* values typed as the simulation generic protocols (``ActionProposal``,
-  ``SegmentState``, ``ParticipantState``, ``AgentDecision``) are projected
-  to their protocol attributes only; extra dataclass fields are dropped.
-* ``indent`` must be a non-bool ``int``; cyclic inputs are rejected with
-  a deterministic ``ValueError`` rather than ``RecursionError``.
+JSON-serializable abdp value) and emits a stable, sorted-key JSON string
+through the shared :mod:`abdp.reporting._normalize` invariants.
+``indent`` must be a non-bool ``int``.
 """
 
-import dataclasses
 import json
-import math
-from datetime import datetime, timedelta
-from enum import StrEnum
 from typing import Any
-from uuid import UUID
 
-from abdp.agents.decision import AgentDecision
-from abdp.simulation.action_proposal import ActionProposal
-from abdp.simulation.participant_state import ParticipantState
-from abdp.simulation.segment_state import SegmentState
+from abdp.reporting._normalize import to_jsonable
 
 __all__ = ["render_json_report"]
 
@@ -37,7 +18,7 @@ def render_json_report(value: Any, *, indent: int = 2) -> str:
     """Render ``value`` to a deterministic JSON string."""
     if isinstance(indent, bool) or not isinstance(indent, int):
         raise TypeError(f"indent must be int, got {type(indent).__name__}")
-    payload = _to_jsonable(value, _CycleGuard())
+    payload = to_jsonable(value)
     return json.dumps(
         payload,
         indent=indent,
@@ -46,94 +27,3 @@ def render_json_report(value: Any, *, indent: int = 2) -> str:
         ensure_ascii=False,
         allow_nan=False,
     )
-
-
-class _CycleGuard:
-    """Tracks visited container ids on the active descent path."""
-
-    __slots__ = ("_active",)
-
-    def __init__(self) -> None:
-        self._active: set[int] = set()
-
-    def enter(self, value: Any) -> None:
-        oid = id(value)
-        if oid in self._active:
-            raise ValueError(f"cyclic reference detected while serializing {type(value).__name__}")
-        self._active.add(oid)
-
-    def leave(self, value: Any) -> None:
-        self._active.discard(id(value))
-
-
-def _to_jsonable(value: Any, guard: _CycleGuard) -> Any:
-    if value is None or isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(f"non-finite float values are not JSON-serializable: {value!r}")
-        return value
-    if isinstance(value, StrEnum):
-        return value.value
-    if isinstance(value, str):
-        return value
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, datetime):
-        return _serialize_datetime(value)
-    if isinstance(value, (tuple, list)):
-        guard.enter(value)
-        try:
-            return [_to_jsonable(item, guard) for item in value]
-        finally:
-            guard.leave(value)
-    if isinstance(value, dict):
-        guard.enter(value)
-        try:
-            return _serialize_mapping(value, guard)
-        finally:
-            guard.leave(value)
-    for proto, attrs in _PROTOCOL_PROJECTIONS:
-        if isinstance(value, proto):
-            guard.enter(value)
-            try:
-                return {attr: _to_jsonable(getattr(value, attr), guard) for attr in attrs}
-            finally:
-                guard.leave(value)
-    if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        guard.enter(value)
-        try:
-            return _serialize_dataclass(value, guard)
-        finally:
-            guard.leave(value)
-    raise TypeError(f"cannot serialize value of type {type(value).__name__}")
-
-
-def _serialize_datetime(value: datetime) -> str:
-    tz = value.tzinfo
-    if tz is None or tz.utcoffset(value) != timedelta(0):
-        raise ValueError("datetime must be timezone-aware UTC")
-    return value.isoformat()
-
-
-def _serialize_mapping(value: dict[Any, Any], guard: _CycleGuard) -> dict[str, Any]:
-    out: dict[str, Any] = {}
-    for k, v in value.items():
-        if not isinstance(k, str):
-            raise TypeError(f"dict key must be str, got {type(k).__name__}")
-        out[k] = _to_jsonable(v, guard)
-    return out
-
-
-def _serialize_dataclass(value: Any, guard: _CycleGuard) -> dict[str, Any]:
-    return {f.name: _to_jsonable(getattr(value, f.name), guard) for f in dataclasses.fields(value)}
-
-
-_PROTOCOL_PROJECTIONS: tuple[tuple[type, tuple[str, ...]], ...] = (
-    (ActionProposal, ("proposal_id", "actor_id", "action_key", "payload")),
-    (AgentDecision, ("agent_id", "proposals")),
-    (SegmentState, ("segment_id", "participant_ids")),
-    (ParticipantState, ("participant_id",)),
-)

--- a/src/abdp/reporting/markdown_renderer.py
+++ b/src/abdp/reporting/markdown_renderer.py
@@ -1,0 +1,139 @@
+"""Deterministic Markdown renderer for :class:`abdp.evidence.AuditLog`.
+
+``render_markdown_report`` produces a byte-stable Markdown audit report.
+Sections appear in a fixed order (Header, Summary, Metrics, Gates,
+Evidence, Claims) with one blank line between them and a trailing
+newline at end of document. All scalar values flow through
+:mod:`abdp.reporting._normalize` so UTC, NaN, and dict-key invariants
+match :func:`abdp.reporting.render_json_report`. Inline JSON inside
+table cells and bullet lines uses a compact ``json.dumps`` with sorted
+keys. Pipe characters in table cells are escaped as ``\\|`` and raw
+newlines in single-line contexts are replaced with ``<br>``.
+"""
+
+import json
+from typing import Any
+
+from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
+from abdp.evaluation.gate import GateResult
+from abdp.evaluation.metric import MetricResult
+from abdp.reporting._normalize import to_jsonable
+
+__all__ = ["render_markdown_report"]
+
+
+def render_markdown_report(audit: AuditLog[Any, Any, Any]) -> str:
+    """Render ``audit`` to a deterministic Markdown audit report."""
+    if not isinstance(audit, AuditLog):
+        raise TypeError(f"render_markdown_report expects AuditLog, got {type(audit).__name__}")
+    sections = (
+        _section_header(audit),
+        _section_summary(audit),
+        _section_metrics_table(audit.summary.metrics),
+        _section_gates_table(audit.summary.gates),
+        _section_evidence_list(audit.evidence),
+        _section_claims_list(audit.claims),
+    )
+    return "\n\n".join(sections) + "\n"
+
+
+def _section_header(audit: AuditLog[Any, Any, Any]) -> str:
+    return (
+        "# Audit Report\n"
+        "\n"
+        f"- Scenario: {audit.scenario_key}\n"
+        f"- Seed: {int(audit.seed)}\n"
+        f"- Steps: {audit.run.step_count}"
+    )
+
+
+def _section_summary(audit: AuditLog[Any, Any, Any]) -> str:
+    summary = audit.summary
+    return (
+        "## Summary\n"
+        "\n"
+        f"- Overall status: {summary.overall_status.value}\n"
+        f"- Metrics: {len(summary.metrics)}\n"
+        f"- Gates: {len(summary.gates)}\n"
+        f"- Evidence: {len(audit.evidence)}\n"
+        f"- Claims: {len(audit.claims)}"
+    )
+
+
+def _section_metrics_table(metrics: tuple[MetricResult, ...]) -> str:
+    lines = ["## Metrics", "", "| Metric ID | Value | Details |", "| --- | --- | --- |"]
+    for metric in metrics:
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    _table_cell(metric.metric_id),
+                    _table_cell(_inline_json(metric.value)),
+                    _table_cell(_inline_json(metric.details)),
+                )
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _section_gates_table(gates: tuple[GateResult, ...]) -> str:
+    lines = [
+        "## Gates",
+        "",
+        "| Gate ID | Status | Reason | Details |",
+        "| --- | --- | --- | --- |",
+    ]
+    for gate in gates:
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    _table_cell(gate.gate_id),
+                    _table_cell(gate.status.value),
+                    _table_cell(gate.reason),
+                    _table_cell(_inline_json(gate.details)),
+                )
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _section_evidence_list(evidence: tuple[EvidenceRecord, ...]) -> str:
+    lines = ["## Evidence", ""]
+    for record in evidence:
+        created_at = to_jsonable(record.created_at)
+        payload = _inline_json(record.payload)
+        lines.append(
+            f"- {record.evidence_id} [{created_at}] step={record.step_index}"
+            f" agent={record.agent_id} key={record.evidence_key} payload={payload}"
+        )
+    return "\n".join(lines)
+
+
+def _section_claims_list(claims: tuple[ClaimRecord, ...]) -> str:
+    lines = ["## Claims", ""]
+    for claim in claims:
+        statement = _inline_json(claim.statement)
+        evidence_ids = _inline_json(list(claim.evidence_ids))
+        metadata = _inline_json(claim.metadata)
+        lines.append(
+            f"- {claim.claim_id} statement={statement} confidence={claim.confidence}"
+            f" evidence={evidence_ids} metadata={metadata}"
+        )
+    return "\n".join(lines)
+
+
+def _inline_json(value: Any) -> str:
+    return json.dumps(
+        to_jsonable(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _table_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", "<br>")

--- a/src/abdp/reporting/markdown_renderer.py
+++ b/src/abdp/reporting/markdown_renderer.py
@@ -42,7 +42,7 @@ def _section_header(audit: AuditLog[Any, Any, Any]) -> str:
     return (
         "# Audit Report\n"
         "\n"
-        f"- Scenario: {audit.scenario_key}\n"
+        f"- Scenario: {_inline_text(audit.scenario_key)}\n"
         f"- Seed: {int(audit.seed)}\n"
         f"- Steps: {audit.run.step_count}"
     )
@@ -84,7 +84,8 @@ def _section_evidence_list(evidence: tuple[EvidenceRecord, ...]) -> str:
         payload = _inline_json(record.payload)
         lines.append(
             f"- {record.evidence_id} [{created_at}] step={record.step_index}"
-            f" agent={record.agent_id} key={record.evidence_key} payload={payload}"
+            f" agent={_inline_text(record.agent_id)}"
+            f" key={_inline_text(record.evidence_key)} payload={payload}"
         )
     return "\n".join(lines)
 
@@ -126,3 +127,7 @@ def _inline_json(value: Any) -> str:
 
 def _table_cell(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def _inline_text(text: str) -> str:
+    return text.replace("\r\n", "<br>").replace("\n", "<br>").replace("\r", "<br>")

--- a/src/abdp/reporting/markdown_renderer.py
+++ b/src/abdp/reporting/markdown_renderer.py
@@ -12,6 +12,7 @@ newlines in single-line contexts are replaced with ``<br>``.
 """
 
 import json
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
@@ -61,43 +62,19 @@ def _section_summary(audit: AuditLog[Any, Any, Any]) -> str:
 
 
 def _section_metrics_table(metrics: tuple[MetricResult, ...]) -> str:
-    lines = ["## Metrics", "", "| Metric ID | Value | Details |", "| --- | --- | --- |"]
-    for metric in metrics:
-        lines.append(
-            "| "
-            + " | ".join(
-                (
-                    _table_cell(metric.metric_id),
-                    _table_cell(_inline_json(metric.value)),
-                    _table_cell(_inline_json(metric.details)),
-                )
-            )
-            + " |"
-        )
-    return "\n".join(lines)
+    return _render_table(
+        title="## Metrics",
+        headers=("Metric ID", "Value", "Details"),
+        rows=((metric.metric_id, _inline_json(metric.value), _inline_json(metric.details)) for metric in metrics),
+    )
 
 
 def _section_gates_table(gates: tuple[GateResult, ...]) -> str:
-    lines = [
-        "## Gates",
-        "",
-        "| Gate ID | Status | Reason | Details |",
-        "| --- | --- | --- | --- |",
-    ]
-    for gate in gates:
-        lines.append(
-            "| "
-            + " | ".join(
-                (
-                    _table_cell(gate.gate_id),
-                    _table_cell(gate.status.value),
-                    _table_cell(gate.reason),
-                    _table_cell(_inline_json(gate.details)),
-                )
-            )
-            + " |"
-        )
-    return "\n".join(lines)
+    return _render_table(
+        title="## Gates",
+        headers=("Gate ID", "Status", "Reason", "Details"),
+        rows=((gate.gate_id, gate.status.value, gate.reason, _inline_json(gate.details)) for gate in gates),
+    )
 
 
 def _section_evidence_list(evidence: tuple[EvidenceRecord, ...]) -> str:
@@ -122,6 +99,18 @@ def _section_claims_list(claims: tuple[ClaimRecord, ...]) -> str:
             f"- {claim.claim_id} statement={statement} confidence={claim.confidence}"
             f" evidence={evidence_ids} metadata={metadata}"
         )
+    return "\n".join(lines)
+
+
+def _render_table(*, title: str, headers: Sequence[str], rows: Iterable[Sequence[str]]) -> str:
+    lines = [
+        title,
+        "",
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_table_cell(cell) for cell in row) + " |")
     return "\n".join(lines)
 
 

--- a/tests/reporting/test_markdown_renderer.py
+++ b/tests/reporting/test_markdown_renderer.py
@@ -1,7 +1,7 @@
 """Tests for ``abdp.reporting.render_markdown_report``."""
 
 from datetime import UTC, datetime, timedelta, timezone
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 import pytest
@@ -94,8 +94,9 @@ def test_render_markdown_report_is_deterministic() -> None:
 
 
 def test_render_markdown_report_rejects_non_audit_log() -> None:
+    bad = cast(AuditLog[Any, Any, Any], {"not": "audit"})
     with pytest.raises(TypeError, match="AuditLog"):
-        render_markdown_report({"not": "audit"})  # type: ignore[arg-type]
+        render_markdown_report(bad)
 
 
 def test_render_markdown_report_ends_with_newline() -> None:
@@ -246,3 +247,53 @@ def test_render_markdown_report_handles_payload_with_non_string_dict_key() -> No
     bad_metric = MetricResult(metric_id="m", value=bad_value, details={})
     with pytest.raises(TypeError, match="dict key"):
         render_markdown_report(_audit(summary=_summary(metrics=(bad_metric,))))
+
+
+def test_render_markdown_report_sanitizes_newlines_in_scenario_key() -> None:
+    run = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="line1\nline2",
+        seed=Seed(0),
+        steps=(),
+        final_state=_state(),
+    )
+    audit = AuditLog[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="line1\nline2",
+        seed=Seed(0),
+        run=run,
+        summary=_summary(),
+        evidence=(_evidence(),),
+        claims=(_claim(),),
+    )
+    rendered = render_markdown_report(audit)
+    assert "- Scenario: line1<br>line2\n" in rendered
+    assert "- Scenario: line1\nline2" not in rendered
+
+
+def test_render_markdown_report_sanitizes_newlines_in_evidence_fields() -> None:
+    evidence = EvidenceRecord(
+        evidence_id=UUID(int=1),
+        evidence_key="key\nwith\nbreaks",
+        step_index=0,
+        agent_id="agent\nname",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    rendered = render_markdown_report(_audit(evidence=(evidence,)))
+    assert "agent=agent<br>name" in rendered
+    assert "key=key<br>with<br>breaks" in rendered
+    assert "agent\nname" not in rendered
+    assert "key\nwith\nbreaks" not in rendered
+
+
+def test_render_markdown_report_sanitizes_carriage_returns_in_text_fields() -> None:
+    evidence = EvidenceRecord(
+        evidence_id=UUID(int=1),
+        evidence_key="a\r\nb\rc",
+        step_index=0,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    rendered = render_markdown_report(_audit(evidence=(evidence,)))
+    assert "key=a<br>b<br>c" in rendered
+    assert "\r" not in rendered

--- a/tests/reporting/test_markdown_renderer.py
+++ b/tests/reporting/test_markdown_renderer.py
@@ -1,12 +1,13 @@
 """Tests for ``abdp.reporting.render_markdown_report``."""
 
-from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
+from typing import cast
 from uuid import UUID
 
 import pytest
 
 from abdp.core import Seed
+from abdp.core.types import JsonValue
 from abdp.evaluation import EvaluationSummary, GateStatus
 from abdp.evaluation.gate import GateResult
 from abdp.evaluation.metric import MetricResult
@@ -234,12 +235,14 @@ def test_render_markdown_report_golden_vector() -> None:
         "\n"
         "## Claims\n"
         "\n"
-        '- 00000000-0000-0000-0000-000000000064 statement="s" confidence=0.5 evidence=["00000000-0000-0000-0000-000000000001"] metadata={}\n'
+        '- 00000000-0000-0000-0000-000000000064 statement="s" confidence=0.5'
+        ' evidence=["00000000-0000-0000-0000-000000000001"] metadata={}\n'
     )
     assert rendered == expected
 
 
 def test_render_markdown_report_handles_payload_with_non_string_dict_key() -> None:
-    bad_metric = MetricResult(metric_id="m", value={1: "v"}, details={})  # type: ignore[dict-item]
+    bad_value = cast(JsonValue, {1: "v"})
+    bad_metric = MetricResult(metric_id="m", value=bad_value, details={})
     with pytest.raises(TypeError, match="dict key"):
         render_markdown_report(_audit(summary=_summary(metrics=(bad_metric,))))

--- a/tests/reporting/test_markdown_renderer.py
+++ b/tests/reporting/test_markdown_renderer.py
@@ -1,0 +1,245 @@
+"""Tests for ``abdp.reporting.render_markdown_report``."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone
+from uuid import UUID
+
+import pytest
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evaluation.gate import GateResult
+from abdp.evaluation.metric import MetricResult
+from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
+from abdp.reporting import render_markdown_report
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+def _state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=Seed(0),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("00000000-0000-0000-0000-000000000001"),
+            tier="bronze",
+            storage_key="snapshots/run",
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _run() -> ScenarioRun[SegmentState, ParticipantState, ActionProposal]:
+    return ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        steps=(),
+        final_state=_state(),
+    )
+
+
+def _summary(
+    *,
+    metrics: tuple[MetricResult, ...] = (),
+    gates: tuple[GateResult, ...] = (),
+    overall_status: GateStatus = GateStatus.PASS,
+) -> EvaluationSummary:
+    return EvaluationSummary(metrics=metrics, gates=gates, overall_status=overall_status)
+
+
+def _evidence() -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_id=UUID(int=1),
+        evidence_key="ek",
+        step_index=0,
+        agent_id="agent",
+        payload={"x": 1},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _claim() -> ClaimRecord:
+    return ClaimRecord(
+        claim_id=UUID(int=100),
+        statement="s",
+        evidence_ids=(UUID(int=1),),
+        confidence=0.5,
+        metadata={},
+    )
+
+
+def _audit(
+    *,
+    summary: EvaluationSummary | None = None,
+    evidence: tuple[EvidenceRecord, ...] | None = None,
+    claims: tuple[ClaimRecord, ...] | None = None,
+) -> AuditLog[SegmentState, ParticipantState, ActionProposal]:
+    return AuditLog[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="k",
+        seed=Seed(0),
+        run=_run(),
+        summary=summary if summary is not None else _summary(),
+        evidence=evidence if evidence is not None else (_evidence(),),
+        claims=claims if claims is not None else (_claim(),),
+    )
+
+
+def test_render_markdown_report_is_deterministic() -> None:
+    audit = _audit()
+    assert render_markdown_report(audit) == render_markdown_report(audit)
+
+
+def test_render_markdown_report_rejects_non_audit_log() -> None:
+    with pytest.raises(TypeError, match="AuditLog"):
+        render_markdown_report({"not": "audit"})  # type: ignore[arg-type]
+
+
+def test_render_markdown_report_ends_with_newline() -> None:
+    rendered = render_markdown_report(_audit())
+    assert rendered.endswith("\n")
+
+
+def test_render_markdown_report_includes_all_sections_in_order() -> None:
+    rendered = render_markdown_report(_audit())
+    positions = [
+        rendered.index("# Audit Report"),
+        rendered.index("## Summary"),
+        rendered.index("## Metrics"),
+        rendered.index("## Gates"),
+        rendered.index("## Evidence"),
+        rendered.index("## Claims"),
+    ]
+    assert positions == sorted(positions)
+
+
+def test_render_markdown_report_header_has_scenario_seed_steps() -> None:
+    rendered = render_markdown_report(_audit())
+    assert "- Scenario: k" in rendered
+    assert "- Seed: 0" in rendered
+    assert "- Steps: 0" in rendered
+
+
+def test_render_markdown_report_summary_has_overall_status() -> None:
+    rendered = render_markdown_report(_audit())
+    assert "- Overall status: pass" in rendered
+
+
+def test_render_markdown_report_metrics_table_uses_pipe_syntax() -> None:
+    metric = MetricResult(metric_id="m1", value=42, details={"k": "v"})
+    rendered = render_markdown_report(_audit(summary=_summary(metrics=(metric,))))
+    assert "| Metric ID | Value | Details |" in rendered
+    assert "| --- | --- | --- |" in rendered
+    assert "| m1 | 42 |" in rendered
+
+
+def test_render_markdown_report_gates_table_uses_pipe_syntax() -> None:
+    gate = GateResult(gate_id="g1", status=GateStatus.WARN, reason="r", details={})
+    rendered = render_markdown_report(_audit(summary=_summary(gates=(gate,), overall_status=GateStatus.WARN)))
+    assert "| Gate ID | Status | Reason | Details |" in rendered
+    assert "| --- | --- | --- | --- |" in rendered
+    assert "| g1 | warn | r |" in rendered
+
+
+def test_render_markdown_report_empty_metrics_table_has_header_and_separator() -> None:
+    rendered = render_markdown_report(_audit(summary=_summary()))
+    metrics_section = rendered.split("## Metrics", 1)[1].split("##", 1)[0]
+    assert "| Metric ID | Value | Details |" in metrics_section
+    assert "| --- | --- | --- |" in metrics_section
+
+
+def test_render_markdown_report_escapes_pipe_in_table_cells() -> None:
+    gate = GateResult(gate_id="g", status=GateStatus.FAIL, reason="a|b", details={})
+    rendered = render_markdown_report(_audit(summary=_summary(gates=(gate,), overall_status=GateStatus.FAIL)))
+    assert "a\\|b" in rendered
+
+
+def test_render_markdown_report_replaces_newlines_in_cells_with_br() -> None:
+    gate = GateResult(gate_id="g", status=GateStatus.FAIL, reason="line1\nline2", details={})
+    rendered = render_markdown_report(_audit(summary=_summary(gates=(gate,), overall_status=GateStatus.FAIL)))
+    assert "line1<br>line2" in rendered
+
+
+def test_render_markdown_report_evidence_list_includes_id_and_iso_datetime() -> None:
+    rendered = render_markdown_report(_audit())
+    assert "00000000-0000-0000-0000-000000000001" in rendered
+    assert "2026-01-01T00:00:00+00:00" in rendered
+
+
+def test_render_markdown_report_claims_list_uses_json_string_for_statement() -> None:
+    claim = ClaimRecord(
+        claim_id=UUID(int=200),
+        statement='has "quotes" in it',
+        evidence_ids=(UUID(int=1),),
+        confidence=0.9,
+        metadata={},
+    )
+    rendered = render_markdown_report(_audit(claims=(claim,)))
+    assert '\\"quotes\\"' in rendered
+
+
+def test_render_markdown_report_rejects_non_utc_datetime_in_evidence() -> None:
+    bad_evidence = EvidenceRecord.__new__(EvidenceRecord)
+    object.__setattr__(bad_evidence, "evidence_id", UUID(int=2))
+    object.__setattr__(bad_evidence, "evidence_key", "k")
+    object.__setattr__(bad_evidence, "step_index", 0)
+    object.__setattr__(bad_evidence, "agent_id", "a")
+    object.__setattr__(bad_evidence, "payload", {})
+    object.__setattr__(bad_evidence, "created_at", datetime(2026, 1, 1, tzinfo=timezone(timedelta(hours=9))))
+    with pytest.raises(ValueError, match="UTC"):
+        render_markdown_report(_audit(evidence=(bad_evidence,)))
+
+
+def test_render_markdown_report_golden_vector() -> None:
+    rendered = render_markdown_report(
+        _audit(
+            summary=_summary(
+                metrics=(MetricResult(metric_id="m", value=1, details={}),),
+                gates=(GateResult(gate_id="g", status=GateStatus.PASS, reason="ok", details={}),),
+            )
+        )
+    )
+    expected = (
+        "# Audit Report\n"
+        "\n"
+        "- Scenario: k\n"
+        "- Seed: 0\n"
+        "- Steps: 0\n"
+        "\n"
+        "## Summary\n"
+        "\n"
+        "- Overall status: pass\n"
+        "- Metrics: 1\n"
+        "- Gates: 1\n"
+        "- Evidence: 1\n"
+        "- Claims: 1\n"
+        "\n"
+        "## Metrics\n"
+        "\n"
+        "| Metric ID | Value | Details |\n"
+        "| --- | --- | --- |\n"
+        "| m | 1 | {} |\n"
+        "\n"
+        "## Gates\n"
+        "\n"
+        "| Gate ID | Status | Reason | Details |\n"
+        "| --- | --- | --- | --- |\n"
+        "| g | pass | ok | {} |\n"
+        "\n"
+        "## Evidence\n"
+        "\n"
+        '- 00000000-0000-0000-0000-000000000001 [2026-01-01T00:00:00+00:00] step=0 agent=agent key=ek payload={"x":1}\n'
+        "\n"
+        "## Claims\n"
+        "\n"
+        '- 00000000-0000-0000-0000-000000000064 statement="s" confidence=0.5 evidence=["00000000-0000-0000-0000-000000000001"] metadata={}\n'
+    )
+    assert rendered == expected
+
+
+def test_render_markdown_report_handles_payload_with_non_string_dict_key() -> None:
+    bad_metric = MetricResult(metric_id="m", value={1: "v"}, details={})  # type: ignore[dict-item]
+    with pytest.raises(TypeError, match="dict key"):
+        render_markdown_report(_audit(summary=_summary(metrics=(bad_metric,))))

--- a/tests/reporting/test_reporting_public_surface.py
+++ b/tests/reporting/test_reporting_public_surface.py
@@ -6,9 +6,13 @@ import pytest
 
 import abdp.reporting
 from abdp.reporting.json_renderer import render_json_report
+from abdp.reporting.markdown_renderer import render_markdown_report
 
-EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("render_json_report",)
-EXPECTED_SOURCE_IDENTITY: dict[str, object] = {"render_json_report": render_json_report}
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("render_json_report", "render_markdown_report")
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "render_json_report": render_json_report,
+    "render_markdown_report": render_markdown_report,
+}
 
 
 def test_reporting_package_all_lists_exact_expected_symbols() -> None:


### PR DESCRIPTION
## Summary

- Adds `render_markdown_report` for deterministic Markdown rendering of `AuditLog`.
- Extracts shared `_normalize` module (CycleGuard + to_jsonable) used by both JSON and Markdown renderers.
- Consolidates table rendering via shared `_render_table` helper.

## Design

Per Oracle design consult (10/12 APPROVE with overrides): strict `AuditLog` input, `\\|` escape, `<br>` for newlines, UTC enforced via `to_jsonable`, dedicated compact `json.dumps`, header+separator empty tables, trailing `\n`, single blank between sections, golden vector pinned, surface extension, shared normalization module, table-cell+inline-text sanitizers, `statement=<json-string>` in claims.

## TDD

- RED `c8acf74` test(reporting): add failing checks for render_markdown_report (#120)
- GREEN `9fd3c25` feat(reporting): add deterministic Markdown renderer (#120)
- REFACTOR `f2bcd46` refactor(reporting): consolidate markdown table helpers (#120)

## Verification

- `uv run pytest -q`: 725 passed, 100% coverage
- `uv run ruff check .`: clean
- `uv run ruff format --check .`: clean
- `uv run mypy --strict src tests`: clean

Closes #120