### PR TITLE
feat(cli): implement report subcommand (#123)

### DIFF
--- a/src/abdp/cli/__init__.py
+++ b/src/abdp/cli/__init__.py
@@ -9,11 +9,14 @@ surface; subsequent issues extend ``__all__`` against the frozen surface
 test in ``tests/cli/test_cli_public_surface.py``.
 """
 
-import abdp.cli.run as _run  # noqa: F401  -- force-import so the submodule pop sticks via sys.modules.
+import abdp.cli.report as _report  # noqa: F401  -- force-import so submodule pop sticks via sys.modules.
+import abdp.cli.run as _run  # noqa: F401  -- force-import so submodule pop sticks via sys.modules.
 from abdp.cli.loader import LoaderError, load_audit_log_factory
 
 globals().pop("loader", None)
 globals().pop("run", None)
+globals().pop("report", None)
 del _run
+del _report
 
 __all__: tuple[str, ...] = ("LoaderError", "load_audit_log_factory")

--- a/src/abdp/cli/__main__.py
+++ b/src/abdp/cli/__main__.py
@@ -1,16 +1,15 @@
 """Argparse entrypoint for the ``abdp`` CLI.
 
-Wires the ``run`` subcommand to :mod:`abdp.cli.run` and keeps ``report``
-as a stub returning exit code 2 until issue #123 lands. ``main`` is the
-console-script entry point referenced by ``[project.scripts] abdp`` in
-``pyproject.toml``.
+Wires the ``run`` and ``report`` subcommands to :mod:`abdp.cli.run` and
+:mod:`abdp.cli.report`. ``main`` is the console-script entry point
+referenced by ``[project.scripts] abdp`` in ``pyproject.toml``.
 """
 
 import argparse
-import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+from abdp.cli.report import REPORT_FORMATS, report_command
 from abdp.cli.run import parse_seed_arg, run_command
 
 __all__ = ["build_parser", "main"]
@@ -39,7 +38,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write the JSON report to FILE instead of stdout.",
     )
     report_parser = subparsers.add_parser("report", help="Render a report from a saved AuditLog.")
-    report_parser.add_argument("path", nargs="?", help="Path to a serialized AuditLog.")
+    report_parser.add_argument("path", type=Path, help="Path to a serialized AuditLog JSON file.")
+    report_parser.add_argument(
+        "--format",
+        required=True,
+        choices=REPORT_FORMATS,
+        help="Output format.",
+    )
+    report_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Write the report to FILE instead of stdout.",
+    )
     return parser
 
 
@@ -51,8 +63,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.command == "run":
         return run_command(args)
-    print(f"abdp {args.command}: not implemented yet.", file=sys.stderr)
-    return 2
+    return report_command(args)
 
 
 if __name__ == "__main__":

--- a/src/abdp/cli/report.py
+++ b/src/abdp/cli/report.py
@@ -27,6 +27,7 @@ from uuid import UUID
 from abdp.agents import AgentDecision
 from abdp.core import Seed, validate_seed
 from abdp.core.types import JsonObject, JsonValue
+from abdp.data.snapshot_manifest import SnapshotTier
 from abdp.evaluation import EvaluationSummary, GateResult, GateStatus, MetricResult
 from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
 from abdp.reporting import render_json_report, render_markdown_report
@@ -57,14 +58,14 @@ def report(path: Path, *, format: ReportFormat, output: Path | None = None) -> i
         text = path.read_text(encoding="utf-8")
         loaded = json.loads(text)
         audit = _audit_log_from_jsonable(loaded)
+        if format == "json":
+            rendered = render_json_report(audit)
+        else:
+            rendered = render_markdown_report(audit)
+        _write_output(rendered, output)
     except (OSError, json.JSONDecodeError, ReportError) as exc:
-        print(str(exc), file=sys.stderr)
+        print(str(exc).splitlines()[0] if str(exc) else type(exc).__name__, file=sys.stderr)
         return _EXIT_ERROR
-    if format == "json":
-        rendered = render_json_report(audit)
-    else:
-        rendered = render_markdown_report(audit)
-    _write_output(rendered, output)
     return _EXIT_OK
 
 
@@ -189,7 +190,7 @@ def _snapshot_ref_from_jsonable(data: Any) -> SnapshotRef:
         raise ReportError(f"snapshot_ref.tier must be bronze/silver/gold, got {tier!r}")
     return SnapshotRef(
         snapshot_id=_require_uuid(obj, "snapshot_id"),
-        tier=cast(Any, tier),
+        tier=cast(SnapshotTier, tier),
         storage_key=_require_str(obj, "storage_key"),
     )
 

--- a/src/abdp/cli/report.py
+++ b/src/abdp/cli/report.py
@@ -1,0 +1,363 @@
+"""``abdp report`` subcommand: load a serialized AuditLog, render JSON or Markdown.
+
+The reconstructor rebuilds an :class:`abdp.evidence.AuditLog` instance from
+the JSON representation produced by :func:`abdp.reporting.render_json_report`.
+Protocol-typed fields (``decisions``, ``proposals``, ``segments``,
+``participants``, ``pending_actions``) are rehydrated into private frozen
+dataclass carriers that satisfy the corresponding ``runtime_checkable``
+``Protocol`` shapes; this guarantees that
+:func:`abdp.reporting.render_markdown_report` and
+:func:`abdp.reporting.render_json_report` produce byte-identical output for
+the reconstructed audit. The subcommand always returns ``0`` on success
+regardless of ``summary.overall_status``; loader, parse, and shape errors
+return ``2`` with a single-line stderr message.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, Literal, cast
+from uuid import UUID
+
+from abdp.agents import AgentDecision
+from abdp.core import Seed, validate_seed
+from abdp.core.types import JsonObject, JsonValue
+from abdp.evaluation import EvaluationSummary, GateResult, GateStatus, MetricResult
+from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
+from abdp.reporting import render_json_report, render_markdown_report
+from abdp.scenario import ScenarioRun, ScenarioStep
+from abdp.simulation import (
+    ActionProposal,
+    ParticipantState,
+    SegmentState,
+    SimulationState,
+)
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+__all__ = ["ReportError", "ReportFormat", "REPORT_FORMATS", "report", "report_command"]
+
+ReportFormat = Literal["json", "markdown"]
+REPORT_FORMATS: Final[tuple[ReportFormat, ...]] = ("json", "markdown")
+
+_EXIT_OK = 0
+_EXIT_ERROR = 2
+
+
+class ReportError(Exception):
+    """Raised when a serialized audit cannot be parsed or reconstructed."""
+
+
+def report(path: Path, *, format: ReportFormat, output: Path | None = None) -> int:
+    try:
+        text = path.read_text(encoding="utf-8")
+        loaded = json.loads(text)
+        audit = _audit_log_from_jsonable(loaded)
+    except (OSError, json.JSONDecodeError, ReportError) as exc:
+        print(str(exc), file=sys.stderr)
+        return _EXIT_ERROR
+    if format == "json":
+        rendered = render_json_report(audit)
+    else:
+        rendered = render_markdown_report(audit)
+    _write_output(rendered, output)
+    return _EXIT_OK
+
+
+def report_command(args: argparse.Namespace) -> int:
+    return report(
+        cast(Path, args.path),
+        format=cast(ReportFormat, args.format),
+        output=cast("Path | None", args.output),
+    )
+
+
+def _write_output(content: str, output: Path | None) -> None:
+    encoded = content.encode("utf-8")
+    if output is None:
+        buffer = getattr(sys.stdout, "buffer", None)
+        if buffer is None:
+            sys.stdout.write(content)
+        else:
+            buffer.write(encoded)
+    else:
+        output.write_bytes(encoded)
+
+
+@dataclass(frozen=True, slots=True)
+class _SegmentCarrier:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ParticipantCarrier:
+    participant_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ActionProposalCarrier:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentDecisionCarrier:
+    agent_id: str
+    proposals: tuple[_ActionProposalCarrier, ...]
+
+
+def _audit_log_from_jsonable(data: Any) -> AuditLog[Any, Any, Any]:
+    obj = _require_object(data, "audit log")
+    scenario_key = _require_str(obj, "scenario_key")
+    seed = _require_seed(obj, "seed")
+    try:
+        return AuditLog[SegmentState, ParticipantState, ActionProposal](
+            scenario_key=scenario_key,
+            seed=seed,
+            run=_scenario_run_from_jsonable(_require_field(obj, "run")),
+            summary=_evaluation_summary_from_jsonable(_require_field(obj, "summary")),
+            evidence=tuple(_evidence_record_from_jsonable(item) for item in _require_list(obj, "evidence")),
+            claims=tuple(_claim_record_from_jsonable(item) for item in _require_list(obj, "claims")),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ReportError(f"invalid audit log: {exc}") from exc
+
+
+def _scenario_run_from_jsonable(
+    data: Any,
+) -> ScenarioRun[SegmentState, ParticipantState, ActionProposal]:
+    obj = _require_object(data, "run")
+    return ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key=_require_str(obj, "scenario_key"),
+        seed=_require_seed(obj, "seed"),
+        steps=tuple(_scenario_step_from_jsonable(item) for item in _require_list(obj, "steps")),
+        final_state=_simulation_state_from_jsonable(_require_field(obj, "final_state")),
+    )
+
+
+def _scenario_step_from_jsonable(
+    data: Any,
+) -> ScenarioStep[SegmentState, ParticipantState, ActionProposal]:
+    obj = _require_object(data, "step")
+    return ScenarioStep[SegmentState, ParticipantState, ActionProposal](
+        state=_simulation_state_from_jsonable(_require_field(obj, "state")),
+        decisions=cast(
+            "tuple[AgentDecision[ActionProposal], ...]",
+            tuple(_agent_decision_from_jsonable(item) for item in _require_list(obj, "decisions")),
+        ),
+        proposals=cast(
+            "tuple[ActionProposal, ...]",
+            tuple(_action_proposal_from_jsonable(item) for item in _require_list(obj, "proposals")),
+        ),
+    )
+
+
+def _simulation_state_from_jsonable(
+    data: Any,
+) -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
+    obj = _require_object(data, "simulation state")
+    step_index_raw = _require_field(obj, "step_index")
+    if isinstance(step_index_raw, bool) or not isinstance(step_index_raw, int):
+        raise ReportError("simulation state.step_index must be int")
+    return SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=step_index_raw,
+        seed=_require_seed(obj, "seed"),
+        snapshot_ref=_snapshot_ref_from_jsonable(_require_field(obj, "snapshot_ref")),
+        segments=cast(
+            "tuple[SegmentState, ...]",
+            tuple(_segment_from_jsonable(item) for item in _require_list(obj, "segments")),
+        ),
+        participants=cast(
+            "tuple[ParticipantState, ...]",
+            tuple(_participant_from_jsonable(item) for item in _require_list(obj, "participants")),
+        ),
+        pending_actions=cast(
+            "tuple[ActionProposal, ...]",
+            tuple(_action_proposal_from_jsonable(item) for item in _require_list(obj, "pending_actions")),
+        ),
+    )
+
+
+def _snapshot_ref_from_jsonable(data: Any) -> SnapshotRef:
+    obj = _require_object(data, "snapshot_ref")
+    tier = _require_str(obj, "tier")
+    if tier not in ("bronze", "silver", "gold"):
+        raise ReportError(f"snapshot_ref.tier must be bronze/silver/gold, got {tier!r}")
+    return SnapshotRef(
+        snapshot_id=_uuid_from_jsonable(_require_field(obj, "snapshot_id"), "snapshot_id"),
+        tier=cast(Any, tier),
+        storage_key=_require_str(obj, "storage_key"),
+    )
+
+
+def _evaluation_summary_from_jsonable(data: Any) -> EvaluationSummary:
+    obj = _require_object(data, "summary")
+    overall = _require_str(obj, "overall_status")
+    try:
+        status = GateStatus(overall)
+    except ValueError as exc:
+        raise ReportError(f"summary.overall_status must be a valid GateStatus: {overall!r}") from exc
+    return EvaluationSummary(
+        metrics=tuple(_metric_result_from_jsonable(item) for item in _require_list(obj, "metrics")),
+        gates=tuple(_gate_result_from_jsonable(item) for item in _require_list(obj, "gates")),
+        overall_status=status,
+    )
+
+
+def _metric_result_from_jsonable(data: Any) -> MetricResult:
+    obj = _require_object(data, "metric")
+    return MetricResult(
+        metric_id=_require_str(obj, "metric_id"),
+        value=cast(JsonValue, _require_field(obj, "value")),
+        details=_require_object_field(obj, "details"),
+    )
+
+
+def _gate_result_from_jsonable(data: Any) -> GateResult:
+    obj = _require_object(data, "gate")
+    status_raw = _require_str(obj, "status")
+    try:
+        status = GateStatus(status_raw)
+    except ValueError as exc:
+        raise ReportError(f"gate.status must be a valid GateStatus: {status_raw!r}") from exc
+    return GateResult(
+        gate_id=_require_str(obj, "gate_id"),
+        status=status,
+        reason=_require_str(obj, "reason"),
+        details=_require_object_field(obj, "details"),
+    )
+
+
+def _evidence_record_from_jsonable(data: Any) -> EvidenceRecord:
+    obj = _require_object(data, "evidence")
+    step_index_raw = _require_field(obj, "step_index")
+    if isinstance(step_index_raw, bool) or not isinstance(step_index_raw, int):
+        raise ReportError("evidence.step_index must be int")
+    return EvidenceRecord(
+        evidence_id=_uuid_from_jsonable(_require_field(obj, "evidence_id"), "evidence_id"),
+        evidence_key=_require_str(obj, "evidence_key"),
+        step_index=step_index_raw,
+        agent_id=_require_str(obj, "agent_id"),
+        payload=cast(JsonValue, _require_field(obj, "payload")),
+        created_at=_datetime_from_jsonable(_require_field(obj, "created_at"), "created_at"),
+    )
+
+
+def _claim_record_from_jsonable(data: Any) -> ClaimRecord:
+    obj = _require_object(data, "claim")
+    confidence_raw = _require_field(obj, "confidence")
+    if isinstance(confidence_raw, bool) or not isinstance(confidence_raw, (int, float)):
+        raise ReportError("claim.confidence must be a number")
+    return ClaimRecord(
+        claim_id=_uuid_from_jsonable(_require_field(obj, "claim_id"), "claim_id"),
+        statement=_require_str(obj, "statement"),
+        evidence_ids=tuple(_uuid_from_jsonable(item, "evidence_ids[]") for item in _require_list(obj, "evidence_ids")),
+        confidence=float(confidence_raw),
+        metadata=_require_object_field(obj, "metadata"),
+    )
+
+
+def _segment_from_jsonable(data: Any) -> _SegmentCarrier:
+    obj = _require_object(data, "segment")
+    participant_ids_raw = _require_list(obj, "participant_ids")
+    return _SegmentCarrier(
+        segment_id=_require_str(obj, "segment_id"),
+        participant_ids=tuple(_require_str_value(item, "participant_ids[]") for item in participant_ids_raw),
+    )
+
+
+def _participant_from_jsonable(data: Any) -> _ParticipantCarrier:
+    obj = _require_object(data, "participant")
+    return _ParticipantCarrier(participant_id=_require_str(obj, "participant_id"))
+
+
+def _action_proposal_from_jsonable(data: Any) -> _ActionProposalCarrier:
+    obj = _require_object(data, "action proposal")
+    return _ActionProposalCarrier(
+        proposal_id=_require_str(obj, "proposal_id"),
+        actor_id=_require_str(obj, "actor_id"),
+        action_key=_require_str(obj, "action_key"),
+        payload=cast(JsonValue, _require_field(obj, "payload")),
+    )
+
+
+def _agent_decision_from_jsonable(data: Any) -> _AgentDecisionCarrier:
+    obj = _require_object(data, "agent decision")
+    return _AgentDecisionCarrier(
+        agent_id=_require_str(obj, "agent_id"),
+        proposals=tuple(_action_proposal_from_jsonable(item) for item in _require_list(obj, "proposals")),
+    )
+
+
+def _require_object(data: Any, label: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ReportError(f"{label} must be an object")
+    return cast(dict[str, Any], data)
+
+
+def _require_field(obj: dict[str, Any], name: str) -> Any:
+    if name not in obj:
+        raise ReportError(f"missing required field {name!r}")
+    return obj[name]
+
+
+def _require_str(obj: dict[str, Any], name: str) -> str:
+    value = _require_field(obj, name)
+    if not isinstance(value, str):
+        raise ReportError(f"field {name!r} must be a string")
+    return value
+
+
+def _require_str_value(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise ReportError(f"{label} must be a string")
+    return value
+
+
+def _require_list(obj: dict[str, Any], name: str) -> list[Any]:
+    value = _require_field(obj, name)
+    if not isinstance(value, list):
+        raise ReportError(f"field {name!r} must be a list")
+    return value
+
+
+def _require_object_field(obj: dict[str, Any], name: str) -> JsonObject:
+    value = _require_field(obj, name)
+    if not isinstance(value, dict):
+        raise ReportError(f"field {name!r} must be an object")
+    return cast(JsonObject, value)
+
+
+def _require_seed(obj: dict[str, Any], name: str) -> Seed:
+    value = _require_field(obj, name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ReportError(f"field {name!r} must be an int seed")
+    try:
+        return validate_seed(value)
+    except (TypeError, ValueError) as exc:
+        raise ReportError(f"field {name!r} is not a valid seed: {exc}") from exc
+
+
+def _uuid_from_jsonable(value: Any, label: str) -> UUID:
+    if not isinstance(value, str):
+        raise ReportError(f"{label} must be a UUID string")
+    try:
+        return UUID(value)
+    except ValueError as exc:
+        raise ReportError(f"{label} is not a valid UUID: {value!r}") from exc
+
+
+def _datetime_from_jsonable(value: Any, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ReportError(f"{label} must be an ISO 8601 string")
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ReportError(f"{label} is not a valid ISO 8601 datetime: {value!r}") from exc

--- a/src/abdp/cli/report.py
+++ b/src/abdp/cli/report.py
@@ -163,11 +163,8 @@ def _simulation_state_from_jsonable(
     data: Any,
 ) -> SimulationState[SegmentState, ParticipantState, ActionProposal]:
     obj = _require_object(data, "simulation state")
-    step_index_raw = _require_field(obj, "step_index")
-    if isinstance(step_index_raw, bool) or not isinstance(step_index_raw, int):
-        raise ReportError("simulation state.step_index must be int")
     return SimulationState[SegmentState, ParticipantState, ActionProposal](
-        step_index=step_index_raw,
+        step_index=_require_int(obj, "step_index", "simulation state.step_index"),
         seed=_require_seed(obj, "seed"),
         snapshot_ref=_snapshot_ref_from_jsonable(_require_field(obj, "snapshot_ref")),
         segments=cast(
@@ -191,7 +188,7 @@ def _snapshot_ref_from_jsonable(data: Any) -> SnapshotRef:
     if tier not in ("bronze", "silver", "gold"):
         raise ReportError(f"snapshot_ref.tier must be bronze/silver/gold, got {tier!r}")
     return SnapshotRef(
-        snapshot_id=_uuid_from_jsonable(_require_field(obj, "snapshot_id"), "snapshot_id"),
+        snapshot_id=_require_uuid(obj, "snapshot_id"),
         tier=cast(Any, tier),
         storage_key=_require_str(obj, "storage_key"),
     )
@@ -237,16 +234,13 @@ def _gate_result_from_jsonable(data: Any) -> GateResult:
 
 def _evidence_record_from_jsonable(data: Any) -> EvidenceRecord:
     obj = _require_object(data, "evidence")
-    step_index_raw = _require_field(obj, "step_index")
-    if isinstance(step_index_raw, bool) or not isinstance(step_index_raw, int):
-        raise ReportError("evidence.step_index must be int")
     return EvidenceRecord(
-        evidence_id=_uuid_from_jsonable(_require_field(obj, "evidence_id"), "evidence_id"),
+        evidence_id=_require_uuid(obj, "evidence_id"),
         evidence_key=_require_str(obj, "evidence_key"),
-        step_index=step_index_raw,
+        step_index=_require_int(obj, "step_index", "evidence.step_index"),
         agent_id=_require_str(obj, "agent_id"),
         payload=cast(JsonValue, _require_field(obj, "payload")),
-        created_at=_datetime_from_jsonable(_require_field(obj, "created_at"), "created_at"),
+        created_at=_require_datetime(obj, "created_at"),
     )
 
 
@@ -256,7 +250,7 @@ def _claim_record_from_jsonable(data: Any) -> ClaimRecord:
     if isinstance(confidence_raw, bool) or not isinstance(confidence_raw, (int, float)):
         raise ReportError("claim.confidence must be a number")
     return ClaimRecord(
-        claim_id=_uuid_from_jsonable(_require_field(obj, "claim_id"), "claim_id"),
+        claim_id=_require_uuid(obj, "claim_id"),
         statement=_require_str(obj, "statement"),
         evidence_ids=tuple(_uuid_from_jsonable(item, "evidence_ids[]") for item in _require_list(obj, "evidence_ids")),
         confidence=float(confidence_raw),
@@ -343,6 +337,21 @@ def _require_seed(obj: dict[str, Any], name: str) -> Seed:
         return validate_seed(value)
     except (TypeError, ValueError) as exc:
         raise ReportError(f"field {name!r} is not a valid seed: {exc}") from exc
+
+
+def _require_int(obj: dict[str, Any], name: str, label: str) -> int:
+    value = _require_field(obj, name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ReportError(f"{label} must be int")
+    return int(value)
+
+
+def _require_uuid(obj: dict[str, Any], name: str) -> UUID:
+    return _uuid_from_jsonable(_require_field(obj, name), name)
+
+
+def _require_datetime(obj: dict[str, Any], name: str) -> datetime:
+    return _datetime_from_jsonable(_require_field(obj, name), name)
 
 
 def _uuid_from_jsonable(value: Any, label: str) -> UUID:

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -39,15 +39,6 @@ def test_main_report_subcommand_help_exits_zero() -> None:
     assert exc_info.value.code == 0
 
 
-def test_main_report_subcommand_returns_two_with_not_implemented_message(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    exit_code = main(["report"])
-    captured = capsys.readouterr()
-    assert exit_code == 2
-    assert "not implemented" in captured.err.lower()
-
-
 def test_python_dash_m_abdp_help_exits_zero() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "abdp", "--help"],

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -243,6 +243,25 @@ def test_report_help_exits_zero() -> None:
     assert exc_info.value.code == 0
 
 
+def test_report_output_to_missing_parent_directory_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    audit = build_rich_audit_log(Seed(0))
+    src = tmp_path / "in.json"
+    _write_json(audit, src)
+    bad_output = tmp_path / "does" / "not" / "exist" / "out.json"
+
+    exit_code = main(["report", str(src), "--format", "json", "--output", str(bad_output)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+    assert captured.err.count(b"\n") == 1
+    assert not bad_output.exists()
+
+
 def test_report_falls_back_to_text_write_when_stdout_has_no_buffer(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -1,0 +1,264 @@
+"""Tests for ``abdp.cli.report`` subcommand."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from abdp.cli.__main__ import main
+from abdp.core import Seed
+from abdp.evaluation import EvaluationSummary, GateResult, GateStatus, MetricResult
+from abdp.evidence import AuditLog, ClaimRecord, EvidenceRecord
+from abdp.reporting import render_json_report, render_markdown_report
+from abdp.scenario import ScenarioRun, ScenarioStep
+from abdp.simulation import (
+    ActionProposal,
+    ParticipantState,
+    SegmentState,
+    SimulationState,
+)
+from abdp.simulation.snapshot_ref import SnapshotRef
+from tests.cli._fixtures import build_audit_log
+
+
+_UUID_A = UUID("11111111-1111-1111-1111-111111111111")
+_UUID_B = UUID("22222222-2222-2222-2222-222222222222")
+_UUID_C = UUID("33333333-3333-3333-3333-333333333333")
+
+
+def _rich_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    snapshot = SnapshotRef(snapshot_id=_UUID_A, tier="silver", storage_key="snap/key")
+    state = SimulationState[SegmentState, ParticipantState, ActionProposal](
+        step_index=0,
+        seed=seed,
+        snapshot_ref=snapshot,
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+    step = ScenarioStep[SegmentState, ParticipantState, ActionProposal](
+        state=state,
+        decisions=(),
+        proposals=(),
+    )
+    run = ScenarioRun[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="rich-✓",
+        seed=seed,
+        steps=(step, step),
+        final_state=state,
+    )
+    metrics = (
+        MetricResult(metric_id="m1", value=1, details={"k": "v"}),
+        MetricResult(metric_id="m2", value=2.5, details={}),
+    )
+    gates = (
+        GateResult(gate_id="g1", status=GateStatus.PASS, reason="ok", details={}),
+        GateResult(gate_id="g2", status=GateStatus.WARN, reason="meh", details={"x": 1}),
+    )
+    summary = EvaluationSummary(metrics=metrics, gates=gates, overall_status=GateStatus.WARN)
+    evidence = (
+        EvidenceRecord(
+            evidence_id=_UUID_B,
+            evidence_key="ek",
+            step_index=0,
+            agent_id="agent-1",
+            payload={"data": [1, 2, 3]},
+            created_at=datetime(2026, 4, 1, 12, 0, tzinfo=UTC),
+        ),
+    )
+    claims = (
+        ClaimRecord(
+            claim_id=_UUID_C,
+            statement="claim-✓",
+            evidence_ids=(_UUID_B,),
+            confidence=0.75,
+            metadata={"k": "v"},
+        ),
+    )
+    return AuditLog[SegmentState, ParticipantState, ActionProposal](
+        scenario_key="rich-✓",
+        seed=seed,
+        run=run,
+        summary=summary,
+        evidence=evidence,
+        claims=claims,
+    )
+
+
+def build_rich_audit_log(seed: Seed) -> AuditLog[Any, Any, Any]:
+    return _rich_audit_log(seed)
+
+
+def _write_json(audit: AuditLog[Any, Any, Any], path: Path) -> None:
+    path.write_bytes(render_json_report(audit).encode("utf-8"))
+
+
+def test_report_json_round_trip_is_byte_identical(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    audit = build_rich_audit_log(Seed(42))
+    src = tmp_path / "in.json"
+    _write_json(audit, src)
+    expected = src.read_bytes()
+
+    exit_code = main(["report", str(src), "--format", "json"])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == expected
+
+
+def test_report_markdown_matches_direct_renderer_call(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    audit = build_rich_audit_log(Seed(7))
+    src = tmp_path / "in.json"
+    _write_json(audit, src)
+    expected = render_markdown_report(audit).encode("utf-8")
+
+    exit_code = main(["report", str(src), "--format", "markdown"])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == expected
+
+
+def test_report_with_output_writes_file_byte_equal(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    audit = build_rich_audit_log(Seed(0))
+    src = tmp_path / "in.json"
+    _write_json(audit, src)
+    out = tmp_path / "out.json"
+
+    exit_code = main(["report", str(src), "--format", "json", "--output", str(out)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == b""
+    assert out.read_bytes() == src.read_bytes()
+
+
+def test_report_markdown_with_output_writes_file_byte_equal(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    audit = build_rich_audit_log(Seed(1))
+    src = tmp_path / "in.json"
+    _write_json(audit, src)
+    out = tmp_path / "out.md"
+
+    exit_code = main(["report", str(src), "--format", "markdown", "--output", str(out)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == b""
+    assert out.read_bytes() == render_markdown_report(audit).encode("utf-8")
+
+
+@pytest.mark.parametrize("status", [GateStatus.PASS, GateStatus.WARN, GateStatus.FAIL])
+def test_report_returns_zero_regardless_of_overall_status(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+    status: GateStatus,
+) -> None:
+    audit = build_audit_log(Seed(0))
+    src = tmp_path / "in.json"
+    payload = json.loads(render_json_report(audit))
+    payload["summary"]["overall_status"] = status.value
+    src.write_bytes(json.dumps(payload).encode("utf-8"))
+
+    exit_code = main(["report", str(src), "--format", "json"])
+    capsysbinary.readouterr()
+    assert exit_code == 0
+
+
+def test_report_missing_file_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    missing = tmp_path / "nope.json"
+    exit_code = main(["report", str(missing), "--format", "json"])
+    captured = capsysbinary.readouterr()
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_report_invalid_json_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    src = tmp_path / "bad.json"
+    src.write_text("not json {", encoding="utf-8")
+    exit_code = main(["report", str(src), "--format", "json"])
+    captured = capsysbinary.readouterr()
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_report_invalid_audit_shape_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    src = tmp_path / "shape.json"
+    src.write_bytes(b'{"scenario_key": "x"}')
+    exit_code = main(["report", str(src), "--format", "markdown"])
+    captured = capsysbinary.readouterr()
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_report_missing_format_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["report", "any.json"])
+    assert exc_info.value.code == 2
+
+
+def test_report_missing_path_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["report", "--format", "json"])
+    assert exc_info.value.code == 2
+
+
+def test_report_invalid_format_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["report", "any.json", "--format", "yaml"])
+    assert exc_info.value.code == 2
+
+
+def test_report_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["report", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_report_falls_back_to_text_write_when_stdout_has_no_buffer(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import io
+    import sys
+
+    audit = build_rich_audit_log(Seed(0))
+    src = tmp_path / "in.json"
+    _write_json(audit, src)
+
+    text_only = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", text_only)
+    exit_code = main(["report", str(src), "--format", "json"])
+    capsys.readouterr()
+
+    assert exit_code == 0
+    assert text_only.getvalue() == render_json_report(audit)

--- a/tests/cli/test_report_validators.py
+++ b/tests/cli/test_report_validators.py
@@ -1,0 +1,264 @@
+"""Coverage tests for ``abdp.cli.report`` reconstruction validators."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typing import cast
+
+import pytest
+
+from abdp.cli.__main__ import main
+from abdp.cli.report import ReportError, _audit_log_from_jsonable
+from abdp.core import Seed
+from abdp.reporting import render_json_report
+from tests.cli._fixtures import build_audit_log
+
+
+def _baseline_payload() -> dict[str, object]:
+    audit = build_audit_log(Seed(0))
+    return cast(dict[str, object], json.loads(render_json_report(audit)))
+
+
+def _set(payload: dict[str, object], path: list[str], value: object) -> dict[str, object]:
+    cursor: object = payload
+    for key in path[:-1]:
+        assert isinstance(cursor, dict)
+        cursor = cursor[key]
+    assert isinstance(cursor, dict)
+    cursor[path[-1]] = value
+    return payload
+
+
+def _write(tmp_path: Path, payload: dict[str, object]) -> Path:
+    out = tmp_path / "audit.json"
+    out.write_bytes(json.dumps(payload).encode("utf-8"))
+    return out
+
+
+def test_audit_log_must_be_object() -> None:
+    with pytest.raises(ReportError, match="audit log must be an object"):
+        _audit_log_from_jsonable(["not", "an", "object"])
+
+
+def test_missing_required_field_raises() -> None:
+    with pytest.raises(ReportError, match="missing required field 'scenario_key'"):
+        _audit_log_from_jsonable({})
+
+
+def test_invalid_seed_type_raises() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["seed"], "not-an-int")
+    with pytest.raises(ReportError, match="seed.*must be an int seed"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_invalid_seed_value_raises() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["seed"], -1)
+    _set(payload, ["run", "seed"], -1)
+    with pytest.raises(ReportError, match="not a valid seed"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_audit_log_post_init_mismatch_wrapped() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["scenario_key"], "different")
+    with pytest.raises(ReportError, match="invalid audit log"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_step_index_must_be_int() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["run", "final_state", "step_index"], "zero")
+    with pytest.raises(ReportError, match="simulation state.step_index must be int"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_invalid_snapshot_tier_raises() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["run", "final_state", "snapshot_ref", "tier"], "platinum")
+    with pytest.raises(ReportError, match="snapshot_ref.tier"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_invalid_overall_status_raises() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["summary", "overall_status"], "unknown")
+    with pytest.raises(ReportError, match="summary.overall_status"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_invalid_gate_status_raises() -> None:
+    payload = _baseline_payload()
+    payload_summary = payload["summary"]
+    assert isinstance(payload_summary, dict)
+    payload_summary["gates"] = [
+        {"gate_id": "g1", "status": "yikes", "reason": "x", "details": {}},
+    ]
+    with pytest.raises(ReportError, match="gate.status"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_evidence_step_index_must_be_int() -> None:
+    payload = _baseline_payload()
+    payload["evidence"] = [
+        {
+            "evidence_id": "11111111-1111-1111-1111-111111111111",
+            "evidence_key": "k",
+            "step_index": "zero",
+            "agent_id": "a",
+            "payload": {},
+            "created_at": "2026-04-01T00:00:00+00:00",
+        }
+    ]
+    with pytest.raises(ReportError, match="evidence.step_index must be int"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_claim_confidence_must_be_number() -> None:
+    payload = _baseline_payload()
+    payload["claims"] = [
+        {
+            "claim_id": "11111111-1111-1111-1111-111111111111",
+            "statement": "s",
+            "evidence_ids": ["22222222-2222-2222-2222-222222222222"],
+            "confidence": "high",
+            "metadata": {},
+        }
+    ]
+    with pytest.raises(ReportError, match="claim.confidence"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_string_field_type_validation() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["scenario_key"], 42)
+    with pytest.raises(ReportError, match="scenario_key.*must be a string"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_list_field_type_validation() -> None:
+    payload = _baseline_payload()
+    _set(payload, ["evidence"], "not-a-list")
+    with pytest.raises(ReportError, match="evidence.*must be a list"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_object_field_type_validation() -> None:
+    payload = _baseline_payload()
+    payload_summary = payload["summary"]
+    assert isinstance(payload_summary, dict)
+    payload_summary["metrics"] = [{"metric_id": "m", "value": 1, "details": "not-object"}]
+    with pytest.raises(ReportError, match="details.*must be an object"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_uuid_must_be_string() -> None:
+    payload = _baseline_payload()
+    payload["evidence"] = [
+        {
+            "evidence_id": 42,
+            "evidence_key": "k",
+            "step_index": 0,
+            "agent_id": "a",
+            "payload": {},
+            "created_at": "2026-04-01T00:00:00+00:00",
+        }
+    ]
+    with pytest.raises(ReportError, match="evidence_id must be a UUID string"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_uuid_invalid_string_raises() -> None:
+    payload = _baseline_payload()
+    payload["evidence"] = [
+        {
+            "evidence_id": "not-a-uuid",
+            "evidence_key": "k",
+            "step_index": 0,
+            "agent_id": "a",
+            "payload": {},
+            "created_at": "2026-04-01T00:00:00+00:00",
+        }
+    ]
+    with pytest.raises(ReportError, match="evidence_id is not a valid UUID"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_datetime_must_be_string() -> None:
+    payload = _baseline_payload()
+    payload["evidence"] = [
+        {
+            "evidence_id": "11111111-1111-1111-1111-111111111111",
+            "evidence_key": "k",
+            "step_index": 0,
+            "agent_id": "a",
+            "payload": {},
+            "created_at": 0,
+        }
+    ]
+    with pytest.raises(ReportError, match="created_at must be an ISO 8601 string"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_datetime_invalid_string_raises() -> None:
+    payload = _baseline_payload()
+    payload["evidence"] = [
+        {
+            "evidence_id": "11111111-1111-1111-1111-111111111111",
+            "evidence_key": "k",
+            "step_index": 0,
+            "agent_id": "a",
+            "payload": {},
+            "created_at": "yesterday",
+        }
+    ]
+    with pytest.raises(ReportError, match="created_at is not a valid"):
+        _audit_log_from_jsonable(payload)
+
+
+def test_segment_carrier_satisfies_protocol(tmp_path: Path) -> None:
+    payload = _baseline_payload()
+    final_state = payload["run"]
+    assert isinstance(final_state, dict)
+    fs = final_state["final_state"]
+    assert isinstance(fs, dict)
+    fs["segments"] = [{"segment_id": "s1", "participant_ids": ["p1", "p2"]}]
+    fs["participants"] = [{"participant_id": "p1"}]
+    fs["pending_actions"] = [{"proposal_id": "pr", "actor_id": "a", "action_key": "k", "payload": {}}]
+    final_state["steps"] = [
+        {
+            "state": fs,
+            "decisions": [
+                {
+                    "agent_id": "agent",
+                    "proposals": [{"proposal_id": "pr", "actor_id": "a", "action_key": "k", "payload": {}}],
+                }
+            ],
+            "proposals": [{"proposal_id": "pr", "actor_id": "a", "action_key": "k", "payload": {}}],
+        }
+    ]
+
+    src = _write(tmp_path, payload)
+    out = tmp_path / "out.json"
+    exit_code = main(["report", str(src), "--format", "json", "--output", str(out)])
+    assert exit_code == 0
+    assert out.exists()
+    rebuilt = json.loads(out.read_bytes())
+    assert isinstance(rebuilt, dict)
+    rebuilt_run = rebuilt["run"]
+    assert isinstance(rebuilt_run, dict)
+    assert len(rebuilt_run["steps"]) == 1
+
+
+def test_participant_id_must_be_string() -> None:
+    payload = _baseline_payload()
+    final_state = payload["run"]
+    assert isinstance(final_state, dict)
+    fs = final_state["final_state"]
+    assert isinstance(fs, dict)
+    fs["segments"] = [{"segment_id": "s", "participant_ids": [42]}]
+    with pytest.raises(ReportError, match="participant_ids.*must be a string"):
+        _audit_log_from_jsonable(payload)


### PR DESCRIPTION
## Summary

- Implements `abdp report PATH --format {json,markdown} [--output FILE]`.
- Reconstructs `AuditLog` from JSON via private frozen dataclass carriers that satisfy the runtime_checkable simulation/agent protocols, so `render_json_report` and `render_markdown_report` are byte-identical for the rebuilt audit.
- Always exits 0 on success regardless of `summary.overall_status`; exits 2 on read/parse/shape errors with a single-line stderr message.

## TDD

- RED  `test(cli): add failing tests for report subcommand (#123)` — 15 behaviour tests
- GREEN `feat(cli): implement report subcommand (#123)` — implementation + validator tests + wires `__main__.py`
- REFACTOR `refactor(cli): extract field helpers in report reconstructor (#123)` — `_require_int`, `_require_uuid`, `_require_datetime`

## Verification

- 816 tests pass, 100% coverage
- ruff, ruff-format, mypy --strict all green

Closes #123