### PR TITLE
docs: signpost v0.1 historical docs vs current shipped surface (#167)

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,5 +1,7 @@
 # Product requirements (v0.1)
 
+> **Historical (v0.1 baseline).** See [Roadmap](roadmap.md) for current scope and [README](../README.md) for the current shipped surface.
+
 This document defines the minimum product boundary for v0.1 of ABDP and continues the scope set in [docs/vision.md](vision.md).
 
 ## Primary user and job

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,5 +1,7 @@
 # Project vision
 
+> **Historical (v0.1 baseline).** See [Roadmap](roadmap.md) for current scope and [README](../README.md) for the current shipped surface.
+
 A Python framework for reproducible agent-based decision simulation
 
 ## Problem statement

--- a/tests/meta/test_doc_prd.py
+++ b/tests/meta/test_doc_prd.py
@@ -59,6 +59,11 @@ FORBIDDEN_SNIPPETS: list[str] = [
     "Conventional Commits",
 ]
 
+HISTORICAL_CALLOUT_LINE = (
+    "> **Historical (v0.1 baseline).** See [Roadmap](roadmap.md) for current "
+    "scope and [README](../README.md) for the current shipped surface."
+)
+
 
 def _read_prd_text() -> str:
     return PRD_PATH.read_text(encoding="utf-8")
@@ -118,3 +123,16 @@ def test_prd_stays_within_line_budget() -> None:
     text = _read_prd_text()
 
     assert len(text.splitlines()) <= MAX_LINE_COUNT
+
+
+def test_prd_signposts_v01_baseline_above_first_section() -> None:
+    text = _read_prd_text()
+
+    callout_index = text.find(HISTORICAL_CALLOUT_LINE)
+    assert callout_index >= 0, "Historical (v0.1 baseline) callout missing"
+
+    first_section_index = text.index(REQUIRED_HEADINGS[0])
+    assert callout_index < first_section_index, "Historical callout must appear above the first '##' section heading"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in HISTORICAL_CALLOUT_LINE, snippet

--- a/tests/meta/test_doc_vision.py
+++ b/tests/meta/test_doc_vision.py
@@ -53,6 +53,11 @@ FORBIDDEN_SNIPPETS: tuple[str, ...] = (
     "v1.0",
 )
 
+HISTORICAL_CALLOUT_LINE = (
+    "> **Historical (v0.1 baseline).** See [Roadmap](roadmap.md) for current "
+    "scope and [README](../README.md) for the current shipped surface."
+)
+
 MAX_VISION_LINES = 60
 
 
@@ -103,3 +108,16 @@ def test_vision_avoids_forbidden_scope_and_stays_within_line_budget() -> None:
         assert snippet not in text, snippet
 
     assert len(text.splitlines()) <= MAX_VISION_LINES
+
+
+def test_vision_signposts_v01_baseline_above_problem_statement() -> None:
+    text = _read_vision_text()
+
+    callout_index = text.find(HISTORICAL_CALLOUT_LINE)
+    assert callout_index >= 0, "Historical (v0.1 baseline) callout missing"
+
+    problem_index = text.index("## Problem statement")
+    assert callout_index < problem_index, "Historical callout must appear above the '## Problem statement' heading"
+
+    for snippet in FORBIDDEN_SNIPPETS:
+        assert snippet not in HISTORICAL_CALLOUT_LINE, snippet


### PR DESCRIPTION
Closes #167.

## Summary

abdp now ships v0.3 surfaces (`abdp.agents`, `abdp.scenario`, `abdp.evaluation`, `abdp.evidence`, `abdp.reporting`, `abdp.cli`) but `docs/vision.md` and `docs/prd.md` remain pinned to the v0.1 baseline by meta-tests that explicitly forbid `v0.2`/`v1.0` wording. New readers can mistake either historical doc for current state. This PR adds a single non-invasive callout near the top of each historical doc:

> **Historical (v0.1 baseline).** See [Roadmap](roadmap.md) for current scope and [README](../README.md) for the current shipped surface.

## TDD trail

- **RED** (`eba114c`): added `test_vision_signposts_v01_baseline_above_problem_statement` and `test_prd_signposts_v01_baseline_above_first_section`. Each asserts the exact callout line, its position above the first \`##\` heading, and that the callout itself contains no FORBIDDEN snippets. Confirmed failing (2 failed, 10 passed).
- **GREEN** (`5daa6b0`): inserted the callout in both docs above their first section.

Existing FORBIDDEN_SNIPPETS, REQUIRED_HEADINGS, MAX_*_LINES, and section-anchor assertions are intentionally untouched (additive only, per acceptance criterion).

## Line budgets

| Doc            | Before | After | Cap | Bumped? |
|----------------|-------:|------:|----:|---------|
| docs/vision.md |     29 |    31 |  60 | no      |
| docs/prd.md    |     41 |    43 |  80 | no      |

The 2-line callout fits within existing budgets so no `MAX_*_LINES` bump is needed.

## Verification

\`\`\`
ruff format --check    -> 145 files already formatted
ruff check             -> All checks passed
mypy --strict src tests -> Success: no issues found in 145 source files
pytest --cov           -> 849 passed, coverage 100.00%
                          (was 847 + the 2 new RED tests now passing)
\`\`\`

## Out of scope

- Rewriting any v0.1 doc body (existing meta-tests pin the content).
- Creating a parallel "current state" doc (README + roadmap already serve that role).
- Loosening any forbidden-snippet rule (additive only).