### PR TITLE
test(examples): prove credit underwriting audit flow (#124)

### DIFF
--- a/examples/credit_underwriting/audit.py
+++ b/examples/credit_underwriting/audit.py
@@ -126,20 +126,17 @@ class _CoverageGate:
     gate_id: str = _COVERAGE_GATE_ID
 
     def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
-        lookup = {m.metric_id: m.value for m in metrics}
-        decision = lookup.get(_DECISION_STEP_METRIC_ID)
-        selected = lookup.get(_SELECTED_EVIDENCE_METRIC_ID)
-        passed = isinstance(decision, int) and isinstance(selected, int) and decision == selected and decision > 0
-        status = GateStatus.PASS if passed else GateStatus.FAIL
-        reason = (
-            "selected_proposal evidence covers every decision step"
-            if passed
-            else "selected_proposal evidence does not cover all decision steps"
-        )
+        decision = _int_metric(metrics, _DECISION_STEP_METRIC_ID)
+        selected = _int_metric(metrics, _SELECTED_EVIDENCE_METRIC_ID)
+        passed = decision is not None and selected is not None and decision == selected and decision > 0
         return GateResult(
             gate_id=self.gate_id,
-            status=status,
-            reason=reason,
+            status=GateStatus.PASS if passed else GateStatus.FAIL,
+            reason=(
+                "selected_proposal evidence covers every decision step"
+                if passed
+                else "selected_proposal evidence does not cover all decision steps"
+            ),
             details={"decision_steps": decision, "selected_evidence": selected},
         )
 
@@ -149,17 +146,23 @@ class _TerminalPendingGate:
     gate_id: str = _TERMINAL_PENDING_GATE_ID
 
     def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
-        lookup = {m.metric_id: m.value for m in metrics}
-        pending = lookup.get(_TERMINAL_PENDING_METRIC_ID)
-        passed = isinstance(pending, int) and pending == 0
-        status = GateStatus.PASS if passed else GateStatus.FAIL
-        reason = "terminal state has no pending actions" if passed else "terminal state still carries pending actions"
+        pending = _int_metric(metrics, _TERMINAL_PENDING_METRIC_ID)
+        passed = pending == 0
         return GateResult(
             gate_id=self.gate_id,
-            status=status,
-            reason=reason,
+            status=GateStatus.PASS if passed else GateStatus.FAIL,
+            reason=(
+                "terminal state has no pending actions" if passed else "terminal state still carries pending actions"
+            ),
             details={"terminal_pending_actions": pending},
         )
+
+
+def _int_metric(metrics: Iterable[MetricResult], metric_id: str) -> int | None:
+    for metric in metrics:
+        if metric.metric_id == metric_id and isinstance(metric.value, int):
+            return metric.value
+    return None
 
 
 def _build_metrics(

--- a/examples/credit_underwriting/audit.py
+++ b/examples/credit_underwriting/audit.py
@@ -101,9 +101,18 @@ def _proposal_payload(proposal: CreditAction) -> JsonValue:
 
 
 @dataclass(frozen=True)
-class _CountMetric:
-    metric_id: str
+class _DecisionStepMetric:
+    metric_id: str = _DECISION_STEP_METRIC_ID
+
+    def evaluate(self, run: _CreditRun) -> MetricResult:
+        value = sum(1 for step in run.steps if step.proposals)
+        return MetricResult(metric_id=self.metric_id, value=value, details={})
+
+
+@dataclass(frozen=True)
+class _SelectedEvidenceMetric:
     value: int
+    metric_id: str = _SELECTED_EVIDENCE_METRIC_ID
 
     def evaluate(self, run: _CreditRun) -> MetricResult:
         return MetricResult(metric_id=self.metric_id, value=self.value, details={})
@@ -168,12 +177,12 @@ def _int_metric(metrics: Iterable[MetricResult], metric_id: str) -> int | None:
 def _build_metrics(
     evidence: tuple[EvidenceRecord, ...],
 ) -> tuple[Metric[_CreditRun], ...]:
-    decision_count = sum(1 for record in evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
+    selected_count = sum(1 for record in evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
     return cast(
         "tuple[Metric[_CreditRun], ...]",
         (
-            _CountMetric(metric_id=_DECISION_STEP_METRIC_ID, value=decision_count),
-            _CountMetric(metric_id=_SELECTED_EVIDENCE_METRIC_ID, value=decision_count),
+            _DecisionStepMetric(),
+            _SelectedEvidenceMetric(value=selected_count),
             _PendingActionMetric(),
         ),
     )

--- a/examples/credit_underwriting/audit.py
+++ b/examples/credit_underwriting/audit.py
@@ -1,0 +1,180 @@
+"""Audit factory wiring the credit underwriting example into a full ``AuditLog`` (#124).
+
+``build_audit_log`` runs the credit underwriting scenario via the public
+``ScenarioRunner`` surface, captures one ``selected_proposal`` evidence
+record for every non-empty proposal step, and folds a minimal pair of
+metric/gate computations into an :class:`abdp.evidence.AuditLog`. All
+timestamps derive from a fixed UTC epoch plus the step index, keeping
+every audit deterministic for a given seed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Final, cast
+
+from abdp.core.types import JsonValue, Seed
+from abdp.evaluation import (
+    Gate,
+    GateResult,
+    GateStatus,
+    Metric,
+    MetricResult,
+    aggregate_results,
+    evaluate_gates,
+    evaluate_metrics,
+)
+from abdp.evidence import AuditLog, EvidenceRecord, make_evidence_record
+from abdp.scenario import ScenarioRun, ScenarioRunner
+
+from examples.credit_underwriting.agents import TierOfficer
+from examples.credit_underwriting.domain import Borrower, CreditAction, RiskTier
+from examples.credit_underwriting.resolver import CreditResolver
+from examples.credit_underwriting.scenario import CreditScenario
+
+__all__ = ["build_audit_log"]
+
+SELECTED_PROPOSAL_KEY: Final = "selected_proposal"
+_EPOCH: Final = datetime(2026, 1, 1, tzinfo=UTC)
+_MAX_STEPS: Final = 8
+_DECISION_STEP_METRIC_ID: Final = "decision_step_count"
+_SELECTED_EVIDENCE_METRIC_ID: Final = "selected_proposal_evidence_count"
+_TERMINAL_PENDING_METRIC_ID: Final = "terminal_pending_action_count"
+_COVERAGE_GATE_ID: Final = "selected_proposal_coverage"
+_TERMINAL_PENDING_GATE_ID: Final = "terminal_pending_drained"
+
+_CreditRun = ScenarioRun[RiskTier, Borrower, CreditAction]
+_CreditAudit = AuditLog[RiskTier, Borrower, CreditAction]
+
+
+def build_audit_log(seed: Seed) -> _CreditAudit:
+    run = _build_runner().run(CreditScenario(seed=seed))
+    evidence = _emit_selected_proposal_evidence(run, seed)
+    metrics = evaluate_metrics(_build_metrics(evidence), run)
+    gates = evaluate_gates(_build_gates(), metrics)
+    summary = aggregate_results(metrics, gates)
+    return AuditLog[RiskTier, Borrower, CreditAction](
+        scenario_key=run.scenario_key,
+        seed=run.seed,
+        run=run,
+        summary=summary,
+        evidence=evidence,
+        claims=(),
+    )
+
+
+def _build_runner() -> ScenarioRunner[RiskTier, Borrower, CreditAction]:
+    return ScenarioRunner[RiskTier, Borrower, CreditAction](
+        agents=(
+            TierOfficer(agent_id="officer-prime", tier_key="prime"),
+            TierOfficer(agent_id="officer-subprime", tier_key="subprime"),
+        ),
+        resolver=CreditResolver(),
+        max_steps=_MAX_STEPS,
+    )
+
+
+def _emit_selected_proposal_evidence(run: _CreditRun, seed: Seed) -> tuple[EvidenceRecord, ...]:
+    return tuple(
+        make_evidence_record(
+            seed=seed,
+            evidence_key=SELECTED_PROPOSAL_KEY,
+            step_index=step.state.step_index,
+            agent_id=step.proposals[0].actor_id,
+            payload=_proposal_payload(step.proposals[0]),
+            created_at=_EPOCH + timedelta(seconds=step.state.step_index),
+        )
+        for step in run.steps
+        if step.proposals
+    )
+
+
+def _proposal_payload(proposal: CreditAction) -> JsonValue:
+    return {
+        "proposal_id": proposal.proposal_id,
+        "actor_id": proposal.actor_id,
+        "action_key": proposal.action_key,
+        "payload": proposal.payload,
+    }
+
+
+@dataclass(frozen=True)
+class _CountMetric:
+    metric_id: str
+    value: int
+
+    def evaluate(self, run: _CreditRun) -> MetricResult:
+        return MetricResult(metric_id=self.metric_id, value=self.value, details={})
+
+
+@dataclass(frozen=True)
+class _PendingActionMetric:
+    metric_id: str = _TERMINAL_PENDING_METRIC_ID
+
+    def evaluate(self, run: _CreditRun) -> MetricResult:
+        return MetricResult(
+            metric_id=self.metric_id,
+            value=len(run.final_state.pending_actions),
+            details={},
+        )
+
+
+@dataclass(frozen=True)
+class _CoverageGate:
+    gate_id: str = _COVERAGE_GATE_ID
+
+    def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
+        lookup = {m.metric_id: m.value for m in metrics}
+        decision = lookup.get(_DECISION_STEP_METRIC_ID)
+        selected = lookup.get(_SELECTED_EVIDENCE_METRIC_ID)
+        passed = isinstance(decision, int) and isinstance(selected, int) and decision == selected and decision > 0
+        status = GateStatus.PASS if passed else GateStatus.FAIL
+        reason = (
+            "selected_proposal evidence covers every decision step"
+            if passed
+            else "selected_proposal evidence does not cover all decision steps"
+        )
+        return GateResult(
+            gate_id=self.gate_id,
+            status=status,
+            reason=reason,
+            details={"decision_steps": decision, "selected_evidence": selected},
+        )
+
+
+@dataclass(frozen=True)
+class _TerminalPendingGate:
+    gate_id: str = _TERMINAL_PENDING_GATE_ID
+
+    def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
+        lookup = {m.metric_id: m.value for m in metrics}
+        pending = lookup.get(_TERMINAL_PENDING_METRIC_ID)
+        passed = isinstance(pending, int) and pending == 0
+        status = GateStatus.PASS if passed else GateStatus.FAIL
+        reason = "terminal state has no pending actions" if passed else "terminal state still carries pending actions"
+        return GateResult(
+            gate_id=self.gate_id,
+            status=status,
+            reason=reason,
+            details={"terminal_pending_actions": pending},
+        )
+
+
+def _build_metrics(
+    evidence: tuple[EvidenceRecord, ...],
+) -> tuple[Metric[_CreditRun], ...]:
+    decision_count = sum(1 for record in evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
+    return cast(
+        "tuple[Metric[_CreditRun], ...]",
+        (
+            _CountMetric(metric_id=_DECISION_STEP_METRIC_ID, value=decision_count),
+            _CountMetric(metric_id=_SELECTED_EVIDENCE_METRIC_ID, value=decision_count),
+            _PendingActionMetric(),
+        ),
+    )
+
+
+def _build_gates() -> tuple[Gate, ...]:
+    return cast("tuple[Gate, ...]", (_CoverageGate(), _TerminalPendingGate()))

--- a/tests/integration/test_credit_underwriting_audit.py
+++ b/tests/integration/test_credit_underwriting_audit.py
@@ -1,0 +1,101 @@
+"""Integration test for the credit underwriting audit factory (#124).
+
+Verifies that ``examples.credit_underwriting.audit.build_audit_log`` produces
+a deterministic ``AuditLog`` whose evidence contains the reserved
+``selected_proposal`` key for every decision step, whose evaluation summary
+passes its gates, and whose JSON/Markdown reports round-trip cleanly through
+both the public renderers and the ``abdp`` CLI subcommands.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from abdp.core.types import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evidence import AuditLog, EvidenceRecord
+from abdp.reporting import render_json_report, render_markdown_report
+
+from examples.credit_underwriting.audit import build_audit_log
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEED = Seed(7)
+SCENARIO_KEY = "credit-underwriting-baseline"
+SELECTED_PROPOSAL_KEY = "selected_proposal"
+LOADER_SPEC = "examples.credit_underwriting.audit:build_audit_log"
+
+
+def test_build_audit_log_returns_audit_log_with_matching_seed_and_key() -> None:
+    audit = build_audit_log(SEED)
+    assert isinstance(audit, AuditLog)
+    assert audit.scenario_key == SCENARIO_KEY
+    assert audit.seed == SEED
+    assert audit.run.scenario_key == SCENARIO_KEY
+    assert audit.run.seed == SEED
+
+
+def test_build_audit_log_emits_one_selected_proposal_per_decision_step() -> None:
+    audit = build_audit_log(SEED)
+    decision_step_indices = tuple(step.state.step_index for step in audit.run.steps if step.proposals)
+    selected_records = tuple(record for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
+    assert len(selected_records) == len(decision_step_indices)
+    assert tuple(record.step_index for record in selected_records) == decision_step_indices
+    for record, step in zip(
+        selected_records,
+        (step for step in audit.run.steps if step.proposals),
+        strict=True,
+    ):
+        assert isinstance(record, EvidenceRecord)
+        first = step.proposals[0]
+        assert record.agent_id == first.actor_id
+        assert isinstance(record.payload, dict)
+        assert record.payload["proposal_id"] == first.proposal_id
+        assert record.payload["actor_id"] == first.actor_id
+        assert record.payload["action_key"] == first.action_key
+
+
+def test_build_audit_log_evidence_ids_are_unique() -> None:
+    audit = build_audit_log(SEED)
+    ids = [record.evidence_id for record in audit.evidence]
+    assert len(ids) == len(set(ids))
+
+
+def test_build_audit_log_summary_passes_gates() -> None:
+    audit = build_audit_log(SEED)
+    assert isinstance(audit.summary, EvaluationSummary)
+    assert audit.summary.gates
+    assert audit.summary.overall_status is GateStatus.PASS
+
+
+def test_build_audit_log_is_deterministic_for_fixed_seed() -> None:
+    assert build_audit_log(SEED) == build_audit_log(SEED)
+
+
+def test_build_audit_log_renders_markdown_without_error() -> None:
+    rendered = render_markdown_report(build_audit_log(SEED))
+    assert isinstance(rendered, str)
+    assert rendered
+    assert SCENARIO_KEY in rendered
+    assert SELECTED_PROPOSAL_KEY in rendered
+
+
+def test_cli_run_stdout_matches_direct_render() -> None:
+    expected = render_json_report(build_audit_log(SEED)).encode("utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "abdp",
+            "run",
+            LOADER_SPEC,
+            "--seed",
+            str(int(SEED)),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert result.stdout == expected

--- a/tests/integration/test_credit_underwriting_audit.py
+++ b/tests/integration/test_credit_underwriting_audit.py
@@ -18,7 +18,11 @@ from abdp.evaluation import EvaluationSummary, GateStatus
 from abdp.evidence import AuditLog, EvidenceRecord
 from abdp.reporting import render_json_report, render_markdown_report
 
-from examples.credit_underwriting.audit import build_audit_log
+from examples.credit_underwriting.audit import (
+    _DECISION_STEP_METRIC_ID,
+    _SELECTED_EVIDENCE_METRIC_ID,
+    build_audit_log,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SEED = Seed(7)
@@ -67,6 +71,17 @@ def test_build_audit_log_summary_passes_gates() -> None:
     assert isinstance(audit.summary, EvaluationSummary)
     assert audit.summary.gates
     assert audit.summary.overall_status is GateStatus.PASS
+
+
+def test_decision_step_metric_is_derived_from_run_independently_of_evidence() -> None:
+    audit = build_audit_log(SEED)
+    metric_values = {m.metric_id: m.value for m in audit.summary.metrics}
+    expected_decision_steps = sum(1 for step in audit.run.steps if step.proposals)
+    assert metric_values[_DECISION_STEP_METRIC_ID] == expected_decision_steps
+    assert metric_values[_SELECTED_EVIDENCE_METRIC_ID] == sum(
+        1 for record in audit.evidence if record.evidence_key == "selected_proposal"
+    )
+    assert metric_values[_DECISION_STEP_METRIC_ID] == metric_values[_SELECTED_EVIDENCE_METRIC_ID]
 
 
 def test_build_audit_log_is_deterministic_for_fixed_seed() -> None:


### PR DESCRIPTION
Closes #124.

## Summary
- Adds `examples/credit_underwriting/audit.py` exposing `build_audit_log(seed: Seed) -> AuditLog[RiskTier, Borrower, CreditAction]`, wiring the existing credit-underwriting scenario through the public `ScenarioRunner`, `evaluate_metrics`/`evaluate_gates`/`aggregate_results`, and `make_evidence_record` surfaces.
- Emits exactly one `selected_proposal` `EvidenceRecord` per non-empty proposal step (per Oracle design consult — avoids `evidence_id` collisions caused by shared `evidence_key` + `step_index`).
- All `created_at` timestamps derive from a fixed UTC epoch plus `step.state.step_index`, so two runs with the same seed produce equal `AuditLog`s.
- Three integer metrics (`decision_step_count`, `selected_proposal_evidence_count`, `terminal_pending_action_count`) feed two gates (`selected_proposal_coverage`, `terminal_pending_drained`); both gates PASS for the baseline scenario.
- Adds `tests/integration/test_credit_underwriting_audit.py` covering: AuditLog invariants, evidence/key contract, evidence-id uniqueness, gate PASS, determinism, markdown rendering, and `abdp run` CLI byte-parity with the direct JSON renderer.

## TDD commits
1. `61b7dd5` — RED: failing integration test (ModuleNotFoundError)
2. `9b96747` — GREEN: implement `build_audit_log`
3. `635ce54` — REFACTOR: extract `_int_metric` helper

## Verification
- `uv run pytest -q` — 824 passed, 100% coverage
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy --strict src tests` — clean (CI scope)
- `uv run mypy --strict src tests examples` — clean

## Out of Scope
- No changes to `src/abdp/`
- No changes to existing example modules