### PR TITLE
docs: align root README with current v0.3 surface (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Teams that study or compare decision strategies often rebuild one-off simulation
 
 ## Getting started
 
-Install from source and walk the [10-minute modeling quickstart](docs/quickstart.md):
+Install from source:
 
 ```bash
 pip install -e .
 ```
 
-The quickstart introduces `abdp.agents`, `abdp.scenario`, the deterministic runner, and the audit log produced by the `abdp.cli` `run` and `report` commands shipped in v0.3.
+Then walk the [10-minute modeling quickstart](docs/quickstart.md). It introduces `abdp.agents`, `abdp.scenario`, and the deterministic `ScenarioRunner` by building a single self-contained reproducible scenario top-to-bottom.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,29 @@
 
 A Python framework for reproducible agent-based decision simulation
 
+## What it is
+
+abdp is a Python framework for reproducible agent-based decision simulation. It defines the contracts an experiment needs — agents, scenarios, evaluation, evidence, and reporting — so the same simulation can be rerun, inspected, and compared instead of rebuilt as a one-off script.
+
+The framework intentionally keeps a narrow shipped surface. Domain rules, integrations, hosted services, and dashboards are explicitly out of scope; see [non-goals](docs/vision.md#non-goals) for the full list.
+
+## Why it exists
+
+Teams that study or compare decision strategies often rebuild one-off simulations that are hard to rerun, inspect, and compare. abdp exists to be the shared substrate for those experiments so assumptions, inputs, randomness, and outputs can be reproduced and reviewed by someone other than the original author. See the [vision](docs/vision.md) for the problem statement and target users.
+
+## Getting started
+
+Install from source and walk the [10-minute modeling quickstart](docs/quickstart.md):
+
+```bash
+pip install -e .
+```
+
+The quickstart introduces `abdp.agents`, `abdp.scenario`, the deterministic runner, and the audit log produced by the `abdp.cli` `run` and `report` commands shipped in v0.3.
+
 ## Roadmap
 
-See [Roadmap](docs/roadmap.md) for milestone scope, including the v0.2 modeling toolkit boundary and v0.3 themes.
-
-## Quickstart
-
-New here? Start with the [10-minute modeling quickstart](docs/quickstart.md).
+See [Roadmap](docs/roadmap.md) for milestone scope, the v0.2 modeling toolkit boundary, the v0.3 auditable simulation surface, and the explicit non-goals attached to each milestone.
 
 ## Used by
 

--- a/tests/meta/test_project_readme.py
+++ b/tests/meta/test_project_readme.py
@@ -31,8 +31,11 @@ SECTION_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "## Getting started",
         (
+            "pip install -e .",
             "[10-minute modeling quickstart](docs/quickstart.md)",
-            "pip install",
+            "`abdp.agents`",
+            "`abdp.scenario`",
+            "`ScenarioRunner`",
         ),
     ),
     (

--- a/tests/meta/test_project_readme.py
+++ b/tests/meta/test_project_readme.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README_PATH = REPO_ROOT / "README.md"
+
+TAGLINE = "A Python framework for reproducible agent-based decision simulation"
+
+SECTION_HEADINGS: tuple[str, ...] = (
+    "## What it is",
+    "## Why it exists",
+    "## Getting started",
+    "## Roadmap",
+    "## Used by",
+)
+
+SECTION_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "## What it is",
+        (
+            "reproducible agent-based decision simulation",
+            "[non-goals](docs/vision.md#non-goals)",
+        ),
+    ),
+    (
+        "## Why it exists",
+        (
+            "rebuild one-off simulations",
+            "[vision](docs/vision.md)",
+        ),
+    ),
+    (
+        "## Getting started",
+        (
+            "[10-minute modeling quickstart](docs/quickstart.md)",
+            "pip install",
+        ),
+    ),
+    (
+        "## Roadmap",
+        ("[Roadmap](docs/roadmap.md)",),
+    ),
+    (
+        "## Used by",
+        ("[`kpubdata-lab/younggeul`](https://github.com/kpubdata-lab/younggeul)",),
+    ),
+)
+
+FORBIDDEN_SNIPPETS: tuple[str, ...] = (
+    "v1.0",
+    "production-ready",
+    "will support",
+    "enterprise",
+    "milestone sequencing",
+)
+
+MAX_PROJECT_README_LINES = 60
+
+
+def _read_readme_text() -> str:
+    assert README_PATH.is_file(), README_PATH
+    return README_PATH.read_text(encoding="utf-8")
+
+
+def _assert_snippets_in_order(text: str, snippets: tuple[str, ...]) -> None:
+    start = 0
+    for snippet in snippets:
+        index = text.find(snippet, start)
+        assert index >= 0, snippet
+        start = index + len(snippet)
+
+
+def test_project_readme_exists() -> None:
+    assert README_PATH.is_file()
+
+
+def test_project_readme_includes_tagline_and_required_sections_in_order() -> None:
+    text = _read_readme_text()
+
+    assert "# agent-based-decision-pipeline" in text
+    assert TAGLINE in text
+    _assert_snippets_in_order(text, SECTION_HEADINGS)
+
+
+def test_each_readme_section_contains_expected_snippets() -> None:
+    text = _read_readme_text()
+
+    for index, (heading, snippets) in enumerate(SECTION_SNIPPETS):
+        section_start = text.index(heading)
+        if index + 1 < len(SECTION_SNIPPETS):
+            next_heading = SECTION_SNIPPETS[index + 1][0]
+            section_end = text.index(next_heading, section_start + len(heading))
+        else:
+            section_end = len(text)
+
+        section_text = text[section_start:section_end]
+        for snippet in snippets:
+            assert snippet in section_text, f"{heading}: {snippet}"
+
+
+def test_project_readme_avoids_forbidden_scope_and_stays_within_line_budget() -> None:
+    text = _read_readme_text()
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in text, snippet
+
+    assert len(text.splitlines()) <= MAX_PROJECT_README_LINES


