### PR TITLE
docs(examples): surface runnable examples in README and add output samples (#166)

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -13,28 +13,35 @@ so their outputs are diffable artifacts.
 ## Credit underwriting
 
 A two-officer pipeline that classifies borrowers into risk tiers and emits
-one `selected_proposal` evidence record per non-empty decision step. Run
+one `selected_proposal` evidence record per non-empty proposal step. Run
 locally with `python -m examples.credit_underwriting` for the short stdout
-summary, or import `build_audit_log` from
-[`examples/credit_underwriting`](../../examples/credit_underwriting) to obtain
-a full `AuditLog` whose evidence stream is keyed by `selected_proposal`.
+summary, or call the audit factory at
+`examples.credit_underwriting.audit:build_audit_log` to obtain a full
+`AuditLog` whose evidence stream is keyed by `selected_proposal`. The
+factory is exposed at the submodule path because
+[`examples/credit_underwriting`](../../examples/credit_underwriting)
+deliberately keeps its package `__init__` empty.
 
 The frozen JSON snapshot below was rendered with `Seed(7)` and is the same
-artifact `abdp run examples.credit_underwriting.audit:build_audit_log
---seed 7` would produce.
+artifact that
+`abdp run examples.credit_underwriting.audit:build_audit_log --seed 7`
+would produce.
 
 ## Queue scheduling
 
 A latency-baseline scheduler that dispatches queued requests across worker
-agents and emits one `selected_proposal` evidence record per dispatched
-proposal. Run locally with `python -m examples.queue_scheduling`, or import
-`build_audit_log` from
-[`examples/queue_scheduling`](../../examples/queue_scheduling) to obtain the
-corresponding `AuditLog`.
+agents and emits one `selected_proposal` evidence record per
+non-empty proposal step (steps that select no candidate emit no evidence).
+Run locally with `python -m examples.queue_scheduling`, or call the audit
+factory at `examples.queue_scheduling.audit:build_audit_log` to obtain the
+corresponding `AuditLog`. The factory is exposed at the submodule path
+because [`examples/queue_scheduling`](../../examples/queue_scheduling)
+deliberately keeps its package `__init__` empty.
 
 The frozen JSON snapshot below was rendered with `Seed(11)` and is the same
-artifact `abdp run examples.queue_scheduling.audit:build_audit_log
---seed 11` would produce.
+artifact that
+`abdp run examples.queue_scheduling.audit:build_audit_log --seed 11`
+would produce.
 
 ## Frozen outputs
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -20,7 +20,8 @@ summary, or call the audit factory at
 `AuditLog` whose evidence stream is keyed by `selected_proposal`. The
 factory is exposed at the submodule path because
 [`examples/credit_underwriting`](../../examples/credit_underwriting)
-deliberately keeps its package `__init__` empty.
+deliberately does not re-export `build_audit_log` from its package
+`__init__`.
 
 The frozen JSON snapshot below was rendered with `Seed(7)` and is the same
 artifact that
@@ -36,7 +37,8 @@ Run locally with `python -m examples.queue_scheduling`, or call the audit
 factory at `examples.queue_scheduling.audit:build_audit_log` to obtain the
 corresponding `AuditLog`. The factory is exposed at the submodule path
 because [`examples/queue_scheduling`](../../examples/queue_scheduling)
-deliberately keeps its package `__init__` empty.
+deliberately does not re-export `build_audit_log` from its package
+`__init__`.
 
 The frozen JSON snapshot below was rendered with `Seed(11)` and is the same
 artifact that

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,4 +1,53 @@
 # Examples
 
-Placeholder only. Worked examples and tutorials live here.
-Detailed expansion is deferred to #044.
+Two end-to-end worked examples ship with abdp. Both run on the public
+`ScenarioRunner` surface, fold a real `selected_proposal` evidence stream
+into an `AuditLog`, and serialize through `abdp.reporting.render_json_report`
+so their outputs are diffable artifacts.
+
+| Example | Run | Source |
+| --- | --- | --- |
+| Credit underwriting | `python -m examples.credit_underwriting` | [`examples/credit_underwriting`](../../examples/credit_underwriting) |
+| Queue scheduling | `python -m examples.queue_scheduling` | [`examples/queue_scheduling`](../../examples/queue_scheduling) |
+
+## Credit underwriting
+
+A two-officer pipeline that classifies borrowers into risk tiers and emits
+one `selected_proposal` evidence record per non-empty decision step. Run
+locally with `python -m examples.credit_underwriting` for the short stdout
+summary, or import `build_audit_log` from
+[`examples/credit_underwriting`](../../examples/credit_underwriting) to obtain
+a full `AuditLog` whose evidence stream is keyed by `selected_proposal`.
+
+The frozen JSON snapshot below was rendered with `Seed(7)` and is the same
+artifact `abdp run examples.credit_underwriting.audit:build_audit_log
+--seed 7` would produce.
+
+## Queue scheduling
+
+A latency-baseline scheduler that dispatches queued requests across worker
+agents and emits one `selected_proposal` evidence record per dispatched
+proposal. Run locally with `python -m examples.queue_scheduling`, or import
+`build_audit_log` from
+[`examples/queue_scheduling`](../../examples/queue_scheduling) to obtain the
+corresponding `AuditLog`.
+
+The frozen JSON snapshot below was rendered with `Seed(11)` and is the same
+artifact `abdp run examples.queue_scheduling.audit:build_audit_log
+--seed 11` would produce.
+
+## Frozen outputs
+
+These checked-in JSON files are the byte-identical output of the audit
+factories at the seeds noted above. They are regenerated only when the
+example logic intentionally changes; `tests/meta/test_examples_outputs.py`
+asserts that each file matches a fresh
+`render_json_report(build_audit_log(seed))` and that every snapshot still
+contains the reserved `selected_proposal` evidence key.
+
+- [`outputs/credit_underwriting_report.json`](outputs/credit_underwriting_report.json) — `Seed(7)`, `scenario_key="credit-underwriting-baseline"`.
+- [`outputs/queue_scheduling_report.json`](outputs/queue_scheduling_report.json) — `Seed(11)`, `scenario_key="latency-baseline"`.
+
+To regenerate (only after an intentional behaviour change), render each
+factory through `render_json_report` and overwrite the corresponding file
+under `docs/examples/outputs/`.

--- a/docs/examples/outputs/credit_underwriting_report.json
+++ b/docs/examples/outputs/credit_underwriting_report.json
@@ -1,0 +1,471 @@
+{
+  "claims": [],
+  "evidence": [
+    {
+      "agent_id": "officer-prime",
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "evidence_id": "75876f6b-c5e4-50c1-a344-25679b350b0d",
+      "evidence_key": "selected_proposal",
+      "payload": {
+        "action_key": "escalate",
+        "actor_id": "officer-prime",
+        "payload": {
+          "case_id": "case-prior-001",
+          "reason": "carry_over_review"
+        },
+        "proposal_id": "escalate-prior-001"
+      },
+      "step_index": 0
+    },
+    {
+      "agent_id": "officer-prime",
+      "created_at": "2026-01-01T00:00:01+00:00",
+      "evidence_id": "9c42945e-8ea8-5dab-8463-02b8f463691f",
+      "evidence_key": "selected_proposal",
+      "payload": {
+        "action_key": "escalate",
+        "actor_id": "officer-prime",
+        "payload": {
+          "case_id": "case-borrower-frank",
+          "reason": "borderline_request_info"
+        },
+        "proposal_id": "escalate-borrower-frank-step1"
+      },
+      "step_index": 1
+    }
+  ],
+  "run": {
+    "final_state": {
+      "participants": [
+        {
+          "participant_id": "borrower-alice"
+        },
+        {
+          "participant_id": "borrower-bob"
+        },
+        {
+          "participant_id": "borrower-frank"
+        },
+        {
+          "participant_id": "borrower-carol"
+        },
+        {
+          "participant_id": "borrower-dave"
+        },
+        {
+          "participant_id": "borrower-grace"
+        }
+      ],
+      "pending_actions": [],
+      "seed": 7,
+      "segments": [
+        {
+          "participant_ids": [],
+          "segment_id": "tier-prime"
+        },
+        {
+          "participant_ids": [],
+          "segment_id": "tier-subprime"
+        }
+      ],
+      "snapshot_ref": {
+        "snapshot_id": "33333333-3333-3333-3333-333333333333",
+        "storage_key": "snapshots/bronze/credit-underwriting-initial.json",
+        "tier": "bronze"
+      },
+      "step_index": 2
+    },
+    "scenario_key": "credit-underwriting-baseline",
+    "seed": 7,
+    "steps": [
+      {
+        "decisions": [
+          {
+            "agent_id": "officer-prime",
+            "proposals": [
+              {
+                "action_key": "approve",
+                "actor_id": "officer-prime",
+                "payload": {
+                  "borrower_id": "borrower-alice",
+                  "credit_score": 780,
+                  "requested_amount_cents": 3000000
+                },
+                "proposal_id": "decision-prime-borrower-alice-step0"
+              },
+              {
+                "action_key": "decline",
+                "actor_id": "officer-prime",
+                "payload": {
+                  "borrower_id": "borrower-bob",
+                  "credit_score": 700,
+                  "requested_amount_cents": 4000000
+                },
+                "proposal_id": "decision-prime-borrower-bob-step0"
+              },
+              {
+                "action_key": "request_info",
+                "actor_id": "officer-prime",
+                "payload": {
+                  "borrower_id": "borrower-frank",
+                  "credit_score": 750,
+                  "requested_amount_cents": 6000000
+                },
+                "proposal_id": "decision-prime-borrower-frank-step0"
+              }
+            ]
+          },
+          {
+            "agent_id": "officer-subprime",
+            "proposals": [
+              {
+                "action_key": "approve",
+                "actor_id": "officer-subprime",
+                "payload": {
+                  "borrower_id": "borrower-carol",
+                  "credit_score": 620,
+                  "requested_amount_cents": 800000
+                },
+                "proposal_id": "decision-subprime-borrower-carol-step0"
+              },
+              {
+                "action_key": "decline",
+                "actor_id": "officer-subprime",
+                "payload": {
+                  "borrower_id": "borrower-dave",
+                  "credit_score": 550,
+                  "requested_amount_cents": 1200000
+                },
+                "proposal_id": "decision-subprime-borrower-dave-step0"
+              },
+              {
+                "action_key": "request_info",
+                "actor_id": "officer-subprime",
+                "payload": {
+                  "borrower_id": "borrower-grace",
+                  "credit_score": 600,
+                  "requested_amount_cents": 1500000
+                },
+                "proposal_id": "decision-subprime-borrower-grace-step0"
+              }
+            ]
+          }
+        ],
+        "proposals": [
+          {
+            "action_key": "escalate",
+            "actor_id": "officer-prime",
+            "payload": {
+              "case_id": "case-prior-001",
+              "reason": "carry_over_review"
+            },
+            "proposal_id": "escalate-prior-001"
+          },
+          {
+            "action_key": "approve",
+            "actor_id": "officer-prime",
+            "payload": {
+              "borrower_id": "borrower-alice",
+              "credit_score": 780,
+              "requested_amount_cents": 3000000
+            },
+            "proposal_id": "decision-prime-borrower-alice-step0"
+          },
+          {
+            "action_key": "decline",
+            "actor_id": "officer-prime",
+            "payload": {
+              "borrower_id": "borrower-bob",
+              "credit_score": 700,
+              "requested_amount_cents": 4000000
+            },
+            "proposal_id": "decision-prime-borrower-bob-step0"
+          },
+          {
+            "action_key": "request_info",
+            "actor_id": "officer-prime",
+            "payload": {
+              "borrower_id": "borrower-frank",
+              "credit_score": 750,
+              "requested_amount_cents": 6000000
+            },
+            "proposal_id": "decision-prime-borrower-frank-step0"
+          },
+          {
+            "action_key": "approve",
+            "actor_id": "officer-subprime",
+            "payload": {
+              "borrower_id": "borrower-carol",
+              "credit_score": 620,
+              "requested_amount_cents": 800000
+            },
+            "proposal_id": "decision-subprime-borrower-carol-step0"
+          },
+          {
+            "action_key": "decline",
+            "actor_id": "officer-subprime",
+            "payload": {
+              "borrower_id": "borrower-dave",
+              "credit_score": 550,
+              "requested_amount_cents": 1200000
+            },
+            "proposal_id": "decision-subprime-borrower-dave-step0"
+          },
+          {
+            "action_key": "request_info",
+            "actor_id": "officer-subprime",
+            "payload": {
+              "borrower_id": "borrower-grace",
+              "credit_score": 600,
+              "requested_amount_cents": 1500000
+            },
+            "proposal_id": "decision-subprime-borrower-grace-step0"
+          }
+        ],
+        "state": {
+          "participants": [
+            {
+              "participant_id": "borrower-alice"
+            },
+            {
+              "participant_id": "borrower-bob"
+            },
+            {
+              "participant_id": "borrower-frank"
+            },
+            {
+              "participant_id": "borrower-carol"
+            },
+            {
+              "participant_id": "borrower-dave"
+            },
+            {
+              "participant_id": "borrower-grace"
+            }
+          ],
+          "pending_actions": [
+            {
+              "action_key": "escalate",
+              "actor_id": "officer-prime",
+              "payload": {
+                "case_id": "case-prior-001",
+                "reason": "carry_over_review"
+              },
+              "proposal_id": "escalate-prior-001"
+            }
+          ],
+          "seed": 7,
+          "segments": [
+            {
+              "participant_ids": [
+                "borrower-alice",
+                "borrower-bob",
+                "borrower-frank"
+              ],
+              "segment_id": "tier-prime"
+            },
+            {
+              "participant_ids": [
+                "borrower-carol",
+                "borrower-dave",
+                "borrower-grace"
+              ],
+              "segment_id": "tier-subprime"
+            }
+          ],
+          "snapshot_ref": {
+            "snapshot_id": "33333333-3333-3333-3333-333333333333",
+            "storage_key": "snapshots/bronze/credit-underwriting-initial.json",
+            "tier": "bronze"
+          },
+          "step_index": 0
+        }
+      },
+      {
+        "decisions": [
+          {
+            "agent_id": "officer-prime",
+            "proposals": []
+          },
+          {
+            "agent_id": "officer-subprime",
+            "proposals": []
+          }
+        ],
+        "proposals": [
+          {
+            "action_key": "escalate",
+            "actor_id": "officer-prime",
+            "payload": {
+              "case_id": "case-borrower-frank",
+              "reason": "borderline_request_info"
+            },
+            "proposal_id": "escalate-borrower-frank-step1"
+          },
+          {
+            "action_key": "escalate",
+            "actor_id": "officer-subprime",
+            "payload": {
+              "case_id": "case-borrower-grace",
+              "reason": "borderline_request_info"
+            },
+            "proposal_id": "escalate-borrower-grace-step1"
+          }
+        ],
+        "state": {
+          "participants": [
+            {
+              "participant_id": "borrower-alice"
+            },
+            {
+              "participant_id": "borrower-bob"
+            },
+            {
+              "participant_id": "borrower-frank"
+            },
+            {
+              "participant_id": "borrower-carol"
+            },
+            {
+              "participant_id": "borrower-dave"
+            },
+            {
+              "participant_id": "borrower-grace"
+            }
+          ],
+          "pending_actions": [
+            {
+              "action_key": "escalate",
+              "actor_id": "officer-prime",
+              "payload": {
+                "case_id": "case-borrower-frank",
+                "reason": "borderline_request_info"
+              },
+              "proposal_id": "escalate-borrower-frank-step1"
+            },
+            {
+              "action_key": "escalate",
+              "actor_id": "officer-subprime",
+              "payload": {
+                "case_id": "case-borrower-grace",
+                "reason": "borderline_request_info"
+              },
+              "proposal_id": "escalate-borrower-grace-step1"
+            }
+          ],
+          "seed": 7,
+          "segments": [
+            {
+              "participant_ids": [],
+              "segment_id": "tier-prime"
+            },
+            {
+              "participant_ids": [],
+              "segment_id": "tier-subprime"
+            }
+          ],
+          "snapshot_ref": {
+            "snapshot_id": "33333333-3333-3333-3333-333333333333",
+            "storage_key": "snapshots/bronze/credit-underwriting-initial.json",
+            "tier": "bronze"
+          },
+          "step_index": 1
+        }
+      },
+      {
+        "decisions": [
+          {
+            "agent_id": "officer-prime",
+            "proposals": []
+          },
+          {
+            "agent_id": "officer-subprime",
+            "proposals": []
+          }
+        ],
+        "proposals": [],
+        "state": {
+          "participants": [
+            {
+              "participant_id": "borrower-alice"
+            },
+            {
+              "participant_id": "borrower-bob"
+            },
+            {
+              "participant_id": "borrower-frank"
+            },
+            {
+              "participant_id": "borrower-carol"
+            },
+            {
+              "participant_id": "borrower-dave"
+            },
+            {
+              "participant_id": "borrower-grace"
+            }
+          ],
+          "pending_actions": [],
+          "seed": 7,
+          "segments": [
+            {
+              "participant_ids": [],
+              "segment_id": "tier-prime"
+            },
+            {
+              "participant_ids": [],
+              "segment_id": "tier-subprime"
+            }
+          ],
+          "snapshot_ref": {
+            "snapshot_id": "33333333-3333-3333-3333-333333333333",
+            "storage_key": "snapshots/bronze/credit-underwriting-initial.json",
+            "tier": "bronze"
+          },
+          "step_index": 2
+        }
+      }
+    ]
+  },
+  "scenario_key": "credit-underwriting-baseline",
+  "seed": 7,
+  "summary": {
+    "gates": [
+      {
+        "details": {
+          "decision_steps": 2,
+          "selected_evidence": 2
+        },
+        "gate_id": "selected_proposal_coverage",
+        "reason": "selected_proposal evidence covers every decision step",
+        "status": "pass"
+      },
+      {
+        "details": {
+          "terminal_pending_actions": 0
+        },
+        "gate_id": "terminal_pending_drained",
+        "reason": "terminal state has no pending actions",
+        "status": "pass"
+      }
+    ],
+    "metrics": [
+      {
+        "details": {},
+        "metric_id": "decision_step_count",
+        "value": 2
+      },
+      {
+        "details": {},
+        "metric_id": "selected_proposal_evidence_count",
+        "value": 2
+      },
+      {
+        "details": {},
+        "metric_id": "terminal_pending_action_count",
+        "value": 0
+      }
+    ],
+    "overall_status": "pass"
+  }
+}

--- a/docs/examples/outputs/queue_scheduling_report.json
+++ b/docs/examples/outputs/queue_scheduling_report.json
@@ -1,0 +1,476 @@
+{
+  "claims": [],
+  "evidence": [
+    {
+      "agent_id": "worker-flex",
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "evidence_id": "41227ad2-59a5-5a5f-a813-712ca4a4d227",
+      "evidence_key": "selected_proposal",
+      "payload": {
+        "action_key": "enqueue",
+        "actor_id": "worker-flex",
+        "payload": {
+          "job": {
+            "job_id": "job-hot",
+            "latency_ms": 35,
+            "priority": 9,
+            "queue_id": "expedite"
+          },
+          "slot_id": "slot-expedite"
+        },
+        "proposal_id": "proposal-enqueue"
+      },
+      "step_index": 0
+    },
+    {
+      "agent_id": "worker-fast",
+      "created_at": "2026-01-01T00:00:01+00:00",
+      "evidence_id": "10f54f31-23ab-55da-b53d-9468092564d5",
+      "evidence_key": "selected_proposal",
+      "payload": {
+        "action_key": "heartbeat",
+        "actor_id": "worker-fast",
+        "payload": {
+          "queue_id": "expedite",
+          "step_index": 1
+        },
+        "proposal_id": "heartbeat-expedite-step1"
+      },
+      "step_index": 1
+    },
+    {
+      "agent_id": "worker-fast",
+      "created_at": "2026-01-01T00:00:02+00:00",
+      "evidence_id": "4e809c98-e9a5-53b1-9dfd-0007edef9506",
+      "evidence_key": "selected_proposal",
+      "payload": {
+        "action_key": "heartbeat",
+        "actor_id": "worker-fast",
+        "payload": {
+          "queue_id": "expedite",
+          "step_index": 2
+        },
+        "proposal_id": "heartbeat-expedite-step2"
+      },
+      "step_index": 2
+    }
+  ],
+  "run": {
+    "final_state": {
+      "participants": [
+        {
+          "participant_id": "worker-fast"
+        },
+        {
+          "participant_id": "worker-flex"
+        }
+      ],
+      "pending_actions": [],
+      "seed": 11,
+      "segments": [
+        {
+          "participant_ids": [
+            "worker-fast"
+          ],
+          "segment_id": "slot-expedite"
+        },
+        {
+          "participant_ids": [
+            "worker-flex"
+          ],
+          "segment_id": "slot-standard"
+        }
+      ],
+      "snapshot_ref": {
+        "snapshot_id": "22222222-2222-2222-2222-222222222222",
+        "storage_key": "snapshots/bronze/queue-scheduling-initial.json",
+        "tier": "bronze"
+      },
+      "step_index": 3
+    },
+    "scenario_key": "latency-baseline",
+    "seed": 11,
+    "steps": [
+      {
+        "decisions": [
+          {
+            "agent_id": "worker-fast",
+            "proposals": [
+              {
+                "action_key": "heartbeat",
+                "actor_id": "worker-fast",
+                "payload": {
+                  "queue_id": "expedite",
+                  "step_index": 0
+                },
+                "proposal_id": "heartbeat-expedite-step0"
+              }
+            ]
+          },
+          {
+            "agent_id": "worker-flex",
+            "proposals": [
+              {
+                "action_key": "heartbeat",
+                "actor_id": "worker-flex",
+                "payload": {
+                  "queue_id": "standard",
+                  "step_index": 0
+                },
+                "proposal_id": "heartbeat-standard-step0"
+              }
+            ]
+          }
+        ],
+        "proposals": [
+          {
+            "action_key": "enqueue",
+            "actor_id": "worker-flex",
+            "payload": {
+              "job": {
+                "job_id": "job-hot",
+                "latency_ms": 35,
+                "priority": 9,
+                "queue_id": "expedite"
+              },
+              "slot_id": "slot-expedite"
+            },
+            "proposal_id": "proposal-enqueue"
+          },
+          {
+            "action_key": "promote",
+            "actor_id": "worker-fast",
+            "payload": {
+              "from_slot_id": "slot-standard",
+              "job": {
+                "job_id": "job-aging",
+                "latency_ms": 140,
+                "priority": 6,
+                "queue_id": "standard"
+              },
+              "to_slot_id": "slot-expedite"
+            },
+            "proposal_id": "proposal-promote"
+          },
+          {
+            "action_key": "drop",
+            "actor_id": "worker-fast",
+            "payload": {
+              "job": {
+                "job_id": "job-stale",
+                "latency_ms": 420,
+                "priority": 1,
+                "queue_id": "standard"
+              },
+              "reason": "latency_budget_exceeded"
+            },
+            "proposal_id": "proposal-drop"
+          },
+          {
+            "action_key": "heartbeat",
+            "actor_id": "worker-fast",
+            "payload": {
+              "queue_id": "expedite",
+              "step_index": 0
+            },
+            "proposal_id": "heartbeat-expedite-step0"
+          },
+          {
+            "action_key": "heartbeat",
+            "actor_id": "worker-flex",
+            "payload": {
+              "queue_id": "standard",
+              "step_index": 0
+            },
+            "proposal_id": "heartbeat-standard-step0"
+          }
+        ],
+        "state": {
+          "participants": [
+            {
+              "participant_id": "worker-fast"
+            },
+            {
+              "participant_id": "worker-flex"
+            }
+          ],
+          "pending_actions": [
+            {
+              "action_key": "enqueue",
+              "actor_id": "worker-flex",
+              "payload": {
+                "job": {
+                  "job_id": "job-hot",
+                  "latency_ms": 35,
+                  "priority": 9,
+                  "queue_id": "expedite"
+                },
+                "slot_id": "slot-expedite"
+              },
+              "proposal_id": "proposal-enqueue"
+            },
+            {
+              "action_key": "promote",
+              "actor_id": "worker-fast",
+              "payload": {
+                "from_slot_id": "slot-standard",
+                "job": {
+                  "job_id": "job-aging",
+                  "latency_ms": 140,
+                  "priority": 6,
+                  "queue_id": "standard"
+                },
+                "to_slot_id": "slot-expedite"
+              },
+              "proposal_id": "proposal-promote"
+            },
+            {
+              "action_key": "drop",
+              "actor_id": "worker-fast",
+              "payload": {
+                "job": {
+                  "job_id": "job-stale",
+                  "latency_ms": 420,
+                  "priority": 1,
+                  "queue_id": "standard"
+                },
+                "reason": "latency_budget_exceeded"
+              },
+              "proposal_id": "proposal-drop"
+            }
+          ],
+          "seed": 11,
+          "segments": [
+            {
+              "participant_ids": [
+                "worker-fast"
+              ],
+              "segment_id": "slot-expedite"
+            },
+            {
+              "participant_ids": [
+                "worker-flex"
+              ],
+              "segment_id": "slot-standard"
+            }
+          ],
+          "snapshot_ref": {
+            "snapshot_id": "22222222-2222-2222-2222-222222222222",
+            "storage_key": "snapshots/bronze/queue-scheduling-initial.json",
+            "tier": "bronze"
+          },
+          "step_index": 0
+        }
+      },
+      {
+        "decisions": [
+          {
+            "agent_id": "worker-fast",
+            "proposals": [
+              {
+                "action_key": "heartbeat",
+                "actor_id": "worker-fast",
+                "payload": {
+                  "queue_id": "expedite",
+                  "step_index": 1
+                },
+                "proposal_id": "heartbeat-expedite-step1"
+              }
+            ]
+          },
+          {
+            "agent_id": "worker-flex",
+            "proposals": [
+              {
+                "action_key": "heartbeat",
+                "actor_id": "worker-flex",
+                "payload": {
+                  "queue_id": "standard",
+                  "step_index": 1
+                },
+                "proposal_id": "heartbeat-standard-step1"
+              }
+            ]
+          }
+        ],
+        "proposals": [
+          {
+            "action_key": "heartbeat",
+            "actor_id": "worker-fast",
+            "payload": {
+              "queue_id": "expedite",
+              "step_index": 1
+            },
+            "proposal_id": "heartbeat-expedite-step1"
+          },
+          {
+            "action_key": "heartbeat",
+            "actor_id": "worker-flex",
+            "payload": {
+              "queue_id": "standard",
+              "step_index": 1
+            },
+            "proposal_id": "heartbeat-standard-step1"
+          }
+        ],
+        "state": {
+          "participants": [
+            {
+              "participant_id": "worker-fast"
+            },
+            {
+              "participant_id": "worker-flex"
+            }
+          ],
+          "pending_actions": [],
+          "seed": 11,
+          "segments": [
+            {
+              "participant_ids": [
+                "worker-fast"
+              ],
+              "segment_id": "slot-expedite"
+            },
+            {
+              "participant_ids": [
+                "worker-flex"
+              ],
+              "segment_id": "slot-standard"
+            }
+          ],
+          "snapshot_ref": {
+            "snapshot_id": "22222222-2222-2222-2222-222222222222",
+            "storage_key": "snapshots/bronze/queue-scheduling-initial.json",
+            "tier": "bronze"
+          },
+          "step_index": 1
+        }
+      },
+      {
+        "decisions": [
+          {
+            "agent_id": "worker-fast",
+            "proposals": [
+              {
+                "action_key": "heartbeat",
+                "actor_id": "worker-fast",
+                "payload": {
+                  "queue_id": "expedite",
+                  "step_index": 2
+                },
+                "proposal_id": "heartbeat-expedite-step2"
+              }
+            ]
+          },
+          {
+            "agent_id": "worker-flex",
+            "proposals": [
+              {
+                "action_key": "heartbeat",
+                "actor_id": "worker-flex",
+                "payload": {
+                  "queue_id": "standard",
+                  "step_index": 2
+                },
+                "proposal_id": "heartbeat-standard-step2"
+              }
+            ]
+          }
+        ],
+        "proposals": [
+          {
+            "action_key": "heartbeat",
+            "actor_id": "worker-fast",
+            "payload": {
+              "queue_id": "expedite",
+              "step_index": 2
+            },
+            "proposal_id": "heartbeat-expedite-step2"
+          },
+          {
+            "action_key": "heartbeat",
+            "actor_id": "worker-flex",
+            "payload": {
+              "queue_id": "standard",
+              "step_index": 2
+            },
+            "proposal_id": "heartbeat-standard-step2"
+          }
+        ],
+        "state": {
+          "participants": [
+            {
+              "participant_id": "worker-fast"
+            },
+            {
+              "participant_id": "worker-flex"
+            }
+          ],
+          "pending_actions": [],
+          "seed": 11,
+          "segments": [
+            {
+              "participant_ids": [
+                "worker-fast"
+              ],
+              "segment_id": "slot-expedite"
+            },
+            {
+              "participant_ids": [
+                "worker-flex"
+              ],
+              "segment_id": "slot-standard"
+            }
+          ],
+          "snapshot_ref": {
+            "snapshot_id": "22222222-2222-2222-2222-222222222222",
+            "storage_key": "snapshots/bronze/queue-scheduling-initial.json",
+            "tier": "bronze"
+          },
+          "step_index": 2
+        }
+      }
+    ]
+  },
+  "scenario_key": "latency-baseline",
+  "seed": 11,
+  "summary": {
+    "gates": [
+      {
+        "details": {
+          "decision_steps": 3,
+          "selected_evidence": 3
+        },
+        "gate_id": "selected_proposal_coverage",
+        "reason": "selected_proposal evidence covers every decision step",
+        "status": "pass"
+      },
+      {
+        "details": {
+          "terminal_pending_actions": 0
+        },
+        "gate_id": "terminal_pending_drained",
+        "reason": "terminal state has no pending actions",
+        "status": "pass"
+      }
+    ],
+    "metrics": [
+      {
+        "details": {},
+        "metric_id": "decision_step_count",
+        "value": 3
+      },
+      {
+        "details": {},
+        "metric_id": "selected_proposal_evidence_count",
+        "value": 3
+      },
+      {
+        "details": {},
+        "metric_id": "terminal_pending_action_count",
+        "value": 0
+      }
+    ],
+    "overall_status": "pass"
+  }
+}

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -76,7 +76,9 @@ EXPECTED_EXAMPLES_INDEX_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
         (
             "python -m examples.credit_underwriting",
             "[`examples/credit_underwriting`](../../examples/credit_underwriting)",
+            "`examples.credit_underwriting.audit:build_audit_log`",
             "`selected_proposal`",
+            "non-empty proposal step",
         ),
     ),
     (
@@ -84,7 +86,9 @@ EXPECTED_EXAMPLES_INDEX_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
         (
             "python -m examples.queue_scheduling",
             "[`examples/queue_scheduling`](../../examples/queue_scheduling)",
+            "`examples.queue_scheduling.audit:build_audit_log`",
             "`selected_proposal`",
+            "non-empty proposal step",
         ),
     ),
     (

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -17,6 +17,7 @@ README_PATHS: tuple[Path, ...] = (
 
 MAX_DOCS_INDEX_LINES = 10
 MAX_SUBSECTION_README_LINES = 10
+MAX_EXAMPLES_INDEX_LINES = 80
 
 EXPECTED_DOCS_INDEX_SNIPPETS = (
     "# Docs",
@@ -35,7 +36,7 @@ EXPECTED_SUBSECTION_TITLES: tuple[tuple[Path, str], ...] = (
     (ADR_README_PATH, "# ADRs"),
 )
 
-EXPECTED_SUBSECTION_README_SNIPPETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+EXPECTED_PLACEHOLDER_SUBSECTION_README_SNIPPETS: tuple[tuple[Path, tuple[str, ...]], ...] = (
     (
         DEVELOPMENT_README_PATH,
         (
@@ -53,14 +54,6 @@ EXPECTED_SUBSECTION_README_SNIPPETS: tuple[tuple[Path, tuple[str, ...]], ...] = 
         ),
     ),
     (
-        EXAMPLES_README_PATH,
-        (
-            "# Examples",
-            "Placeholder only. Worked examples and tutorials live here.",
-            "Detailed expansion is deferred to #044.",
-        ),
-    ),
-    (
         ADR_README_PATH,
         (
             "# ADRs",
@@ -69,6 +62,51 @@ EXPECTED_SUBSECTION_README_SNIPPETS: tuple[tuple[Path, tuple[str, ...]], ...] = 
             "Directory index details are deferred to #044.",
         ),
     ),
+)
+
+EXPECTED_EXAMPLES_INDEX_SECTIONS: tuple[str, ...] = (
+    "## Credit underwriting",
+    "## Queue scheduling",
+    "## Frozen outputs",
+)
+
+EXPECTED_EXAMPLES_INDEX_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "## Credit underwriting",
+        (
+            "python -m examples.credit_underwriting",
+            "[`examples/credit_underwriting`](../../examples/credit_underwriting)",
+            "`selected_proposal`",
+        ),
+    ),
+    (
+        "## Queue scheduling",
+        (
+            "python -m examples.queue_scheduling",
+            "[`examples/queue_scheduling`](../../examples/queue_scheduling)",
+            "`selected_proposal`",
+        ),
+    ),
+    (
+        "## Frozen outputs",
+        (
+            "[`outputs/credit_underwriting_report.json`](outputs/credit_underwriting_report.json)",
+            "[`outputs/queue_scheduling_report.json`](outputs/queue_scheduling_report.json)",
+            "byte-identical",
+        ),
+    ),
+)
+
+FORBIDDEN_EXAMPLES_INDEX_SNIPPETS: tuple[str, ...] = (
+    "coming soon",
+    "future example",
+    "will support",
+    "production-ready",
+    "enterprise",
+    "v1.0",
+    "milestone sequencing",
+    "Placeholder only.",
+    "Detailed expansion is deferred to #044.",
 )
 
 EXPECTED_ADR_TEMPLATE_POINTER = "Start from [0000-template.md](0000-template.md) when writing a new ADR."
@@ -105,13 +143,40 @@ def test_subsection_readmes_declare_expected_titles() -> None:
         assert expected_title in _read_text(path)
 
 
-def test_subsection_readmes_remain_placeholders_and_stay_short() -> None:
-    for path, expected_snippets in EXPECTED_SUBSECTION_README_SNIPPETS:
+def test_placeholder_subsection_readmes_remain_short() -> None:
+    for path, expected_snippets in EXPECTED_PLACEHOLDER_SUBSECTION_README_SNIPPETS:
         readme_text = _read_text(path)
 
         _assert_snippets_in_order(readme_text, expected_snippets)
 
         assert len(readme_text.splitlines()) < MAX_SUBSECTION_README_LINES
+
+
+def test_examples_index_surfaces_runnable_examples_and_frozen_outputs() -> None:
+    text = _read_text(EXAMPLES_README_PATH)
+
+    _assert_snippets_in_order(text, EXPECTED_EXAMPLES_INDEX_SECTIONS)
+
+    for index, (heading, snippets) in enumerate(EXPECTED_EXAMPLES_INDEX_SNIPPETS):
+        section_start = text.index(heading)
+        if index + 1 < len(EXPECTED_EXAMPLES_INDEX_SNIPPETS):
+            next_heading = EXPECTED_EXAMPLES_INDEX_SNIPPETS[index + 1][0]
+            section_end = text.index(next_heading, section_start + len(heading))
+        else:
+            section_end = len(text)
+
+        section_text = text[section_start:section_end]
+        for snippet in snippets:
+            assert snippet in section_text, f"{heading}: {snippet}"
+
+
+def test_examples_index_avoids_forbidden_scope_and_stays_within_line_budget() -> None:
+    text = _read_text(EXAMPLES_README_PATH)
+
+    for snippet in FORBIDDEN_EXAMPLES_INDEX_SNIPPETS:
+        assert snippet not in text, snippet
+
+    assert len(text.splitlines()) <= MAX_EXAMPLES_INDEX_LINES
 
 
 def test_adr_readme_references_template() -> None:

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -79,6 +79,7 @@ EXPECTED_EXAMPLES_INDEX_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "`examples.credit_underwriting.audit:build_audit_log`",
             "`selected_proposal`",
             "non-empty proposal step",
+            "does not re-export `build_audit_log`",
         ),
     ),
     (
@@ -89,6 +90,7 @@ EXPECTED_EXAMPLES_INDEX_SNIPPETS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "`examples.queue_scheduling.audit:build_audit_log`",
             "`selected_proposal`",
             "non-empty proposal step",
+            "does not re-export `build_audit_log`",
         ),
     ),
     (
@@ -111,6 +113,8 @@ FORBIDDEN_EXAMPLES_INDEX_SNIPPETS: tuple[str, ...] = (
     "milestone sequencing",
     "Placeholder only.",
     "Detailed expansion is deferred to #044.",
+    "keeps its package `__init__` empty",
+    "package `__init__` empty",
 )
 
 EXPECTED_ADR_TEMPLATE_POINTER = "Start from [0000-template.md](0000-template.md) when writing a new ADR."

--- a/tests/meta/test_examples_outputs.py
+++ b/tests/meta/test_examples_outputs.py
@@ -29,9 +29,9 @@ def test_credit_underwriting_frozen_output_matches_fresh_render() -> None:
     committed_text, committed_obj = _load_committed(CREDIT_OUTPUT_PATH)
     fresh_text = render_json_report(build_credit_audit(CREDIT_SEED))
 
-    assert (
-        committed_text == fresh_text
-    ), "credit_underwriting_report.json is stale; regenerate from build_audit_log(Seed(7))"
+    assert committed_text == fresh_text, (
+        "credit_underwriting_report.json is stale; regenerate from build_audit_log(Seed(7))"
+    )
     assert committed_obj["scenario_key"] == "credit-underwriting-baseline"
     assert committed_obj["seed"] == int(CREDIT_SEED)
 
@@ -40,9 +40,9 @@ def test_queue_scheduling_frozen_output_matches_fresh_render() -> None:
     committed_text, committed_obj = _load_committed(QUEUE_OUTPUT_PATH)
     fresh_text = render_json_report(build_queue_audit(QUEUE_SEED))
 
-    assert (
-        committed_text == fresh_text
-    ), "queue_scheduling_report.json is stale; regenerate from build_audit_log(Seed(11))"
+    assert committed_text == fresh_text, (
+        "queue_scheduling_report.json is stale; regenerate from build_audit_log(Seed(11))"
+    )
     assert committed_obj["scenario_key"] == "latency-baseline"
     assert committed_obj["seed"] == int(QUEUE_SEED)
 

--- a/tests/meta/test_examples_outputs.py
+++ b/tests/meta/test_examples_outputs.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from abdp.core.types import Seed
+from abdp.reporting import render_json_report
+from examples.credit_underwriting.audit import build_audit_log as build_credit_audit
+from examples.queue_scheduling.audit import build_audit_log as build_queue_audit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OUTPUTS_DIR = REPO_ROOT / "docs" / "examples" / "outputs"
+CREDIT_OUTPUT_PATH = OUTPUTS_DIR / "credit_underwriting_report.json"
+QUEUE_OUTPUT_PATH = OUTPUTS_DIR / "queue_scheduling_report.json"
+
+CREDIT_SEED = Seed(7)
+QUEUE_SEED = Seed(11)
+SELECTED_PROPOSAL_KEY = "selected_proposal"
+
+
+def _load_committed(path: Path) -> tuple[str, dict[str, Any]]:
+    assert path.is_file(), path
+    text = path.read_text(encoding="utf-8")
+    return text, json.loads(text)
+
+
+def test_credit_underwriting_frozen_output_matches_fresh_render() -> None:
+    committed_text, committed_obj = _load_committed(CREDIT_OUTPUT_PATH)
+    fresh_text = render_json_report(build_credit_audit(CREDIT_SEED))
+
+    assert (
+        committed_text == fresh_text
+    ), "credit_underwriting_report.json is stale; regenerate from build_audit_log(Seed(7))"
+    assert committed_obj["scenario_key"] == "credit-underwriting-baseline"
+    assert committed_obj["seed"] == int(CREDIT_SEED)
+
+
+def test_queue_scheduling_frozen_output_matches_fresh_render() -> None:
+    committed_text, committed_obj = _load_committed(QUEUE_OUTPUT_PATH)
+    fresh_text = render_json_report(build_queue_audit(QUEUE_SEED))
+
+    assert (
+        committed_text == fresh_text
+    ), "queue_scheduling_report.json is stale; regenerate from build_audit_log(Seed(11))"
+    assert committed_obj["scenario_key"] == "latency-baseline"
+    assert committed_obj["seed"] == int(QUEUE_SEED)
+
+
+def test_each_frozen_output_contains_selected_proposal_evidence() -> None:
+    for path in (CREDIT_OUTPUT_PATH, QUEUE_OUTPUT_PATH):
+        _text, obj = _load_committed(path)
+        evidence = obj["evidence"]
+        assert isinstance(evidence, list) and evidence, f"{path.name}: evidence must be non-empty"
+        keys = {record["evidence_key"] for record in evidence}
+        assert SELECTED_PROPOSAL_KEY in keys, f"{path.name}: missing reserved evidence_key {SELECTED_PROPOSAL_KEY!r}"


### PR DESCRIPTION
## Summary
- Replaces `docs/examples/README.md` placeholder with a real index covering both shipped worked examples (Credit underwriting, Queue scheduling) with how to run them, what they demonstrate, source links, and the reserved `selected_proposal` evidence key contract.
- Adds a Frozen outputs section + checked-in deterministic JSON snapshots under `docs/examples/outputs/` (credit_underwriting_report.json @ Seed(7), queue_scheduling_report.json @ Seed(11)).
- Adds `tests/meta/test_examples_outputs.py` enforcing exact byte-equality between each committed snapshot and a fresh `render_json_report(build_audit_log(seed))`, plus presence of the reserved `selected_proposal` evidence key per the v0.3 audit-flow contract.
- Restructures `tests/meta/test_docs_scaffold.py`: drops the old EXAMPLES_README placeholder snippet from the placeholder set, adds a dedicated examples-index check with `MAX_EXAMPLES_INDEX_LINES = 80`, ordered H2 sections, per-section literal snippets, and a forbidden-snippet fence.

## TDD trail
- RED `e9bd1c1` — `test(docs): pin examples index and frozen outputs to v0.3 audit flow (#166)`.
- GREEN — `docs(examples): surface runnable examples and frozen outputs (#166)`.

## Verification
- `ruff format .` — clean.
- `ruff check .` — All checks passed.
- `mypy --strict src tests` — no issues, 145 source files.
- `pytest --cov` — **847 passed, 100% line coverage**.
- `docs/examples/README.md` actual length: 53 lines (cap 80).
- Both frozen JSON snapshots verified byte-identical against a fresh render.

## Acceptance criteria (from #166)
- [x] `docs/examples/README.md` is no longer a placeholder; H2 sections Credit underwriting / Queue scheduling / Frozen outputs are in place.
- [x] `tests/meta/test_docs_scaffold.py` updated; EXAMPLES_README expectation moved out of the placeholder set into a dedicated examples-index snippet set with its own line budget.
- [x] `docs/examples/outputs/*.json` checked in and referenced from the index.
- [x] Meta-test asserts frozen outputs exist and contain reserved `selected_proposal` evidence key (plus full byte-equality for drift detection).
- [x] Standard verification gates green; 100% coverage maintained.

Closes #166