### PR TITLE
feat(cli): add CLI entrypoint and import-path loader (#121)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 # Build artifacts
 build/
 dist/
+
+# Editable install metadata
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ requires-python = ">=3.12"
 license = { file = "LICENSE" }
 dependencies = []
 
+[project.scripts]
+abdp = "abdp.cli.__main__:main"
+
 [project.optional-dependencies]
 dev = [
     "build>=1.0.0",

--- a/src/abdp/__main__.py
+++ b/src/abdp/__main__.py
@@ -1,0 +1,8 @@
+"""Top-level forwarder so ``python -m abdp`` invokes the CLI."""
+
+from abdp.cli.__main__ import main
+
+__all__ = ["main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/abdp/cli/__init__.py
+++ b/src/abdp/cli/__init__.py
@@ -1,0 +1,16 @@
+"""Public surface for the ``abdp.cli`` package.
+
+The CLI package exposes :func:`load_audit_log_factory` for resolving
+``module.path:callable`` specs into audit-log factories, and
+:class:`LoaderError` for malformed-spec, missing-module, missing-attribute,
+non-callable, and invalid-return errors. The argparse entrypoint lives
+in ``abdp.cli.__main__`` and is intentionally NOT part of the public
+surface; subsequent issues extend ``__all__`` against the frozen surface
+test in ``tests/cli/test_cli_public_surface.py``.
+"""
+
+from abdp.cli.loader import LoaderError, load_audit_log_factory
+
+globals().pop("loader", None)
+
+__all__: tuple[str, ...] = ("LoaderError", "load_audit_log_factory")

--- a/src/abdp/cli/__main__.py
+++ b/src/abdp/cli/__main__.py
@@ -1,0 +1,40 @@
+"""Argparse entrypoint for the ``abdp`` CLI.
+
+Provides ``run`` and ``report`` subcommands as stubs returning exit code
+2 with a 'not implemented' stderr message; subsequent issues fill the
+subcommand bodies. ``main`` is the console-script entry point referenced
+by ``[project.scripts] abdp`` in ``pyproject.toml``.
+"""
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+__all__ = ["build_parser", "main"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="abdp",
+        description="Agent-based decision pipeline CLI.",
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="{run,report}")
+    run_parser = subparsers.add_parser("run", help="Run a scenario and emit an AuditLog.")
+    run_parser.add_argument("spec", nargs="?", help="module.path:callable spec.")
+    report_parser = subparsers.add_parser("report", help="Render a report from a saved AuditLog.")
+    report_parser.add_argument("path", nargs="?", help="Path to a serialized AuditLog.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
+    print(f"abdp {args.command}: not implemented yet.", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/abdp/cli/loader.py
+++ b/src/abdp/cli/loader.py
@@ -40,8 +40,16 @@ def _parse_spec(spec: str) -> tuple[str, str]:
     module_name, attr_name = parts
     if not module_name or not attr_name:
         raise LoaderError(_invalid_spec(spec, "module and callable parts must be non-empty"))
-    if module_name != module_name.strip() or attr_name != attr_name.strip():
+    if any(ch.isspace() for ch in module_name) or any(ch.isspace() for ch in attr_name):
         raise LoaderError(_invalid_spec(spec, "module and callable parts must not contain whitespace"))
+    if (
+        module_name.startswith(".")
+        or module_name.endswith(".")
+        or ".." in module_name
+        or "/" in module_name
+        or "\\" in module_name
+    ):
+        raise LoaderError(_invalid_spec(spec, "module part must be an absolute dotted path (no traversal)"))
     return module_name, attr_name
 
 

--- a/src/abdp/cli/loader.py
+++ b/src/abdp/cli/loader.py
@@ -1,0 +1,68 @@
+"""Loader resolving ``module.path:callable`` specs to audit-log factories.
+
+The loader accepts a strict ``module.path:callable`` spec (single colon,
+no whitespace, no empty parts), imports the named module, retrieves the
+named attribute, and returns a wrapper callable that invokes the resolved
+factory with a :class:`abdp.core.Seed` and validates that the result is
+an :class:`abdp.evidence.AuditLog`. All loader-domain errors raise
+:class:`LoaderError`; the underlying ``ImportError``/``AttributeError`` is
+chained via ``raise ... from``.
+"""
+
+import importlib
+from collections.abc import Callable
+from typing import Any, cast
+
+from abdp.core import Seed
+from abdp.evidence import AuditLog
+
+__all__ = ["LoaderError", "load_audit_log_factory"]
+
+_AuditLogFactory = Callable[[Seed], AuditLog[Any, Any, Any]]
+
+
+class LoaderError(Exception):
+    """Raised when a CLI loader spec cannot be resolved to a valid factory."""
+
+
+def load_audit_log_factory(spec: str) -> _AuditLogFactory:
+    module_name, attr_name = _parse_spec(spec)
+    factory = _resolve_callable(module_name, attr_name)
+    return _wrap_factory(factory, spec)
+
+
+def _parse_spec(spec: str) -> tuple[str, str]:
+    if not isinstance(spec, str) or spec != spec.strip() or ":" not in spec:
+        raise LoaderError(f"Invalid loader spec {spec!r}: expected 'module.path:callable' format.")
+    parts = spec.split(":")
+    if len(parts) != 2:
+        raise LoaderError(f"Invalid loader spec {spec!r}: expected exactly one ':' separator.")
+    module_name, attr_name = parts
+    if not module_name or not attr_name:
+        raise LoaderError(f"Invalid loader spec {spec!r}: module and callable parts must be non-empty.")
+    if module_name != module_name.strip() or attr_name != attr_name.strip():
+        raise LoaderError(f"Invalid loader spec {spec!r}: module and callable parts must not contain whitespace.")
+    return module_name, attr_name
+
+
+def _resolve_callable(module_name: str, attr_name: str) -> Callable[..., object]:
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise LoaderError(f"Cannot import module {module_name!r}: {exc}") from exc
+    if not hasattr(module, attr_name):
+        raise LoaderError(f"Module {module_name!r} has no attribute {attr_name!r}.")
+    obj = getattr(module, attr_name)
+    if not callable(obj):
+        raise LoaderError(f"{module_name}:{attr_name} is not callable (got {type(obj).__name__}).")
+    return cast(Callable[..., object], obj)
+
+
+def _wrap_factory(factory: Callable[..., object], spec: str) -> _AuditLogFactory:
+    def _invoke(seed: Seed) -> AuditLog[Any, Any, Any]:
+        result = factory(seed)
+        if not isinstance(result, AuditLog):
+            raise LoaderError(f"Loader spec {spec!r} returned {type(result).__name__}, expected AuditLog.")
+        return result
+
+    return _invoke

--- a/src/abdp/cli/loader.py
+++ b/src/abdp/cli/loader.py
@@ -33,16 +33,20 @@ def load_audit_log_factory(spec: str) -> _AuditLogFactory:
 
 def _parse_spec(spec: str) -> tuple[str, str]:
     if not isinstance(spec, str) or spec != spec.strip() or ":" not in spec:
-        raise LoaderError(f"Invalid loader spec {spec!r}: expected 'module.path:callable' format.")
+        raise LoaderError(_invalid_spec(spec, "expected 'module.path:callable' format"))
     parts = spec.split(":")
     if len(parts) != 2:
-        raise LoaderError(f"Invalid loader spec {spec!r}: expected exactly one ':' separator.")
+        raise LoaderError(_invalid_spec(spec, "expected exactly one ':' separator"))
     module_name, attr_name = parts
     if not module_name or not attr_name:
-        raise LoaderError(f"Invalid loader spec {spec!r}: module and callable parts must be non-empty.")
+        raise LoaderError(_invalid_spec(spec, "module and callable parts must be non-empty"))
     if module_name != module_name.strip() or attr_name != attr_name.strip():
-        raise LoaderError(f"Invalid loader spec {spec!r}: module and callable parts must not contain whitespace.")
+        raise LoaderError(_invalid_spec(spec, "module and callable parts must not contain whitespace"))
     return module_name, attr_name
+
+
+def _invalid_spec(spec: object, reason: str) -> str:
+    return f"Invalid loader spec {spec!r}: {reason}."
 
 
 def _resolve_callable(module_name: str, attr_name: str) -> Callable[..., object]:

--- a/tests/cli/_fixtures.py
+++ b/tests/cli/_fixtures.py
@@ -1,0 +1,59 @@
+"""Test fixtures for ``abdp.cli`` loader tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evidence import AuditLog
+from abdp.scenario import ScenarioRun
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+NOT_CALLABLE: int = 42
+
+
+def _state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=Seed(0),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("00000000-0000-0000-0000-000000000001"),
+            tier="bronze",
+            storage_key="snapshots/run",
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def build_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    run = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="cli-fixture",
+        seed=seed,
+        steps=(),
+        final_state=_state(),
+    )
+    summary = EvaluationSummary(metrics=(), gates=(), overall_status=GateStatus.PASS)
+    return AuditLog[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="cli-fixture",
+        seed=seed,
+        run=run,
+        summary=summary,
+        evidence=(),
+        claims=(),
+    )
+
+
+def build_not_audit_log(seed: Seed) -> object:
+    _ = seed
+    return {"not": "audit"}
+
+
+def _created_at() -> datetime:
+    return datetime(2026, 1, 1, tzinfo=UTC)

--- a/tests/cli/test_cli_public_surface.py
+++ b/tests/cli/test_cli_public_surface.py
@@ -1,0 +1,43 @@
+"""Frozen public surface of the ``abdp.cli`` package."""
+
+from __future__ import annotations
+
+import pytest
+
+import abdp.cli
+from abdp.cli.loader import LoaderError, load_audit_log_factory
+
+EXPECTED_PUBLIC_NAMES: tuple[str, ...] = ("LoaderError", "load_audit_log_factory")
+EXPECTED_SOURCE_IDENTITY: dict[str, object] = {
+    "LoaderError": LoaderError,
+    "load_audit_log_factory": load_audit_log_factory,
+}
+
+
+def test_cli_package_all_lists_exact_expected_symbols() -> None:
+    assert isinstance(abdp.cli.__all__, tuple)
+    assert all(isinstance(name, str) for name in abdp.cli.__all__)
+    assert abdp.cli.__all__ == EXPECTED_PUBLIC_NAMES
+
+
+def test_cli_package_star_import_yields_exactly_the_public_surface() -> None:
+    namespace: dict[str, object] = {}
+    exec("from abdp.cli import *", namespace)
+    namespace.pop("__builtins__", None)
+    assert sorted(namespace.keys()) == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_cli_package_namespace_exposes_only_approved_public_names() -> None:
+    public_attrs = sorted(name for name in vars(abdp.cli) if not name.startswith("_"))
+    assert public_attrs == sorted(EXPECTED_PUBLIC_NAMES)
+
+
+def test_cli_package_has_module_docstring() -> None:
+    doc = abdp.cli.__doc__
+    assert isinstance(doc, str)
+    assert doc.strip()
+
+
+@pytest.mark.parametrize("name", list(EXPECTED_SOURCE_IDENTITY))
+def test_cli_public_symbols_resolve_to_canonical_definitions(name: str) -> None:
+    assert getattr(abdp.cli, name) is EXPECTED_SOURCE_IDENTITY[name]

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -79,3 +79,9 @@ def test_python_dash_m_abdp_cli_help_exits_zero() -> None:
     assert result.returncode == 0
     assert "run" in result.stdout
     assert "report" in result.stdout
+
+
+def test_top_level_main_module_re_exports_main() -> None:
+    import abdp.__main__ as top_main
+
+    assert top_main.main is main

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -1,0 +1,81 @@
+"""Tests for ``abdp.cli`` argparse help/skeleton."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from abdp.cli.__main__ import main
+
+
+def test_main_with_no_args_prints_help_and_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main([])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "run" in captured.out
+    assert "report" in captured.out
+
+
+def test_main_with_help_flag_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--help"])
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "run" in captured.out
+    assert "report" in captured.out
+
+
+def test_main_run_subcommand_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_main_report_subcommand_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["report", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_main_run_subcommand_returns_two_with_not_implemented_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["run"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "not implemented" in captured.err.lower()
+
+
+def test_main_report_subcommand_returns_two_with_not_implemented_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["report"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "not implemented" in captured.err.lower()
+
+
+def test_python_dash_m_abdp_help_exits_zero() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "abdp", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "run" in result.stdout
+    assert "report" in result.stdout
+
+
+def test_python_dash_m_abdp_cli_help_exits_zero() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "abdp.cli", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "run" in result.stdout
+    assert "report" in result.stdout

--- a/tests/cli/test_loader.py
+++ b/tests/cli/test_loader.py
@@ -1,0 +1,65 @@
+"""Tests for ``abdp.cli.loader``."""
+
+from __future__ import annotations
+
+import pytest
+
+from abdp.cli.loader import LoaderError, load_audit_log_factory
+from abdp.core import Seed
+
+
+def test_load_audit_log_factory_resolves_valid_spec() -> None:
+    factory = load_audit_log_factory("tests.cli._fixtures:build_audit_log")
+    assert callable(factory)
+
+
+def test_loaded_factory_returns_audit_log_when_invoked() -> None:
+    from abdp.evidence import AuditLog
+
+    factory = load_audit_log_factory("tests.cli._fixtures:build_audit_log")
+    result = factory(Seed(0))
+    assert isinstance(result, AuditLog)
+
+
+def test_loaded_factory_rejects_non_audit_log_return() -> None:
+    factory = load_audit_log_factory("tests.cli._fixtures:build_not_audit_log")
+    with pytest.raises(LoaderError, match="AuditLog"):
+        factory(Seed(0))
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "no_colon",
+        "module:",
+        ":callable",
+        "module::callable",
+        "module:callable:extra",
+        " module:callable",
+        "module:callable ",
+        "module: callable",
+        "",
+    ],
+)
+def test_load_audit_log_factory_rejects_malformed_spec(spec: str) -> None:
+    with pytest.raises(LoaderError, match="spec"):
+        load_audit_log_factory(spec)
+
+
+def test_load_audit_log_factory_rejects_missing_module() -> None:
+    with pytest.raises(LoaderError, match="module"):
+        load_audit_log_factory("nonexistent_module_xyz:func")
+
+
+def test_load_audit_log_factory_rejects_missing_attribute() -> None:
+    with pytest.raises(LoaderError, match="attribute"):
+        load_audit_log_factory("tests.cli._fixtures:does_not_exist")
+
+
+def test_load_audit_log_factory_rejects_non_callable_attribute() -> None:
+    with pytest.raises(LoaderError, match="callable"):
+        load_audit_log_factory("tests.cli._fixtures:NOT_CALLABLE")
+
+
+def test_loader_error_is_exception_subclass() -> None:
+    assert issubclass(LoaderError, Exception)

--- a/tests/cli/test_loader.py
+++ b/tests/cli/test_loader.py
@@ -39,6 +39,15 @@ def test_loaded_factory_rejects_non_audit_log_return() -> None:
         "module:callable ",
         "module: callable",
         "",
+        "tests.cli. _fixtures:build_audit_log",
+        "tests.cli._fixtures:build audit_log",
+        "module\twith\ttabs:func",
+        ".os:path",
+        "..pkg.mod:func",
+        "pkg.:func",
+        "pkg..mod:func",
+        "pkg/mod:func",
+        "pkg\\mod:func",
     ],
 )
 def test_load_audit_log_factory_rejects_malformed_spec(spec: str) -> None:


### PR DESCRIPTION
## Summary

- Bootstraps `abdp.cli` package with `load_audit_log_factory(spec)` resolving `module.path:callable` to an audit-log factory.
- Adds `LoaderError` for malformed spec / missing module / missing attr / non-callable / non-AuditLog return.
- Adds argparse skeleton with `run` and `report` stub subcommands.
- Registers `[project.scripts] abdp = "abdp.cli.__main__:main"` and adds top-level `src/abdp/__main__.py` so `python -m abdp` works.

## Design

Per Oracle design consult (10/12 CHANGES with overrides; all addressed): single public function + single `LoaderError`, strict spec parser (one colon, no whitespace, no empty parts), `callable()` check only at load (no signature inspection / no probe call), wrapper validates `isinstance(result, AuditLog)` at call-time, both `cli/__main__.py` and top-level `__main__.py` for `python -m abdp` support.

## TDD

- RED `b6d36f9` test(cli): add failing checks for CLI loader and argparse skeleton (#121)
- GREEN `2b7548a` feat(cli): add CLI entrypoint and import-path loader (#121)
- REFACTOR `bab9ad2` refactor(cli): consolidate loader spec error formatting (#121)

## Verification

- pytest: 759 passed, 100% coverage
- ruff/format/mypy --strict: clean

Closes #121