### PR TITLE
docs(readme): add 'Used by' section listing younggeul as a downstream consumer (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ See [Roadmap](docs/roadmap.md) for milestone scope, including the v0.2 modeling 
 ## Quickstart
 
 New here? Start with the [10-minute modeling quickstart](docs/quickstart.md).
+
+## Used by
+
+- [`kpubdata-lab/younggeul`](https://github.com/kpubdata-lab/younggeul) — Korean apartment market simulation. Adopts `abdp.core.stable_hash`, `abdp.data` contract aliases, `abdp.reporting.render_json_report`, and shadow `abdp.simulation.ScenarioRunner` + `abdp.evidence.AuditLog` projection on top of LangGraph. See younggeul's [ADR-012 final selective-adoption inventory](https://github.com/kpubdata-lab/younggeul/blob/main/docs/adr/012-abdp-backed-core.md#final-selective-adoption-inventory) for the per-surface adoption breakdown.
+
+If your project uses `abdp`, open a PR adding it here.


### PR DESCRIPTION
Closes #160

## Summary

Adds a 5-line \`## Used by\` section to README.md listing [\`kpubdata-lab/younggeul\`](https://github.com/kpubdata-lab/younggeul) as the first known downstream consumer of \`abdp\` v0.3.0. younggeul has completed a selective-adoption migration and now ships a runtime backend switch (\`YOUNGGEUL_CORE_BACKEND={local,abdp}\`) gated by a parity test suite running on every PR. The entry links to younggeul's [ADR-012 final selective-adoption inventory](https://github.com/kpubdata-lab/younggeul/blob/main/docs/adr/012-abdp-backed-core.md#final-selective-adoption-inventory) for the per-surface adoption breakdown.

This is docs-only; no code or examples are touched. The README invites other consumers to add themselves.

## TDD evidence

N/A — this is a docs-only README addition with no behavior or contract change. No tests are required, none were added.

## Verification

\`\`\`text
$ ruff format --check .
156 files already formatted

$ ruff check .
All checks passed!

$ mypy --strict src tests
Success: no issues found in 142 source files

$ pytest --cov
TOTAL    1173      0    282      0   100%
51 files skipped due to complete coverage.
Required test coverage of 100.0% reached. Total coverage: 100.00%
833 passed in 7.58s
\`\`\`

## Mutmut policy

N/A — docs-only change.

## Acceptance criteria checklist

- [x] README.md gains a single new \`## Used by\` section after \`## Quickstart\`
- [x] Section is 5 lines, links \`kpubdata-lab/younggeul\` and the ADR-012 final-inventory anchor
- [x] No other doc changes
- [x] Domain-neutral framing (Korean apartment market mentioned once for identification, no domain claims)
- [x] Invites other consumers to open a PR adding themselves
- [x] mutmut N/A (docs-only)
- [x] ruff/mypy/pytest gates pass (no code touched; full suite still 833 passed, 100% coverage)