### PR TITLE
test(examples): prove queue scheduling audit flow (#125)

### DIFF
--- a/examples/queue_scheduling/audit.py
+++ b/examples/queue_scheduling/audit.py
@@ -1,0 +1,192 @@
+"""Audit factory wiring the queue scheduling example into a full ``AuditLog`` (#125).
+
+``build_audit_log`` runs the queue scheduling scenario via the public
+``ScenarioRunner`` surface, captures one ``selected_proposal`` evidence
+record for every non-empty proposal step, and folds a minimal pair of
+metric/gate computations into an :class:`abdp.evidence.AuditLog`. All
+timestamps derive from a fixed UTC epoch plus the step index, keeping
+every audit deterministic for a given seed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Final, cast
+
+from abdp.core.types import JsonValue, Seed
+from abdp.evaluation import (
+    Gate,
+    GateResult,
+    GateStatus,
+    Metric,
+    MetricResult,
+    aggregate_results,
+    evaluate_gates,
+    evaluate_metrics,
+)
+from abdp.evidence import AuditLog, EvidenceRecord, make_evidence_record
+from abdp.scenario import ScenarioRun, ScenarioRunner
+
+from examples.queue_scheduling.agents import QueueWorkerAgent
+from examples.queue_scheduling.domain import QueueProposal, QueueScenario, Slot, Worker
+from examples.queue_scheduling.resolver import QueueResolver
+
+__all__ = ["build_audit_log"]
+
+SELECTED_PROPOSAL_KEY: Final = "selected_proposal"
+_EPOCH: Final = datetime(2026, 1, 1, tzinfo=UTC)
+_MAX_STEPS: Final = 3
+_SCENARIO_KEY: Final = "latency-baseline"
+_DECISION_STEP_METRIC_ID: Final = "decision_step_count"
+_SELECTED_EVIDENCE_METRIC_ID: Final = "selected_proposal_evidence_count"
+_TERMINAL_PENDING_METRIC_ID: Final = "terminal_pending_action_count"
+_COVERAGE_GATE_ID: Final = "selected_proposal_coverage"
+_TERMINAL_PENDING_GATE_ID: Final = "terminal_pending_drained"
+
+_QueueRun = ScenarioRun[Slot, Worker, QueueProposal]
+_QueueAudit = AuditLog[Slot, Worker, QueueProposal]
+
+
+def build_audit_log(seed: Seed) -> _QueueAudit:
+    run = _build_runner().run(QueueScenario(scenario_key=_SCENARIO_KEY, seed=seed))
+    evidence = _emit_selected_proposal_evidence(run, seed)
+    metrics = evaluate_metrics(_build_metrics(evidence), run)
+    gates = evaluate_gates(_build_gates(), metrics)
+    summary = aggregate_results(metrics, gates)
+    return AuditLog[Slot, Worker, QueueProposal](
+        scenario_key=run.scenario_key,
+        seed=run.seed,
+        run=run,
+        summary=summary,
+        evidence=evidence,
+        claims=(),
+    )
+
+
+def _build_runner() -> ScenarioRunner[Slot, Worker, QueueProposal]:
+    return ScenarioRunner[Slot, Worker, QueueProposal](
+        agents=(
+            QueueWorkerAgent(agent_id="worker-fast", queue_id="expedite"),
+            QueueWorkerAgent(agent_id="worker-flex", queue_id="standard"),
+        ),
+        resolver=QueueResolver(),
+        max_steps=_MAX_STEPS,
+    )
+
+
+def _emit_selected_proposal_evidence(run: _QueueRun, seed: Seed) -> tuple[EvidenceRecord, ...]:
+    return tuple(
+        make_evidence_record(
+            seed=seed,
+            evidence_key=SELECTED_PROPOSAL_KEY,
+            step_index=step.state.step_index,
+            agent_id=step.proposals[0].actor_id,
+            payload=_proposal_payload(step.proposals[0]),
+            created_at=_EPOCH + timedelta(seconds=step.state.step_index),
+        )
+        for step in run.steps
+        if step.proposals
+    )
+
+
+def _proposal_payload(proposal: QueueProposal) -> JsonValue:
+    return {
+        "proposal_id": proposal.proposal_id,
+        "actor_id": proposal.actor_id,
+        "action_key": proposal.action_key,
+        "payload": proposal.payload,
+    }
+
+
+@dataclass(frozen=True)
+class _DecisionStepMetric:
+    metric_id: str = _DECISION_STEP_METRIC_ID
+
+    def evaluate(self, run: _QueueRun) -> MetricResult:
+        value = sum(1 for step in run.steps if step.proposals)
+        return MetricResult(metric_id=self.metric_id, value=value, details={})
+
+
+@dataclass(frozen=True)
+class _SelectedEvidenceMetric:
+    value: int
+    metric_id: str = _SELECTED_EVIDENCE_METRIC_ID
+
+    def evaluate(self, run: _QueueRun) -> MetricResult:
+        return MetricResult(metric_id=self.metric_id, value=self.value, details={})
+
+
+@dataclass(frozen=True)
+class _PendingActionMetric:
+    metric_id: str = _TERMINAL_PENDING_METRIC_ID
+
+    def evaluate(self, run: _QueueRun) -> MetricResult:
+        return MetricResult(
+            metric_id=self.metric_id,
+            value=len(run.final_state.pending_actions),
+            details={},
+        )
+
+
+@dataclass(frozen=True)
+class _CoverageGate:
+    gate_id: str = _COVERAGE_GATE_ID
+
+    def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
+        decision = _int_metric(metrics, _DECISION_STEP_METRIC_ID)
+        selected = _int_metric(metrics, _SELECTED_EVIDENCE_METRIC_ID)
+        passed = decision is not None and selected is not None and decision == selected and decision > 0
+        return GateResult(
+            gate_id=self.gate_id,
+            status=GateStatus.PASS if passed else GateStatus.FAIL,
+            reason=(
+                "selected_proposal evidence covers every decision step"
+                if passed
+                else "selected_proposal evidence does not cover all decision steps"
+            ),
+            details={"decision_steps": decision, "selected_evidence": selected},
+        )
+
+
+@dataclass(frozen=True)
+class _TerminalPendingGate:
+    gate_id: str = _TERMINAL_PENDING_GATE_ID
+
+    def evaluate(self, metrics: Iterable[MetricResult]) -> GateResult:
+        pending = _int_metric(metrics, _TERMINAL_PENDING_METRIC_ID)
+        passed = pending == 0
+        return GateResult(
+            gate_id=self.gate_id,
+            status=GateStatus.PASS if passed else GateStatus.FAIL,
+            reason=(
+                "terminal state has no pending actions" if passed else "terminal state still carries pending actions"
+            ),
+            details={"terminal_pending_actions": pending},
+        )
+
+
+def _int_metric(metrics: Iterable[MetricResult], metric_id: str) -> int | None:
+    for metric in metrics:
+        if metric.metric_id == metric_id and isinstance(metric.value, int):
+            return metric.value
+    return None
+
+
+def _build_metrics(
+    evidence: tuple[EvidenceRecord, ...],
+) -> tuple[Metric[_QueueRun], ...]:
+    selected_count = sum(1 for record in evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
+    return cast(
+        "tuple[Metric[_QueueRun], ...]",
+        (
+            _DecisionStepMetric(),
+            _SelectedEvidenceMetric(value=selected_count),
+            _PendingActionMetric(),
+        ),
+    )
+
+
+def _build_gates() -> tuple[Gate, ...]:
+    return cast("tuple[Gate, ...]", (_CoverageGate(), _TerminalPendingGate()))

--- a/tests/integration/_audit_assertions.py
+++ b/tests/integration/_audit_assertions.py
@@ -1,0 +1,54 @@
+"""Shared assertion helpers for audit-flow integration tests (#125).
+
+Three invariants are identical across every domain audit flow: selected
+proposal coverage per decision step, byte-for-byte determinism for a
+fixed seed, and CLI parity with the public ``render_json_report`` surface.
+Domain-specific scenario keys, loader specs, and payload schemas remain
+local to each test module.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from abdp.core.types import Seed
+from abdp.evidence import AuditLog, EvidenceRecord
+from abdp.reporting import render_json_report
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SELECTED_PROPOSAL_KEY = "selected_proposal"
+
+
+def assert_selected_proposal_per_decision_step(audit: AuditLog[Any, Any, Any]) -> tuple[EvidenceRecord, ...]:
+    decision_step_indices = tuple(step.state.step_index for step in audit.run.steps if step.proposals)
+    selected_records = tuple(record for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
+    assert len(selected_records) == len(decision_step_indices)
+    assert tuple(record.step_index for record in selected_records) == decision_step_indices
+    return selected_records
+
+
+def assert_audit_is_deterministic(
+    factory: Callable[[Seed], AuditLog[Any, Any, Any]],
+    seed: Seed,
+) -> None:
+    assert factory(seed) == factory(seed)
+
+
+def assert_cli_run_matches_direct_render(
+    factory: Callable[[Seed], AuditLog[Any, Any, Any]],
+    loader_spec: str,
+    seed: Seed,
+) -> None:
+    expected = render_json_report(factory(seed)).encode("utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "abdp", "run", loader_spec, "--seed", str(int(seed))],
+        capture_output=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert result.stdout == expected

--- a/tests/integration/test_credit_underwriting_audit.py
+++ b/tests/integration/test_credit_underwriting_audit.py
@@ -9,25 +9,25 @@ both the public renderers and the ``abdp`` CLI subcommands.
 
 from __future__ import annotations
 
-import subprocess
-import sys
-from pathlib import Path
-
 from abdp.core.types import Seed
 from abdp.evaluation import EvaluationSummary, GateStatus
 from abdp.evidence import AuditLog, EvidenceRecord
-from abdp.reporting import render_json_report, render_markdown_report
+from abdp.reporting import render_markdown_report
 
 from examples.credit_underwriting.audit import (
     _DECISION_STEP_METRIC_ID,
     _SELECTED_EVIDENCE_METRIC_ID,
     build_audit_log,
 )
+from tests.integration._audit_assertions import (
+    SELECTED_PROPOSAL_KEY,
+    assert_audit_is_deterministic,
+    assert_cli_run_matches_direct_render,
+    assert_selected_proposal_per_decision_step,
+)
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 SEED = Seed(7)
 SCENARIO_KEY = "credit-underwriting-baseline"
-SELECTED_PROPOSAL_KEY = "selected_proposal"
 LOADER_SPEC = "examples.credit_underwriting.audit:build_audit_log"
 
 
@@ -42,10 +42,7 @@ def test_build_audit_log_returns_audit_log_with_matching_seed_and_key() -> None:
 
 def test_build_audit_log_emits_one_selected_proposal_per_decision_step() -> None:
     audit = build_audit_log(SEED)
-    decision_step_indices = tuple(step.state.step_index for step in audit.run.steps if step.proposals)
-    selected_records = tuple(record for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
-    assert len(selected_records) == len(decision_step_indices)
-    assert tuple(record.step_index for record in selected_records) == decision_step_indices
+    selected_records = assert_selected_proposal_per_decision_step(audit)
     for record, step in zip(
         selected_records,
         (step for step in audit.run.steps if step.proposals),
@@ -79,13 +76,13 @@ def test_decision_step_metric_is_derived_from_run_independently_of_evidence() ->
     expected_decision_steps = sum(1 for step in audit.run.steps if step.proposals)
     assert metric_values[_DECISION_STEP_METRIC_ID] == expected_decision_steps
     assert metric_values[_SELECTED_EVIDENCE_METRIC_ID] == sum(
-        1 for record in audit.evidence if record.evidence_key == "selected_proposal"
+        1 for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY
     )
     assert metric_values[_DECISION_STEP_METRIC_ID] == metric_values[_SELECTED_EVIDENCE_METRIC_ID]
 
 
 def test_build_audit_log_is_deterministic_for_fixed_seed() -> None:
-    assert build_audit_log(SEED) == build_audit_log(SEED)
+    assert_audit_is_deterministic(build_audit_log, SEED)
 
 
 def test_build_audit_log_renders_markdown_without_error() -> None:
@@ -97,20 +94,4 @@ def test_build_audit_log_renders_markdown_without_error() -> None:
 
 
 def test_cli_run_stdout_matches_direct_render() -> None:
-    expected = render_json_report(build_audit_log(SEED)).encode("utf-8")
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "abdp",
-            "run",
-            LOADER_SPEC,
-            "--seed",
-            str(int(SEED)),
-        ],
-        capture_output=True,
-        check=False,
-        cwd=REPO_ROOT,
-    )
-    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
-    assert result.stdout == expected
+    assert_cli_run_matches_direct_render(build_audit_log, LOADER_SPEC, SEED)

--- a/tests/integration/test_queue_scheduling_audit.py
+++ b/tests/integration/test_queue_scheduling_audit.py
@@ -9,25 +9,25 @@ summary passes, and whose JSON output matches the ``abdp run`` CLI byte-for-byte
 
 from __future__ import annotations
 
-import subprocess
-import sys
-from pathlib import Path
-
 from abdp.core.types import Seed
 from abdp.evaluation import EvaluationSummary, GateStatus
 from abdp.evidence import AuditLog, EvidenceRecord
-from abdp.reporting import render_json_report, render_markdown_report
+from abdp.reporting import render_markdown_report
 
 from examples.queue_scheduling.audit import (
     _DECISION_STEP_METRIC_ID,
     _SELECTED_EVIDENCE_METRIC_ID,
     build_audit_log,
 )
+from tests.integration._audit_assertions import (
+    SELECTED_PROPOSAL_KEY,
+    assert_audit_is_deterministic,
+    assert_cli_run_matches_direct_render,
+    assert_selected_proposal_per_decision_step,
+)
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 SEED = Seed(11)
 SCENARIO_KEY = "latency-baseline"
-SELECTED_PROPOSAL_KEY = "selected_proposal"
 LOADER_SPEC = "examples.queue_scheduling.audit:build_audit_log"
 
 
@@ -42,10 +42,7 @@ def test_build_audit_log_returns_audit_log_with_matching_seed_and_key() -> None:
 
 def test_build_audit_log_emits_one_selected_proposal_per_decision_step() -> None:
     audit = build_audit_log(SEED)
-    decision_step_indices = tuple(step.state.step_index for step in audit.run.steps if step.proposals)
-    selected_records = tuple(record for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
-    assert len(selected_records) == len(decision_step_indices)
-    assert tuple(record.step_index for record in selected_records) == decision_step_indices
+    selected_records = assert_selected_proposal_per_decision_step(audit)
     for record, step in zip(
         selected_records,
         (step for step in audit.run.steps if step.proposals),
@@ -85,7 +82,7 @@ def test_decision_step_metric_is_derived_from_run_independently_of_evidence() ->
 
 
 def test_build_audit_log_is_deterministic_for_fixed_seed() -> None:
-    assert build_audit_log(SEED) == build_audit_log(SEED)
+    assert_audit_is_deterministic(build_audit_log, SEED)
 
 
 def test_build_audit_log_renders_markdown_without_error() -> None:
@@ -97,20 +94,4 @@ def test_build_audit_log_renders_markdown_without_error() -> None:
 
 
 def test_cli_run_stdout_matches_direct_render() -> None:
-    expected = render_json_report(build_audit_log(SEED)).encode("utf-8")
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "abdp",
-            "run",
-            LOADER_SPEC,
-            "--seed",
-            str(int(SEED)),
-        ],
-        capture_output=True,
-        check=False,
-        cwd=REPO_ROOT,
-    )
-    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
-    assert result.stdout == expected
+    assert_cli_run_matches_direct_render(build_audit_log, LOADER_SPEC, SEED)

--- a/tests/integration/test_queue_scheduling_audit.py
+++ b/tests/integration/test_queue_scheduling_audit.py
@@ -1,0 +1,116 @@
+"""Integration test for the queue scheduling audit factory (#125).
+
+Mirrors :mod:`tests.integration.test_credit_underwriting_audit` so that the
+audit pipeline is provably domain-neutral: the queue scheduling example must
+produce a deterministic ``AuditLog`` whose evidence carries the reserved
+``selected_proposal`` key for every step with proposals, whose evaluation
+summary passes, and whose JSON output matches the ``abdp run`` CLI byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from abdp.core.types import Seed
+from abdp.evaluation import EvaluationSummary, GateStatus
+from abdp.evidence import AuditLog, EvidenceRecord
+from abdp.reporting import render_json_report, render_markdown_report
+
+from examples.queue_scheduling.audit import (
+    _DECISION_STEP_METRIC_ID,
+    _SELECTED_EVIDENCE_METRIC_ID,
+    build_audit_log,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEED = Seed(11)
+SCENARIO_KEY = "latency-baseline"
+SELECTED_PROPOSAL_KEY = "selected_proposal"
+LOADER_SPEC = "examples.queue_scheduling.audit:build_audit_log"
+
+
+def test_build_audit_log_returns_audit_log_with_matching_seed_and_key() -> None:
+    audit = build_audit_log(SEED)
+    assert isinstance(audit, AuditLog)
+    assert audit.scenario_key == SCENARIO_KEY
+    assert audit.seed == SEED
+    assert audit.run.scenario_key == SCENARIO_KEY
+    assert audit.run.seed == SEED
+
+
+def test_build_audit_log_emits_one_selected_proposal_per_decision_step() -> None:
+    audit = build_audit_log(SEED)
+    decision_step_indices = tuple(step.state.step_index for step in audit.run.steps if step.proposals)
+    selected_records = tuple(record for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY)
+    assert len(selected_records) == len(decision_step_indices)
+    assert tuple(record.step_index for record in selected_records) == decision_step_indices
+    for record, step in zip(
+        selected_records,
+        (step for step in audit.run.steps if step.proposals),
+        strict=True,
+    ):
+        assert isinstance(record, EvidenceRecord)
+        first = step.proposals[0]
+        assert record.agent_id == first.actor_id
+        assert isinstance(record.payload, dict)
+        assert record.payload["proposal_id"] == first.proposal_id
+        assert record.payload["actor_id"] == first.actor_id
+        assert record.payload["action_key"] == first.action_key
+
+
+def test_build_audit_log_evidence_ids_are_unique() -> None:
+    audit = build_audit_log(SEED)
+    ids = [record.evidence_id for record in audit.evidence]
+    assert len(ids) == len(set(ids))
+
+
+def test_build_audit_log_summary_passes_gates() -> None:
+    audit = build_audit_log(SEED)
+    assert isinstance(audit.summary, EvaluationSummary)
+    assert audit.summary.gates
+    assert audit.summary.overall_status is GateStatus.PASS
+
+
+def test_decision_step_metric_is_derived_from_run_independently_of_evidence() -> None:
+    audit = build_audit_log(SEED)
+    metric_values = {m.metric_id: m.value for m in audit.summary.metrics}
+    expected_decision_steps = sum(1 for step in audit.run.steps if step.proposals)
+    assert metric_values[_DECISION_STEP_METRIC_ID] == expected_decision_steps
+    assert metric_values[_SELECTED_EVIDENCE_METRIC_ID] == sum(
+        1 for record in audit.evidence if record.evidence_key == SELECTED_PROPOSAL_KEY
+    )
+    assert metric_values[_DECISION_STEP_METRIC_ID] == metric_values[_SELECTED_EVIDENCE_METRIC_ID]
+
+
+def test_build_audit_log_is_deterministic_for_fixed_seed() -> None:
+    assert build_audit_log(SEED) == build_audit_log(SEED)
+
+
+def test_build_audit_log_renders_markdown_without_error() -> None:
+    rendered = render_markdown_report(build_audit_log(SEED))
+    assert isinstance(rendered, str)
+    assert rendered
+    assert SCENARIO_KEY in rendered
+    assert SELECTED_PROPOSAL_KEY in rendered
+
+
+def test_cli_run_stdout_matches_direct_render() -> None:
+    expected = render_json_report(build_audit_log(SEED)).encode("utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "abdp",
+            "run",
+            LOADER_SPEC,
+            "--seed",
+            str(int(SEED)),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert result.stdout == expected


### PR DESCRIPTION
Closes #125

## Summary
- Mirrors the credit underwriting audit factory for the queue scheduling example, proving the audit pipeline is domain-neutral.
- Adds `examples/queue_scheduling/audit.py` with `build_audit_log(seed)` that runs the scenario via `ScenarioRunner`, captures `selected_proposal` evidence per decision step, and folds metric/gate computations into an `AuditLog`.
- Splits `_DecisionStepMetric` (run-derived) from `_SelectedEvidenceMetric` (evidence-derived) so the coverage gate can detect missing evidence (per Oracle review of #124).
- Extracts `tests/integration/_audit_assertions.py` with three narrow shared invariants: selected-proposal coverage per decision step, determinism for fixed seed, CLI parity with `render_json_report`. Domain-specific scenario keys, loader specs, and payload schemas remain local to each test module (per Oracle 12/12 design consult).
- Refactors `tests/integration/test_credit_underwriting_audit.py` to use the shared helpers.

## Commits
- `70720bd` test(examples): add failing queue scheduling audit-flow integration test (RED)
- `39d8853` feat(examples): add queue scheduling audit factory (GREEN)
- `5702415` refactor(tests): extract shared audit-flow assertion helpers (REFACTOR)

## Verification
- `uv run pytest -q` — 833 passed, 100% coverage
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy --strict src tests` — clean
- `uv run mypy --strict src tests examples` — clean