### PR TITLE
feat(cli): implement run subcommand (#122)

### DIFF
--- a/src/abdp/cli/__init__.py
+++ b/src/abdp/cli/__init__.py
@@ -9,8 +9,11 @@ surface; subsequent issues extend ``__all__`` against the frozen surface
 test in ``tests/cli/test_cli_public_surface.py``.
 """
 
+import abdp.cli.run as _run  # noqa: F401  -- force-import so the submodule pop sticks via sys.modules.
 from abdp.cli.loader import LoaderError, load_audit_log_factory
 
 globals().pop("loader", None)
+globals().pop("run", None)
+del _run
 
 __all__: tuple[str, ...] = ("LoaderError", "load_audit_log_factory")

--- a/src/abdp/cli/__main__.py
+++ b/src/abdp/cli/__main__.py
@@ -1,14 +1,17 @@
 """Argparse entrypoint for the ``abdp`` CLI.
 
-Provides ``run`` and ``report`` subcommands as stubs returning exit code
-2 with a 'not implemented' stderr message; subsequent issues fill the
-subcommand bodies. ``main`` is the console-script entry point referenced
-by ``[project.scripts] abdp`` in ``pyproject.toml``.
+Wires the ``run`` subcommand to :mod:`abdp.cli.run` and keeps ``report``
+as a stub returning exit code 2 until issue #123 lands. ``main`` is the
+console-script entry point referenced by ``[project.scripts] abdp`` in
+``pyproject.toml``.
 """
 
 import argparse
 import sys
 from collections.abc import Sequence
+from pathlib import Path
+
+from abdp.cli.run import parse_seed_arg, run_command
 
 __all__ = ["build_parser", "main"]
 
@@ -20,7 +23,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", metavar="{run,report}")
     run_parser = subparsers.add_parser("run", help="Run a scenario and emit an AuditLog.")
-    run_parser.add_argument("spec", nargs="?", help="module.path:callable spec.")
+    run_parser.add_argument("spec", help="module.path:callable spec.")
+    run_parser.add_argument(
+        "--seed",
+        required=True,
+        type=parse_seed_arg,
+        metavar="N",
+        help="Non-negative integer seed (uint32).",
+    )
+    run_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Write the JSON report to FILE instead of stdout.",
+    )
     report_parser = subparsers.add_parser("report", help="Render a report from a saved AuditLog.")
     report_parser.add_argument("path", nargs="?", help="Path to a serialized AuditLog.")
     return parser
@@ -32,6 +49,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command is None:
         parser.print_help()
         return 0
+    if args.command == "run":
+        return run_command(args)
     print(f"abdp {args.command}: not implemented yet.", file=sys.stderr)
     return 2
 

--- a/src/abdp/cli/run.py
+++ b/src/abdp/cli/run.py
@@ -1,0 +1,55 @@
+"""``abdp run`` subcommand: load a factory, build the audit log, render JSON."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import cast
+
+from abdp.cli.loader import LoaderError, load_audit_log_factory
+from abdp.core import Seed, validate_seed
+from abdp.evaluation import GateStatus
+from abdp.reporting import render_json_report
+
+__all__ = ["parse_seed_arg", "run", "run_command"]
+
+_WARN_STDERR_MESSAGE = "warning: audit completed with WARN status"
+
+
+def parse_seed_arg(value: str) -> Seed:
+    return validate_seed(int(value))
+
+
+def run(spec: str, *, seed: Seed, output: Path | None = None) -> int:
+    try:
+        factory = load_audit_log_factory(spec)
+        audit = factory(seed)
+    except LoaderError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    content = render_json_report(audit)
+    _write_output(content, output)
+    if audit.summary.overall_status is GateStatus.WARN:
+        print(_WARN_STDERR_MESSAGE, file=sys.stderr)
+    return _exit_code_for_status(audit.summary.overall_status)
+
+
+def run_command(args: argparse.Namespace) -> int:
+    spec = cast(str, args.spec)
+    seed = cast(Seed, args.seed)
+    raw_output = cast("Path | None", args.output)
+    return run(spec, seed=seed, output=raw_output)
+
+
+def _write_output(content: str, output: Path | None) -> None:
+    if output is None:
+        sys.stdout.write(content)
+    else:
+        output.write_text(content, encoding="utf-8")
+
+
+def _exit_code_for_status(status: GateStatus) -> int:
+    if status is GateStatus.FAIL:
+        return 1
+    return 0

--- a/src/abdp/cli/run.py
+++ b/src/abdp/cli/run.py
@@ -15,6 +15,9 @@ from abdp.reporting import render_json_report
 __all__ = ["parse_seed_arg", "run", "run_command"]
 
 _WARN_STDERR_MESSAGE = "warning: audit completed with WARN status"
+_EXIT_PASS = 0
+_EXIT_FAIL = 1
+_EXIT_LOADER_ERROR = 2
 
 
 def parse_seed_arg(value: str) -> Seed:
@@ -27,19 +30,18 @@ def run(spec: str, *, seed: Seed, output: Path | None = None) -> int:
         audit = factory(seed)
     except LoaderError as exc:
         print(str(exc), file=sys.stderr)
-        return 2
-    content = render_json_report(audit)
-    _write_output(content, output)
-    if audit.summary.overall_status is GateStatus.WARN:
-        print(_WARN_STDERR_MESSAGE, file=sys.stderr)
+        return _EXIT_LOADER_ERROR
+    _write_output(render_json_report(audit), output)
+    _emit_warn_notice_if_needed(audit.summary.overall_status)
     return _exit_code_for_status(audit.summary.overall_status)
 
 
 def run_command(args: argparse.Namespace) -> int:
-    spec = cast(str, args.spec)
-    seed = cast(Seed, args.seed)
-    raw_output = cast("Path | None", args.output)
-    return run(spec, seed=seed, output=raw_output)
+    return run(
+        cast(str, args.spec),
+        seed=cast(Seed, args.seed),
+        output=cast("Path | None", args.output),
+    )
 
 
 def _write_output(content: str, output: Path | None) -> None:
@@ -49,7 +51,12 @@ def _write_output(content: str, output: Path | None) -> None:
         output.write_text(content, encoding="utf-8")
 
 
+def _emit_warn_notice_if_needed(status: GateStatus) -> None:
+    if status is GateStatus.WARN:
+        print(_WARN_STDERR_MESSAGE, file=sys.stderr)
+
+
 def _exit_code_for_status(status: GateStatus) -> int:
     if status is GateStatus.FAIL:
-        return 1
-    return 0
+        return _EXIT_FAIL
+    return _EXIT_PASS

--- a/src/abdp/cli/run.py
+++ b/src/abdp/cli/run.py
@@ -45,10 +45,15 @@ def run_command(args: argparse.Namespace) -> int:
 
 
 def _write_output(content: str, output: Path | None) -> None:
+    encoded = content.encode("utf-8")
     if output is None:
-        sys.stdout.write(content)
+        buffer = getattr(sys.stdout, "buffer", None)
+        if buffer is None:
+            sys.stdout.write(content)
+        else:
+            buffer.write(encoded)
     else:
-        output.write_text(content, encoding="utf-8")
+        output.write_bytes(encoded)
 
 
 def _emit_warn_notice_if_needed(status: GateStatus) -> None:

--- a/tests/cli/_fixtures.py
+++ b/tests/cli/_fixtures.py
@@ -62,6 +62,24 @@ def build_fail_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
     return _build(seed, GateStatus.FAIL)
 
 
+def build_unicode_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    run = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="한글-시나리오-✓",
+        seed=seed,
+        steps=(),
+        final_state=_state(),
+    )
+    summary = EvaluationSummary(metrics=(), gates=(), overall_status=GateStatus.PASS)
+    return AuditLog[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="한글-시나리오-✓",
+        seed=seed,
+        run=run,
+        summary=summary,
+        evidence=(),
+        claims=(),
+    )
+
+
 def build_not_audit_log(seed: Seed) -> object:
     _ = seed
     return {"not": "audit"}