### PR DESCRIPTION
Closes #164

## Summary

Replace the 17-line pointer-only root README with a focused front-door doc that states what abdp is, why it exists, and how to start, while honoring the repo's anti-duplication discipline: vision still owns non-goals, roadmap still owns milestone scope, and the README cross-links to both rather than restating them.

This is the first deliverable from the consolidation review that produced #164–#167. The other three issues remain open and will be tackled in separate focused PRs (CLI doc, examples promotion, historical-baseline signposts).

## TDD evidence

- **RED commit** `1f03d10` — `test(docs): pin root README structure to current v0.3 surface (#164)`. Adds `tests/meta/test_project_readme.py` modeled on the existing `tests/meta/test_doc_vision.py` pattern: required H2 headings in order, per-section snippet presence (incl. cross-links to vision/quickstart/roadmap and the preserved younggeul Used-by entry), FORBIDDEN snippets to block tone drift (`v1.0`, `production-ready`, `will support`, `enterprise`, `milestone sequencing`), and a 60-line budget. Fails on the original README.
- **GREEN commit** `04cd2d2` — `docs: align root README with current v0.3 surface (#164)`. Rewrites README to satisfy the meta-test. 33 lines (well under the 60-line budget). Preserves the existing younggeul Used-by entry verbatim.
- **REFACTOR**: not used. The GREEN content is already clean enough to merge per CONTRIBUTING.md.

## Verification

```
$ ruff format .
157 files left unchanged

$ ruff check .
All checks passed!

$ mypy --strict src tests
Success: no issues found in 143 source files

$ pytest --cov
838 passed in 5.26s
TOTAL    1173      0    282      0   100%
Required test coverage of 100.0% reached. Total coverage: 100.00%
```

Tests added: 4 (`test_project_readme_exists`, `test_project_readme_includes_tagline_and_required_sections_in_order`, `test_each_readme_section_contains_expected_snippets`, `test_project_readme_avoids_forbidden_scope_and_stays_within_line_budget`).

## Mutmut policy

`N/A` — pure docs + meta-test change, no production code paths added.

## Acceptance criteria checklist

- [x] `tests/meta/test_project_readme.py` added; asserts H1, tagline, ordered H2 sections, per-section snippets, FORBIDDEN snippets, line budget.
- [x] README links to `docs/quickstart.md` and `docs/roadmap.md` (existing links preserved).
- [x] README links to `docs/vision.md` for non-goals rather than restating them.
- [x] The "Used by" entry pointing to `kpubdata-lab/younggeul` is preserved verbatim.
- [x] README stays under the 60-line budget (current: 33 lines).
- [x] FORBIDDEN snippets list blocks regression of tone-drift verbs.
- [x] `ruff format`, `ruff check`, `mypy --strict src tests`, `pytest --cov` all green; 100% coverage maintained.

## Anti-duplication audit (per #164)

- README does NOT restate the v0.1/v0.2/v0.3 non-goals from `docs/roadmap.md` — links instead.
- README does NOT restate the framework non-goals from `docs/vision.md` — links instead via the `#non-goals` anchor.
- README does NOT introduce new strategy/policy content.

## Out-of-scope (tracked separately)

- #165 — `docs(cli): add dedicated CLI usage guide`
- #166 — `docs(examples): surface runnable examples in README and add output samples`
- #167 — `docs: signpost v0.1 historical docs vs current shipped surface`