### PR TITLE
fix: bump abdp package version to 0.3.0 (#162)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abdp"
-version = "0.1.0.dev0"
+version = "0.3.0"
 description = "A Python framework for reproducible agent-based decision simulation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/abdp/version.py
+++ b/src/abdp/version.py
@@ -1,5 +1,5 @@
 def get_version() -> str:
-    return "0.1.0.dev0"
+    return "0.3.0"
 
 
 __version__ = get_version()

--- a/tests/meta/test_pyproject_metadata.py
+++ b/tests/meta/test_pyproject_metadata.py
@@ -7,7 +7,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 
 EXPECTED_PROJECT_NAME = "abdp"
-EXPECTED_PROJECT_VERSION = "0.1.0.dev0"
+EXPECTED_PROJECT_VERSION = "0.3.0"
 EXPECTED_PROJECT_DESCRIPTION = "A Python framework for reproducible agent-based decision simulation"
 EXPECTED_PROJECT_README = "README.md"
 EXPECTED_PROJECT_REQUIRES_PYTHON = ">=3.12"
@@ -50,3 +50,13 @@ def test_project_name_matches_src_layout_package_directory() -> None:
     assert _load_pyproject()["project"]["name"] == package_root.name
     assert package_root.is_dir()
     assert (package_root / "__init__.py").is_file()
+
+
+def test_runtime_version_matches_declared_project_version() -> None:
+    from abdp import __version__, get_version
+
+    declared_version = _load_pyproject()["project"]["version"]
+
+    assert declared_version == EXPECTED_PROJECT_VERSION
+    assert get_version() == declared_version
+    assert __version__ == declared_version

--- a/tests/unit/test_package_version.py
+++ b/tests/unit/test_package_version.py
@@ -1,11 +1,11 @@
 def test_abdp_has_expected_version() -> None:
     from abdp import __version__
 
-    assert __version__ == "0.1.0.dev0"
+    assert __version__ == "0.3.0"
 
 
 def test_get_version_returns_public_version() -> None:
     from abdp import __version__, get_version
 
-    assert get_version() == "0.1.0.dev0"
+    assert get_version() == "0.3.0"
     assert get_version() == __version__


### PR DESCRIPTION
Closes #162

## Summary

`abdp.__version__` and `abdp.get_version()` were reporting `0.1.0.dev0` at the v0.3.0 release line, misleading downstream consumers (e.g., `kpubdata-lab/younggeul`, which pins `abdp` at the `bf0ab1d` / `v0.3.0` commit).

This PR aligns packaging metadata and runtime version reporting with the released tag and adds a regression test that prevents the two from silently drifting apart again.

- `pyproject.toml [project].version`: `0.1.0.dev0` → `0.3.0`
- `src/abdp/version.py`: `get_version()` returns `"0.3.0"`
- new regression test in `tests/meta/test_pyproject_metadata.py` asserts `abdp.__version__`, `abdp.get_version()`, and the declared `[project].version` in `pyproject.toml` all agree

Per the v0.1 roadmap non-goal ("No calendar dates, release promises, or detailed release engineering belongs in `v0.1`"), this PR keeps the version literal static and does **not** introduce `setuptools-scm`, `hatch-vcs`, or `importlib.metadata`-based dynamic versioning.

## TDD evidence

- **RED** — `99eab9f` `test: assert abdp reports 0.3.0 and stays in sync with pyproject (#162)`
  - Bumps test expectations from `"0.1.0.dev0"` to `"0.3.0"` in `tests/unit/test_package_version.py` and `tests/meta/test_pyproject_metadata.py`.
  - Adds `test_runtime_version_matches_declared_project_version` to assert the runtime ↔ packaging-metadata sync.
  - Verified failing locally before the GREEN commit:
    ```
    FAILED tests/unit/test_package_version.py::test_abdp_has_expected_version
    FAILED tests/unit/test_package_version.py::test_get_version_returns_public_version
    FAILED tests/meta/test_pyproject_metadata.py::test_pyproject_declares_required_project_metadata
    FAILED tests/meta/test_pyproject_metadata.py::test_runtime_version_matches_declared_project_version
    4 failed, 2 passed
    ```
- **GREEN** — `2a52e78` `fix: bump abdp package version to 0.3.0 (#162)`
  - Bumps `pyproject.toml [project].version` and `src/abdp/version.py` literals to `"0.3.0"`.
- **REFACTOR** — none. The GREEN change is a two-line literal bump and is already clean enough to merge; per `CONTRIBUTING.md` ("REFACTOR is optional when the GREEN change is already clean enough to merge.") no third commit is invented.

## Verification

Ran the full local gate from repo root after GREEN:

```
$ ruff format --check .
156 files already formatted

$ ruff check .
All checks passed!

$ mypy --strict src tests
Success: no issues found in 142 source files

$ pytest --cov
... 834 passed in 4.60s
TOTAL    1173      0    282      0   100%
Required test coverage of 100.0% reached. Total coverage: 100.00%
```

Test count went from 833 → 834 (the new sync regression test). 100% line coverage maintained.

## Mutmut policy

`N/A` — the production change is a constant-literal bump; no behavior or branching logic is introduced. The new sync test pins both the runtime literal and the packaging-metadata literal, killing any mutation that would alter either.

## Acceptance criteria checklist

- [x] `pyproject.toml` declares `version = "0.3.0"`
- [x] `abdp.get_version()` returns `"0.3.0"`
- [x] `abdp.__version__` returns `"0.3.0"`
- [x] Regression test asserts `abdp.__version__` stays in sync with `pyproject.toml`'s declared `[project].version`
- [x] `ruff format --check .`, `ruff check .`, `mypy --strict src tests`, and `pytest --cov` all pass with 100% line coverage maintained