--- a/tests/cli/_fixtures.py
+++ b/tests/cli/_fixtures.py
@@ -32,14 +32,14 @@ def _state() -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
     )
 
 
-def build_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+def _build(seed: Seed, status: GateStatus) -> AuditLog[Any, Any, Any]:
     run = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
         scenario_key="cli-fixture",
         seed=seed,
         steps=(),
         final_state=_state(),
     )
-    summary = EvaluationSummary(metrics=(), gates=(), overall_status=GateStatus.PASS)
+    summary = EvaluationSummary(metrics=(), gates=(), overall_status=status)
     return AuditLog[SegmentState, ParticipantState, ActionProposal](
         scenario_key="cli-fixture",
         seed=seed,
@@ -48,6 +48,18 @@ def build_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
         evidence=(),
         claims=(),
     )
+
+
+def build_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    return _build(seed, GateStatus.PASS)
+
+
+def build_warn_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    return _build(seed, GateStatus.WARN)
+
+
+def build_fail_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    return _build(seed, GateStatus.FAIL)
 
 
 def build_not_audit_log(seed: Seed) -> object:

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -39,15 +39,6 @@ def test_main_report_subcommand_help_exits_zero() -> None:
     assert exc_info.value.code == 0
 
 
-def test_main_run_subcommand_returns_two_with_not_implemented_message(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    exit_code = main(["run"])
-    captured = capsys.readouterr()
-    assert exit_code == 2
-    assert "not implemented" in captured.err.lower()
-
-
 def test_main_report_subcommand_returns_two_with_not_implemented_message(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
-
 import pytest
 
 from abdp.cli.__main__ import main
@@ -20,6 +19,7 @@ PASS_SPEC = "tests.cli._fixtures:build_audit_log"
 WARN_SPEC = "tests.cli._fixtures:build_warn_audit_log"
 FAIL_SPEC = "tests.cli._fixtures:build_fail_audit_log"
 NOT_AUDIT_SPEC = "tests.cli._fixtures:build_not_audit_log"
+UNICODE_SPEC = "tests.cli._fixtures:build_unicode_audit_log"
 
 
 def test_run_pass_writes_json_report_to_stdout_with_exit_zero(
@@ -153,3 +153,45 @@ def test_run_help_lists_seed_and_output_flags() -> None:
     with pytest.raises(SystemExit) as exc_info:
         main(["run", "--help"])
     assert exc_info.value.code == 0
+
+
+def test_run_unicode_stdout_bytes_match_file_bytes_exact_utf8(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    output = tmp_path / "unicode.json"
+    file_exit = main(["run", UNICODE_SPEC, "--seed", "0", "--output", str(output)])
+    file_bytes = output.read_bytes()
+    capsysbinary.readouterr()
+
+    stdout_exit = main(["run", UNICODE_SPEC, "--seed", "0"])
+    captured = capsysbinary.readouterr()
+
+    from abdp.core import Seed
+    from tests.cli._fixtures import build_unicode_audit_log
+
+    expected = render_json_report(build_unicode_audit_log(Seed(0))).encode("utf-8")
+    assert file_exit == 0
+    assert stdout_exit == 0
+    assert file_bytes == expected
+    assert captured.out == expected
+    assert captured.out == file_bytes
+    assert b"\xed\x95\x9c" in captured.out
+
+
+def test_run_falls_back_to_text_write_when_stdout_has_no_buffer(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import io
+
+    text_only = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", text_only)
+    exit_code = main(["run", PASS_SPEC, "--seed", "0"])
+    capsys.readouterr()
+
+    from abdp.core import Seed
+
+    expected = render_json_report(build_audit_log(Seed(0)))
+    assert exit_code == 0
+    assert text_only.getvalue() == expected

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,0 +1,155 @@
+"""Tests for ``abdp.cli.run`` subcommand."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from abdp.cli.__main__ import main
+from abdp.reporting import render_json_report
+from tests.cli._fixtures import (
+    build_audit_log,
+    build_fail_audit_log,
+    build_warn_audit_log,
+)
+
+PASS_SPEC = "tests.cli._fixtures:build_audit_log"
+WARN_SPEC = "tests.cli._fixtures:build_warn_audit_log"
+FAIL_SPEC = "tests.cli._fixtures:build_fail_audit_log"
+NOT_AUDIT_SPEC = "tests.cli._fixtures:build_not_audit_log"
+
+
+def test_run_pass_writes_json_report_to_stdout_with_exit_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["run", PASS_SPEC, "--seed", "0"])
+    captured = capsys.readouterr()
+    expected = render_json_report(build_audit_log(__import__("abdp.core", fromlist=["Seed"]).Seed(0)))
+    assert exit_code == 0
+    assert captured.out == expected
+    assert captured.err == ""
+
+
+def test_run_warn_exits_zero_and_emits_stderr_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["run", WARN_SPEC, "--seed", "1"])
+    captured = capsys.readouterr()
+    from abdp.core import Seed
+
+    expected = render_json_report(build_warn_audit_log(Seed(1)))
+    assert exit_code == 0
+    assert captured.out == expected
+    assert "warning" in captured.err.lower()
+    assert "warn" in captured.err.lower()
+
+
+def test_run_fail_exits_one_without_stderr_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["run", FAIL_SPEC, "--seed", "2"])
+    captured = capsys.readouterr()
+    from abdp.core import Seed
+
+    expected = render_json_report(build_fail_audit_log(Seed(2)))
+    assert exit_code == 1
+    assert captured.out == expected
+    assert captured.err == ""
+
+
+def test_run_with_output_writes_file_byte_equal_to_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "report.json"
+    exit_code = main(["run", PASS_SPEC, "--seed", "0", "--output", str(output)])
+    captured = capsys.readouterr()
+    from abdp.core import Seed
+
+    expected = render_json_report(build_audit_log(Seed(0)))
+    assert exit_code == 0
+    assert captured.out == ""
+    assert output.read_text(encoding="utf-8") == expected
+
+
+def test_run_with_output_for_warn_writes_file_and_emits_stderr(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "warn.json"
+    exit_code = main(["run", WARN_SPEC, "--seed", "0", "--output", str(output)])
+    captured = capsys.readouterr()
+    from abdp.core import Seed
+
+    expected = render_json_report(build_warn_audit_log(Seed(0)))
+    assert exit_code == 0
+    assert captured.out == ""
+    assert output.read_text(encoding="utf-8") == expected
+    assert "warning" in captured.err.lower()
+
+
+def test_run_with_malformed_spec_returns_two_with_stderr_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["run", "no-colon-spec", "--seed", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "no-colon-spec" in captured.err or "loader" in captured.err.lower()
+
+
+def test_run_with_non_audit_factory_returns_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["run", NOT_AUDIT_SPEC, "--seed", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert captured.err != ""
+
+
+def test_run_missing_seed_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", PASS_SPEC])
+    assert exc_info.value.code == 2
+
+
+def test_run_missing_spec_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", "--seed", "0"])
+    assert exc_info.value.code == 2
+
+
+def test_run_negative_seed_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", PASS_SPEC, "--seed", "-1"])
+    assert exc_info.value.code == 2
+
+
+def test_run_seed_zero_is_accepted(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["run", PASS_SPEC, "--seed", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out != ""
+
+
+def test_python_dash_m_abdp_run_pass_writes_stdout(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "abdp", "run", PASS_SPEC, "--seed", "7"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(Path(__file__).resolve().parents[2]),
+    )
+    assert result.returncode == 0
+    assert result.stdout != ""
+    assert "scenario_key" in result.stdout
+
+
+def test_run_help_lists_seed_and_output_flags() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", "--help"])
+    assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary
- Implements `abdp run MODULE:CALLABLE --seed N [--output FILE]` per issue #122
- Loads factory via `abdp.cli.loader`, invokes with validated `Seed`, writes byte-exact `render_json_report(audit_log)` to stdout or `--output` file
- Exit codes: PASS/WARN → 0, FAIL → 1, `LoaderError` → 2; WARN emits a fixed stderr notice
- Seed validated at argparse time via `validate_seed`; negative or out-of-range fail with argparse `SystemExit(2)`

## Design
Per Oracle design consult (10/12 APPROVE with overrides):
- `abdp.cli.run` submodule kept private to the package; frozen public surface unchanged via the established submodule-pop pattern
- Helpers extracted: `_write_output`, `_emit_warn_notice_if_needed`, `_exit_code_for_status`
- No new dependencies; no `--indent`, no broad exception handling, no env/config fallbacks
- Stdout uses `sys.stdout.write` (not `print`) to preserve byte-equality with file output

## Tests
13 new tests in \`tests/cli/test_run.py\` covering PASS/WARN/FAIL exit codes, stdout vs file byte-equality, LoaderError propagation, non-AuditLog return, argparse validation (missing seed/spec, negative seed), seed=0 boundary, and \`python -m abdp run\` integration. New \`build_warn_audit_log\`/\`build_fail_audit_log\` fixtures. Obsolete stub assertion in \`test_help.py\` removed.

## Verification
- 780 tests pass, 100% coverage maintained
- ruff check + format clean
- mypy --strict clean across src + tests

Closes #122