### PR TITLE
feat(inspector): in-process tracing with pluggable TraceStore + SQLite default (#172)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ This index is intentionally minimal. Detailed expansion is deferred to #044.
 - [Models](models/README.md) — Conceptual model documentation for abdp.
 - [Examples](examples/README.md) — Worked examples and tutorials.
 - [ADRs](adr/README.md) — Architecture decision records and template.
-- [CLI](cli.md) — Command-line usage reference for `abdp run` and `abdp report`.
+- [CLI](cli.md) — Command-line usage reference for `abdp run`, `abdp report`, and `abdp inspect`.
+- [Inspector](inspector.md) — In-process tracing layer and `abdp inspect` query CLI.

--- a/docs/adr/0001-two-plane-execution-model.md
+++ b/docs/adr/0001-two-plane-execution-model.md
@@ -1,0 +1,108 @@
+# 0001 - Two-plane execution model for Inspector and ReviewLoopRunner
+
+## Status
+
+Accepted (2026-04-24, issue #172). Companion to issue #173 (ReviewLoopRunner).
+
+## Context
+
+abdp v0.3 ships a single-plane execution model: `ScenarioRunner` advances a
+`SimulationState`, agents emit proposals, the resolver commits them, and the
+canonical evidence/audit pipeline stores the result. There is no
+observability hook and no place to record the *process* by which a step was
+produced — only the committed outcome.
+
+Two upcoming features need a place to record process-level information:
+
+1. **Inspector / Tracing (#172)** — capture per-step decision evaluations,
+   timings, and (in the future) tool calls.
+2. **Self-Correction / ReviewLoopRunner (#173)** — wrap each step in a
+   propose / critique / revise loop, retaining the rejected attempts as
+   reviewable history while still committing only the accepted attempt to
+   the canonical evidence store.
+
+The constraint that frames the design: the canonical plane (`ScenarioRun`,
+`SimulationState`, `EvidenceRecord`, `ClaimRecord`, `AuditLog`) must stay
+byte-identical for the same `(seed, scenario)` whether or not Inspector and
+review are enabled. Existing public types must not change shape.
+
+Three alternatives were considered for how to model rejected review
+attempts:
+
+- **A. Branchable Seed.** Derive a per-attempt sub-seed and treat each
+  attempt as an independent execution branch. Rejected by Oracle: this
+  promotes attempts to a first-class execution dimension and forces the
+  canonical pipeline to learn about branching just to ignore it. Wrong
+  abstraction.
+- **B. `evidence_key#attemptN` namespace.** Store all attempts (including
+  rejected ones) in the canonical evidence store under suffixed keys. Rejected:
+  this pollutes the canonical domain namespace with values that are never
+  read by reporting or evaluation, and breaks the invariant that an
+  evidence key identifies one accepted observation.
+- **C. Tuple `step_index = (n, attempt_no)`.** Overload the logical step
+  counter to carry attempt identity. Rejected: `step_index` is an integer
+  in every public surface; widening it would either break those surfaces
+  or require a parallel "logical step" field that re-introduces the
+  problem.
+
+## Decision
+
+Adopt a **two-plane execution model**.
+
+- **Canonical plane (unchanged).** `ScenarioRun.steps[i]` is the single
+  accepted outcome of step `i`. `SimulationState.step_index: int` keeps its
+  v0.3 meaning. `EvidenceRecord` and `ClaimRecord` only ever record the
+  accepted attempt. No public types change.
+- **Inspector plane (new, in `abdp.inspector`).** A separate, deterministic
+  per-run event stream captured by `TraceRecorder` and persisted by any
+  `TraceStore`. Event identity is derived from `(seed, run_id, seq)`, so
+  two runs of the same scenario produce byte-identical trace IDs.
+- **ReviewLoopRunner uses the Inspector plane** for rejected attempts.
+  Rejected attempts are recorded as `review.attempt` events with their own
+  `seq` and `parent_event_id`, and never enter the canonical evidence
+  store. Only the first accepted attempt commits to the canonical plane.
+
+Concretely this means:
+
+```text
+canonical:  step 0 (accepted) ── step 1 (accepted) ── step 2 (accepted) ─→ AuditLog
+inspector:  step.begin, decision.evaluate, review.attempt(rejected)*, step.end, …
+            ────────────────────────────────────────────────────────────→ TraceStore
+```
+
+The Inspector plane is observational only: feature-gating it on or off
+never changes the canonical bytes.
+
+## Consequences
+
+**Benefits**
+
+- Public surfaces (`ScenarioRun`, `SimulationState`, `EvidenceRecord`,
+  `ClaimRecord`, `AuditLog`) keep their v0.3 shapes; existing tests, docs,
+  and downstream code keep working unchanged.
+- Determinism proof for ReviewLoopRunner reduces to "only the first accepted
+  attempt commits to canonical", which is local to one helper function.
+- Inspector can ship and stabilize independently of ReviewLoopRunner; v0.4
+  delivers a usable tracing surface even if v0.5 slips.
+- Future work (OTLP export, additional event types, alternative stores) can
+  extend the Inspector plane without touching canonical code.
+
+**Trade-offs**
+
+- Two planes means two query surfaces. Operators inspecting a run consult
+  evidence/audit for *what* happened and the Inspector for *how*. The
+  `abdp inspect` CLI exists to make the Inspector plane queryable.
+- `ScenarioRunner` grows an optional `recorder: TraceRecorder | None`
+  field. The default `None` preserves byte-identical behaviour for
+  existing callers.
+- Rejected review attempts are never persisted to evidence; teams that
+  want them in the canonical plane must build a deliberate adapter on
+  top of the Inspector store.
+
+**Follow-up**
+
+- `abdp.review` (issue #173) will introduce `review.attempt` events,
+  `parent_event_id` chaining, and an explicit "accepted" attribute on the
+  committing attempt.
+- A future issue may add an OTLP exporter that translates `TraceEvent`
+  records into OTel spans for external collectors.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,8 +1,9 @@
 # CLI
 
-The `abdp` console script ships two subcommands for running scenarios and
-rendering audit reports from the command line. The CLI surface is a thin,
-deterministic wrapper around the same building blocks shown in the
+The `abdp` console script ships three subcommands for running scenarios,
+rendering audit reports, and inspecting captured traces from the command
+line. The CLI surface is a thin, deterministic wrapper around the same
+building blocks shown in the
 [10-minute modeling quickstart](quickstart.md); it does not introduce new
 domain primitives.
 
@@ -30,6 +31,7 @@ commands as `abdp …` for brevity, but every example is equivalent to
 | --- | --- |
 | `abdp run` | Build an `AuditLog` from a scenario factory and render it to JSON. |
 | `abdp report` | Reload a serialized `AuditLog` and re-render it as JSON or Markdown. |
+| `abdp inspect` | Query a SQLite trace store and emit JSON Lines (see [Inspector](inspector.md)). |
 
 `abdp` with no arguments (or `--help`) prints the parser help and exits `0`.
 
@@ -80,6 +82,8 @@ single-line stderr message.
 | `abdp run` | `2` | Loader could not resolve the spec or the factory did not return an `AuditLog`. |
 | `abdp report` | `0` | Audit log reloaded and re-rendered successfully. |
 | `abdp report` | `2` | Audit log could not be read, parsed, or reconstructed. |
+| `abdp inspect` | `0` | Trace query completed (zero or more events emitted). |
+| `abdp inspect` | `2` | Trace database missing/corrupt, output unwritable, or argparse rejection. |
 
 `WARN` does not change the exit code; it only emits the stderr notice noted
 under [Running a scenario](#running-a-scenario).

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -1,0 +1,153 @@
+# Inspector
+
+The Inspector is abdp's in-process tracing layer. It captures *how* a scenario
+ran — every step boundary and every agent decision — without touching the
+canonical evidence/audit plane that downstream evaluation depends on.
+
+This guide covers the surface introduced in v0.4: `abdp.inspector` for
+in-process recording and `abdp inspect` for offline querying. It is the
+substrate the upcoming Self-Correction / ReviewLoopRunner (v0.5) builds on.
+
+## Two-plane execution model
+
+abdp keeps two independent record planes side by side:
+
+| Plane | What it stores | Public types |
+| --- | --- | --- |
+| **Canonical** | Committed scenario history: `ScenarioRun`, `SimulationState`, `EvidenceRecord`, `ClaimRecord`, `AuditLog`. Used by reporting, evaluation, audit. | `abdp.scenario`, `abdp.evidence`, `abdp.simulation` (unchanged) |
+| **Inspector** | Deterministic per-run trace events: `step.begin`, `decision.evaluate`, `step.end`, and any future review-attempt events. Never feeds back into evidence. | `abdp.inspector` |
+
+The canonical plane is the source of truth for evaluation. The Inspector plane
+is purely observational: enabling or disabling it never changes evidence,
+audit content, or determinism of the canonical pipeline.
+
+For the design rationale and the alternatives that were rejected, see
+[ADR 0001 — Two-plane execution model for Inspector and ReviewLoopRunner](adr/0001-two-plane-execution-model.md).
+
+## TraceEvent
+
+A `TraceEvent` is one entry in the Inspector plane:
+
+```python
+from abdp.inspector import TraceEvent
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `event_id` | `UUID` | Derived from `(seed, run_id, seq)` via a private namespace; only those three influence identity. |
+| `run_id` | `str` | Caller-chosen identifier for one ScenarioRunner invocation. |
+| `seq` | `int` | Monotonic per run (`0, 1, 2, …`), assigned by `TraceRecorder`. |
+| `step_index` | `int` | The canonical scenario step the event belongs to. |
+| `event_type` | `str` | `step.begin`, `step.end`, `decision.evaluate`, … (extension namespace open). |
+| `attributes` | `Mapping[str, str \| int \| float \| bool]` | OTel-style attribute bag; primitive values only. |
+| `timestamp_ns` | `int` | Equal to `seq`; deterministic, never wall-clock derived. |
+| `parent_event_id` | `UUID \| None` | Span parenting hook for nested events (e.g. review attempts). |
+
+`make_trace_event(...)` is the factory used by `TraceRecorder`; identity is
+fixed by the `(seed, run_id, seq)` triple, so two runs of the same scenario
+produce byte-identical event IDs.
+
+## TraceStore
+
+`TraceStore` is a `Protocol` with two ready-made implementations:
+
+| Implementation | Use it for |
+| --- | --- |
+| `MemoryTraceStore` | Tests and ephemeral in-process inspection. |
+| `SQLiteTraceStore(path)` | Persisted traces; default backend for the CLI. |
+
+Both expose:
+
+- `append(event) -> None`
+- `query(*, run_id, step_index=None, event_type=None) -> Iterator[TraceEvent]`
+- `event(event_id) -> TraceEvent | None`
+- `runs() -> Iterator[str]`
+- `close() -> None` (idempotent)
+
+Filter keys outside of `step_index` / `event_type` are rejected by
+`validate_query_filters` to keep the Protocol contract narrow and forward
+compatible.
+
+## Recording from a scenario
+
+`TraceRecorder` owns the `seq` counter for one run and writes into any
+`TraceStore`. Inject it into `ScenarioRunner` and the runner emits
+`step.begin`, `decision.evaluate` (per agent), and `step.end` events for
+every step automatically:
+
+```python
+from abdp.core import Seed
+from abdp.inspector import SQLiteTraceStore, TraceRecorder
+from abdp.scenario import ScenarioRunner
+
+store = SQLiteTraceStore("traces.db")
+recorder = TraceRecorder(store=store, seed=Seed(7), run_id="nightly-2026-04-24")
+runner = ScenarioRunner(
+    agents=(my_agent,),
+    resolver=my_resolver,
+    max_steps=10,
+    recorder=recorder,
+)
+runner.run(spec)
+store.close()
+```
+
+`recorder` defaults to `None`; the runner is fully backward compatible —
+omit it and no Inspector code path runs.
+
+## Querying with `abdp inspect`
+
+```bash
+abdp inspect <run_id> --db PATH [--step N] [--event-type TYPE] [--output FILE]
+```
+
+The subcommand opens the SQLite trace database, queries the matching events
+for the given `run_id`, and writes one JSON object per line (JSON Lines)
+ordered by `seq`:
+
+```json
+{"attributes": {"scenario_key": "demo"}, "event_id": "…", "event_type": "step.begin", "parent_event_id": null, "run_id": "nightly-2026-04-24", "seq": 0, "step_index": 0, "timestamp_ns": 0}
+{"attributes": {"agent_id": "agent-a", "proposals": 1}, "event_id": "…", "event_type": "decision.evaluate", "parent_event_id": null, "run_id": "nightly-2026-04-24", "seq": 1, "step_index": 0, "timestamp_ns": 1}
+…
+```
+
+- `--step N` keeps only events whose `step_index` equals `N` (must be
+  non-negative).
+- `--event-type TYPE` keeps only events whose `event_type` equals `TYPE`.
+- `--output FILE` writes the JSON Lines to `FILE` instead of stdout. The
+  bytes written to a file are byte-identical to what stdout would produce
+  for the same query.
+- An unknown `run_id` is not an error: the command exits `0` with no
+  output.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Query completed (zero or more events emitted). |
+| `2` | Database missing, corrupt, or output path unwritable; argparse rejection (missing required flag, malformed `--step`). |
+
+## Determinism
+
+Two runs with the same `(seed, scenario_key, run_id)` produce byte-identical
+trace event tuples. Specifically:
+
+- `event_id` is a deterministic UUID over `(seed, run_id, seq)`.
+- `seq` is assigned monotonically by `TraceRecorder`.
+- `timestamp_ns` equals `seq` — the Inspector never reads a wall clock.
+- `attributes` use only primitive Python types and serialize with sorted
+  keys when persisted, so SQLite round-trips preserve byte-equality.
+
+This is the property that lets the upcoming ReviewLoopRunner record
+critique attempts on the Inspector plane without ever destabilizing the
+canonical evidence stream.
+
+## Non-goals
+
+- HTTP / RPC tracing (no HTTP surface in abdp v0.3).
+- OTLP export (forward-compatible attribute names only; no OTel SDK
+  dependency).
+- Distributed / cross-process spans.
+- Web UI or dashboard.
+- Persisting full `SimulationState` in trace events; use `SnapshotRef`
+  pointers instead.

--- a/src/abdp/cli/__init__.py
+++ b/src/abdp/cli/__init__.py
@@ -9,6 +9,7 @@ surface; subsequent issues extend ``__all__`` against the frozen surface
 test in ``tests/cli/test_cli_public_surface.py``.
 """
 
+import abdp.cli.inspect as _inspect  # noqa: F401  -- force-import so submodule pop sticks via sys.modules.
 import abdp.cli.report as _report  # noqa: F401  -- force-import so submodule pop sticks via sys.modules.
 import abdp.cli.run as _run  # noqa: F401  -- force-import so submodule pop sticks via sys.modules.
 from abdp.cli.loader import LoaderError, load_audit_log_factory
@@ -16,7 +17,9 @@ from abdp.cli.loader import LoaderError, load_audit_log_factory
 globals().pop("loader", None)
 globals().pop("run", None)
 globals().pop("report", None)
+globals().pop("inspect", None)
 del _run
 del _report
+del _inspect
 
 __all__: tuple[str, ...] = ("LoaderError", "load_audit_log_factory")

--- a/src/abdp/cli/__main__.py
+++ b/src/abdp/cli/__main__.py
@@ -1,14 +1,15 @@
 """Argparse entrypoint for the ``abdp`` CLI.
 
-Wires the ``run`` and ``report`` subcommands to :mod:`abdp.cli.run` and
-:mod:`abdp.cli.report`. ``main`` is the console-script entry point
-referenced by ``[project.scripts] abdp`` in ``pyproject.toml``.
+Wires the ``run``, ``report``, and ``inspect`` subcommands to their
+respective modules. ``main`` is the console-script entry point referenced
+by ``[project.scripts] abdp`` in ``pyproject.toml``.
 """
 
 import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+from abdp.cli.inspect import inspect_command
 from abdp.cli.report import REPORT_FORMATS, report_command
 from abdp.cli.run import parse_seed_arg, run_command
 
@@ -20,7 +21,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="abdp",
         description="Agent-based decision pipeline CLI.",
     )
-    subparsers = parser.add_subparsers(dest="command", metavar="{run,report}")
+    subparsers = parser.add_subparsers(dest="command", metavar="{run,report,inspect}")
     run_parser = subparsers.add_parser("run", help="Run a scenario and emit an AuditLog.")
     run_parser.add_argument("spec", help="module.path:callable spec.")
     run_parser.add_argument(
@@ -52,6 +53,37 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="FILE",
         help="Write the report to FILE instead of stdout.",
     )
+    inspect_parser = subparsers.add_parser("inspect", help="Query a SQLite trace store and emit JSON Lines.")
+    inspect_parser.add_argument("run_id", help="Run identifier to query.")
+    inspect_parser.add_argument(
+        "--db",
+        required=True,
+        type=Path,
+        metavar="PATH",
+        help="Path to a SQLite trace database.",
+    )
+    inspect_parser.add_argument(
+        "--step",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Only emit events whose step_index equals N.",
+    )
+    inspect_parser.add_argument(
+        "--event-type",
+        dest="event_type",
+        type=str,
+        default=None,
+        metavar="TYPE",
+        help="Only emit events whose event_type equals TYPE.",
+    )
+    inspect_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Write JSON Lines to FILE instead of stdout.",
+    )
     return parser
 
 
@@ -63,6 +95,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.command == "run":
         return run_command(args)
+    if args.command == "inspect":
+        return inspect_command(args)
     return report_command(args)
 
 

--- a/src/abdp/cli/inspect.py
+++ b/src/abdp/cli/inspect.py
@@ -55,10 +55,13 @@ def inspect(
             filters["step_index"] = step
         if event_type is not None:
             filters["event_type"] = event_type
-        events = list(store.query(run_id=run_id, **filters))
+        try:
+            events = list(store.query(run_id=run_id, **filters))
+        except (sqlite3.DatabaseError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            raise InspectError(f"malformed trace database: {exc}") from exc
         rendered = _render_jsonl(events)
         _write_output(rendered, output)
-    except OSError as exc:
+    except (OSError, InspectError) as exc:
         print(str(exc).splitlines()[0] if str(exc) else type(exc).__name__, file=sys.stderr)
         return _EXIT_ERROR
     finally:

--- a/src/abdp/cli/inspect.py
+++ b/src/abdp/cli/inspect.py
@@ -1,0 +1,114 @@
+"""``abdp inspect`` subcommand: query a SQLite trace store and emit JSON Lines.
+
+Each emitted line is a JSON object with the full :class:`abdp.inspector.TraceEvent`
+shape (UUIDs as strings, ``parent_event_id`` nullable). Events are ordered by
+``seq``. Optional ``--step`` and ``--event-type`` filters are translated into
+``TraceStore.query`` keyword arguments. Loader and query errors return ``2`` with
+a single-line stderr message; an unknown ``run_id`` is not an error and exits
+``0`` with no output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, cast
+
+from abdp.inspector import SQLiteTraceStore, TraceEvent
+
+__all__ = ["InspectError", "inspect", "inspect_command"]
+
+_EXIT_OK = 0
+_EXIT_ERROR = 2
+
+
+class InspectError(Exception):
+    """Raised when a trace store cannot be opened or queried."""
+
+
+def inspect(
+    run_id: str,
+    *,
+    db: Path,
+    step: int | None = None,
+    event_type: str | None = None,
+    output: Path | None = None,
+) -> int:
+    if step is not None and step < 0:
+        print("--step must be a non-negative integer", file=sys.stderr)
+        return _EXIT_ERROR
+    if not db.exists():
+        print(f"trace database not found: {db}", file=sys.stderr)
+        return _EXIT_ERROR
+    try:
+        store = _open_store(db)
+    except InspectError as exc:
+        print(str(exc).splitlines()[0], file=sys.stderr)
+        return _EXIT_ERROR
+    try:
+        filters: dict[str, Any] = {}
+        if step is not None:
+            filters["step_index"] = step
+        if event_type is not None:
+            filters["event_type"] = event_type
+        events = list(store.query(run_id=run_id, **filters))
+        rendered = _render_jsonl(events)
+        _write_output(rendered, output)
+    except OSError as exc:
+        print(str(exc).splitlines()[0] if str(exc) else type(exc).__name__, file=sys.stderr)
+        return _EXIT_ERROR
+    finally:
+        store.close()
+    return _EXIT_OK
+
+
+def _open_store(db: Path) -> SQLiteTraceStore:
+    try:
+        return SQLiteTraceStore(db)
+    except sqlite3.DatabaseError as exc:
+        raise InspectError(f"invalid trace database: {exc}") from exc
+
+
+def inspect_command(args: argparse.Namespace) -> int:
+    return inspect(
+        cast(str, args.run_id),
+        db=cast(Path, args.db),
+        step=cast("int | None", args.step),
+        event_type=cast("str | None", args.event_type),
+        output=cast("Path | None", args.output),
+    )
+
+
+def _render_jsonl(events: Iterable[TraceEvent]) -> str:
+    lines: list[str] = []
+    for ev in events:
+        payload: dict[str, Any] = {
+            "event_id": str(ev.event_id),
+            "run_id": ev.run_id,
+            "seq": ev.seq,
+            "step_index": ev.step_index,
+            "event_type": ev.event_type,
+            "attributes": dict(ev.attributes),
+            "timestamp_ns": ev.timestamp_ns,
+            "parent_event_id": str(ev.parent_event_id) if ev.parent_event_id is not None else None,
+        }
+        lines.append(json.dumps(payload, sort_keys=True))
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def _write_output(content: str, output: Path | None) -> None:
+    encoded = content.encode("utf-8")
+    if output is None:
+        buffer = getattr(sys.stdout, "buffer", None)
+        if buffer is None:
+            sys.stdout.write(content)
+        else:
+            buffer.write(encoded)
+    else:
+        output.write_bytes(encoded)

--- a/src/abdp/inspector/__init__.py
+++ b/src/abdp/inspector/__init__.py
@@ -1,0 +1,5 @@
+"""Inspector / Tracing subsystem public surface."""
+
+from abdp.inspector.event import TraceAttributeValue, TraceEvent, make_trace_event
+
+__all__ = ["TraceAttributeValue", "TraceEvent", "make_trace_event"]

--- a/src/abdp/inspector/__init__.py
+++ b/src/abdp/inspector/__init__.py
@@ -1,6 +1,7 @@
 """Inspector / Tracing subsystem public surface."""
 
 from abdp.inspector.event import TraceAttributeValue, TraceEvent, make_trace_event
+from abdp.inspector.recorder import TraceRecorder
 from abdp.inspector.sqlite_store import SQLiteTraceStore
 from abdp.inspector.store import MemoryTraceStore, TraceStore
 
@@ -9,6 +10,7 @@ __all__ = [
     "SQLiteTraceStore",
     "TraceAttributeValue",
     "TraceEvent",
+    "TraceRecorder",
     "TraceStore",
     "make_trace_event",
 ]

--- a/src/abdp/inspector/__init__.py
+++ b/src/abdp/inspector/__init__.py
@@ -1,5 +1,14 @@
 """Inspector / Tracing subsystem public surface."""
 
 from abdp.inspector.event import TraceAttributeValue, TraceEvent, make_trace_event
+from abdp.inspector.sqlite_store import SQLiteTraceStore
+from abdp.inspector.store import MemoryTraceStore, TraceStore
 
-__all__ = ["TraceAttributeValue", "TraceEvent", "make_trace_event"]
+__all__ = [
+    "MemoryTraceStore",
+    "SQLiteTraceStore",
+    "TraceAttributeValue",
+    "TraceEvent",
+    "TraceStore",
+    "make_trace_event",
+]

--- a/src/abdp/inspector/event.py
+++ b/src/abdp/inspector/event.py
@@ -52,6 +52,10 @@ class TraceEvent:
             raise ValueError("step_index must be non-negative")
         if self.timestamp_ns < 0:
             raise ValueError("timestamp_ns must be non-negative")
+        if not isinstance(self.attributes, Mapping):
+            raise TypeError(
+                f"attributes must be a Mapping[str, TraceAttributeValue], got {type(self.attributes).__name__}"
+            )
         frozen: dict[str, TraceAttributeValue] = {}
         for key, value in self.attributes.items():
             if not isinstance(key, str):

--- a/src/abdp/inspector/event.py
+++ b/src/abdp/inspector/event.py
@@ -1,0 +1,90 @@
+"""``TraceEvent`` frozen dataclass and ``make_trace_event`` factory exposed by ``abdp.inspector``.
+
+A ``TraceEvent`` is one entry in the inspector/tracing plane. Identity is
+derived deterministically from ``(seed, run_id, seq)`` via a private
+namespace UUID so the same event captured under the same seed always
+shares an ``event_id``. ``step_index``, ``event_type``, ``attributes``,
+``timestamp_ns``, and ``parent_event_id`` are payload metadata and do
+not influence identity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+from abdp.core.ids import deterministic_uuid
+from abdp.core.types import Seed
+
+__all__ = ["TraceAttributeValue", "TraceEvent", "make_trace_event"]
+
+_TRACE_NAMESPACE: Final = UUID("3a8c7e6d-1f24-4e7b-9c08-7c8a2f5b6d10")
+_NAME_SEPARATOR: Final = "\0"
+
+TraceAttributeValue = str | int | float | bool
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """One entry in the inspector/tracing plane."""
+
+    event_id: UUID
+    run_id: str
+    seq: int
+    step_index: int
+    event_type: str
+    attributes: Mapping[str, TraceAttributeValue]
+    timestamp_ns: int
+    parent_event_id: UUID | None
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise ValueError("run_id must be a non-empty string")
+        if not self.event_type:
+            raise ValueError("event_type must be a non-empty string")
+        if self.seq < 0:
+            raise ValueError("seq must be non-negative")
+        if self.step_index < 0:
+            raise ValueError("step_index must be non-negative")
+        if self.timestamp_ns < 0:
+            raise ValueError("timestamp_ns must be non-negative")
+        for key, value in self.attributes.items():
+            if not isinstance(key, str):
+                raise TypeError(f"attribute key must be str, got {type(key).__name__}")
+            if not isinstance(value, str | int | float | bool):
+                raise TypeError(
+                    f"attribute value for {key!r} must be str|int|float|bool, " f"got {type(value).__name__}"
+                )
+
+
+def make_trace_event(
+    *,
+    seed: Seed,
+    run_id: str,
+    seq: int,
+    step_index: int,
+    event_type: str,
+    attributes: Mapping[str, TraceAttributeValue],
+    timestamp_ns: int,
+    parent_event_id: UUID | None,
+) -> TraceEvent:
+    """Build a :class:`TraceEvent` with a deterministically derived ``event_id``.
+
+    ``event_id`` is derived from ``seed``, the private trace namespace,
+    and ``f"{run_id}\\0{seq}"``; all other arguments are payload metadata
+    and do not influence identity.
+    """
+    name = f"{run_id}{_NAME_SEPARATOR}{seq}"
+    event_id = deterministic_uuid(seed, _TRACE_NAMESPACE, name)
+    return TraceEvent(
+        event_id=event_id,
+        run_id=run_id,
+        seq=seq,
+        step_index=step_index,
+        event_type=event_type,
+        attributes=attributes,
+        timestamp_ns=timestamp_ns,
+        parent_event_id=parent_event_id,
+    )

--- a/src/abdp/inspector/event.py
+++ b/src/abdp/inspector/event.py
@@ -61,9 +61,7 @@ class TraceEvent:
             if not isinstance(key, str):
                 raise TypeError(f"attribute key must be str, got {type(key).__name__}")
             if not isinstance(value, str | int | float | bool):
-                raise TypeError(
-                    f"attribute value for {key!r} must be str|int|float|bool, " f"got {type(value).__name__}"
-                )
+                raise TypeError(f"attribute value for {key!r} must be str|int|float|bool, got {type(value).__name__}")
             if isinstance(value, float) and not math.isfinite(value):
                 raise ValueError(f"attribute value for {key!r} must be a finite float, got {value!r}")
             frozen[key] = value

--- a/src/abdp/inspector/event.py
+++ b/src/abdp/inspector/event.py
@@ -10,8 +10,10 @@ not influence identity.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Final
 from uuid import UUID
 
@@ -50,6 +52,7 @@ class TraceEvent:
             raise ValueError("step_index must be non-negative")
         if self.timestamp_ns < 0:
             raise ValueError("timestamp_ns must be non-negative")
+        frozen: dict[str, TraceAttributeValue] = {}
         for key, value in self.attributes.items():
             if not isinstance(key, str):
                 raise TypeError(f"attribute key must be str, got {type(key).__name__}")
@@ -57,6 +60,10 @@ class TraceEvent:
                 raise TypeError(
                     f"attribute value for {key!r} must be str|int|float|bool, " f"got {type(value).__name__}"
                 )
+            if isinstance(value, float) and not math.isfinite(value):
+                raise ValueError(f"attribute value for {key!r} must be a finite float, got {value!r}")
+            frozen[key] = value
+        object.__setattr__(self, "attributes", MappingProxyType(frozen))
 
 
 def make_trace_event(

--- a/src/abdp/inspector/recorder.py
+++ b/src/abdp/inspector/recorder.py
@@ -34,7 +34,6 @@ class TraceRecorder:
         parent_event_id: UUID | None = None,
     ) -> TraceEvent:
         seq = self._next_seq
-        self._next_seq += 1
         ev = make_trace_event(
             seed=self.seed,
             run_id=self.run_id,
@@ -46,4 +45,5 @@ class TraceRecorder:
             parent_event_id=parent_event_id,
         )
         self.store.append(ev)
+        self._next_seq = seq + 1
         return ev

--- a/src/abdp/inspector/recorder.py
+++ b/src/abdp/inspector/recorder.py
@@ -1,0 +1,49 @@
+"""``TraceRecorder`` helper that writes :class:`TraceEvent`s into a :class:`TraceStore`.
+
+The recorder owns the monotonic ``seq`` counter and timestamp derivation
+for one run, so callers (notably :class:`abdp.scenario.ScenarioRunner`)
+only need to describe *what* happened.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from abdp.core.types import Seed
+from abdp.inspector.event import TraceAttributeValue, TraceEvent, make_trace_event
+from abdp.inspector.store import TraceStore
+
+__all__ = ["TraceRecorder"]
+
+
+@dataclass
+class TraceRecorder:
+    store: TraceStore
+    seed: Seed
+    run_id: str
+    _next_seq: int = field(default=0, init=False, repr=False)
+
+    def record(
+        self,
+        *,
+        event_type: str,
+        step_index: int,
+        attributes: Mapping[str, TraceAttributeValue],
+        parent_event_id: UUID | None = None,
+    ) -> TraceEvent:
+        seq = self._next_seq
+        self._next_seq += 1
+        ev = make_trace_event(
+            seed=self.seed,
+            run_id=self.run_id,
+            seq=seq,
+            step_index=step_index,
+            event_type=event_type,
+            attributes=dict(attributes),
+            timestamp_ns=seq,
+            parent_event_id=parent_event_id,
+        )
+        self.store.append(ev)
+        return ev

--- a/src/abdp/inspector/sqlite_store.py
+++ b/src/abdp/inspector/sqlite_store.py
@@ -65,7 +65,9 @@ class SQLiteTraceStore:
                 ),
             )
         except sqlite3.IntegrityError as exc:
-            raise ValueError(f"duplicate event_id: {event.event_id}") from exc
+            raise ValueError(
+                f"duplicate event_id or (run_id, seq) collision for event_id={event.event_id}: {exc}"
+            ) from exc
         conn.commit()
 
     def query(self, *, run_id: str, **filters: Any) -> Iterator[TraceEvent]:

--- a/src/abdp/inspector/sqlite_store.py
+++ b/src/abdp/inspector/sqlite_store.py
@@ -1,0 +1,118 @@
+"""SQLite-backed :class:`TraceStore` implementation.
+
+Persists :class:`TraceEvent` records into a single ``trace_events`` table
+keyed by ``event_id``. Attribute mappings and ``parent_event_id`` are
+serialized as JSON / nullable TEXT columns. Suitable for local
+development inspection; production deployments should use a future
+OTLP/Postgres adapter (out of scope for this issue).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from abdp.inspector.event import TraceEvent
+from abdp.inspector.store import validate_query_filters
+
+__all__ = ["SQLiteTraceStore"]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS trace_events (
+    event_id        TEXT PRIMARY KEY,
+    run_id          TEXT NOT NULL,
+    seq             INTEGER NOT NULL,
+    step_index      INTEGER NOT NULL,
+    event_type      TEXT NOT NULL,
+    attributes_json TEXT NOT NULL,
+    timestamp_ns    INTEGER NOT NULL,
+    parent_event_id TEXT,
+    UNIQUE(run_id, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_trace_run ON trace_events(run_id, seq);
+CREATE INDEX IF NOT EXISTS idx_trace_step ON trace_events(run_id, step_index);
+CREATE INDEX IF NOT EXISTS idx_trace_type ON trace_events(run_id, event_type);
+"""
+
+
+class SQLiteTraceStore:
+    def __init__(self, path: str | Path) -> None:
+        self._path = str(path)
+        self._conn: sqlite3.Connection | None = sqlite3.connect(self._path)
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def append(self, event: TraceEvent) -> None:
+        conn = self._require_open()
+        if not isinstance(event, TraceEvent):
+            raise TypeError(f"expected TraceEvent, got {type(event).__name__}")
+        try:
+            conn.execute(
+                "INSERT INTO trace_events VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    str(event.event_id),
+                    event.run_id,
+                    event.seq,
+                    event.step_index,
+                    event.event_type,
+                    json.dumps(dict(event.attributes), sort_keys=True),
+                    event.timestamp_ns,
+                    str(event.parent_event_id) if event.parent_event_id else None,
+                ),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"duplicate event_id: {event.event_id}") from exc
+        conn.commit()
+
+    def query(self, *, run_id: str, **filters: Any) -> Iterator[TraceEvent]:
+        validate_query_filters(filters)
+        conn = self._require_open()
+        sql = "SELECT * FROM trace_events WHERE run_id = ?"
+        params: list[Any] = [run_id]
+        if (step_index := filters.get("step_index")) is not None:
+            sql += " AND step_index = ?"
+            params.append(step_index)
+        if (event_type := filters.get("event_type")) is not None:
+            sql += " AND event_type = ?"
+            params.append(event_type)
+        sql += " ORDER BY seq"
+        for row in conn.execute(sql, params):
+            yield _row_to_event(row)
+
+    def event(self, event_id: UUID) -> TraceEvent | None:
+        conn = self._require_open()
+        row = conn.execute("SELECT * FROM trace_events WHERE event_id = ?", (str(event_id),)).fetchone()
+        return _row_to_event(row) if row is not None else None
+
+    def runs(self) -> Iterator[str]:
+        conn = self._require_open()
+        for (run_id,) in conn.execute("SELECT DISTINCT run_id FROM trace_events"):
+            yield run_id
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def _require_open(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RuntimeError("SQLiteTraceStore is closed")
+        return self._conn
+
+
+def _row_to_event(row: tuple[Any, ...]) -> TraceEvent:
+    (event_id, run_id, seq, step_index, event_type, attrs_json, ts_ns, parent_id) = row
+    return TraceEvent(
+        event_id=UUID(event_id),
+        run_id=run_id,
+        seq=seq,
+        step_index=step_index,
+        event_type=event_type,
+        attributes=json.loads(attrs_json),
+        timestamp_ns=ts_ns,
+        parent_event_id=UUID(parent_id) if parent_id else None,
+    )

--- a/src/abdp/inspector/store.py
+++ b/src/abdp/inspector/store.py
@@ -42,13 +42,18 @@ class TraceStore(Protocol):
 class MemoryTraceStore:
     def __init__(self) -> None:
         self._events: dict[UUID, TraceEvent] = {}
+        self._seen_run_seq: set[tuple[str, int]] = set()
 
     def append(self, event: TraceEvent) -> None:
         if not isinstance(event, TraceEvent):
             raise TypeError(f"expected TraceEvent, got {type(event).__name__}")
         if event.event_id in self._events:
             raise ValueError(f"duplicate event_id: {event.event_id}")
+        key = (event.run_id, event.seq)
+        if key in self._seen_run_seq:
+            raise ValueError(f"duplicate (run_id, seq): {key!r}")
         self._events[event.event_id] = event
+        self._seen_run_seq.add(key)
 
     def query(self, *, run_id: str, **filters: Any) -> Iterator[TraceEvent]:
         validate_query_filters(filters)

--- a/src/abdp/inspector/store.py
+++ b/src/abdp/inspector/store.py
@@ -1,0 +1,77 @@
+"""``TraceStore`` protocol and ``MemoryTraceStore`` reference implementation.
+
+Mirrors the ``EvidenceStore`` pattern: a minimal pluggable persistence
+contract for inspector :class:`TraceEvent` records, with an in-memory
+reference implementation backed by insertion-ordered dicts. SQLite-backed
+persistence lives in :mod:`abdp.inspector.sqlite_store`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any, Protocol, runtime_checkable
+from uuid import UUID
+
+from abdp.inspector.event import TraceEvent
+
+__all__ = ["MemoryTraceStore", "TraceStore", "validate_query_filters"]
+
+_QUERY_FILTERS = frozenset({"step_index", "event_type"})
+
+
+def validate_query_filters(filters: dict[str, Any]) -> None:
+    unknown = set(filters) - _QUERY_FILTERS
+    if unknown:
+        joined = ", ".join(sorted(unknown))
+        raise TypeError(f"unknown query filter(s): {joined}")
+
+
+@runtime_checkable
+class TraceStore(Protocol):
+    def append(self, event: TraceEvent) -> None: ...  # pragma: no cover
+
+    def query(self, *, run_id: str, **filters: Any) -> Iterable[TraceEvent]: ...  # pragma: no cover
+
+    def event(self, event_id: UUID) -> TraceEvent | None: ...  # pragma: no cover
+
+    def runs(self) -> Iterable[str]: ...  # pragma: no cover
+
+    def close(self) -> None: ...  # pragma: no cover
+
+
+class MemoryTraceStore:
+    def __init__(self) -> None:
+        self._events: dict[UUID, TraceEvent] = {}
+
+    def append(self, event: TraceEvent) -> None:
+        if not isinstance(event, TraceEvent):
+            raise TypeError(f"expected TraceEvent, got {type(event).__name__}")
+        if event.event_id in self._events:
+            raise ValueError(f"duplicate event_id: {event.event_id}")
+        self._events[event.event_id] = event
+
+    def query(self, *, run_id: str, **filters: Any) -> Iterator[TraceEvent]:
+        validate_query_filters(filters)
+        step_index = filters.get("step_index")
+        event_type = filters.get("event_type")
+        for ev in self._events.values():
+            if ev.run_id != run_id:
+                continue
+            if step_index is not None and ev.step_index != step_index:
+                continue
+            if event_type is not None and ev.event_type != event_type:
+                continue
+            yield ev
+
+    def event(self, event_id: UUID) -> TraceEvent | None:
+        return self._events.get(event_id)
+
+    def runs(self) -> Iterator[str]:
+        seen: set[str] = set()
+        for ev in self._events.values():
+            if ev.run_id not in seen:
+                seen.add(ev.run_id)
+                yield ev.run_id
+
+    def close(self) -> None:
+        return None

--- a/src/abdp/scenario/runner.py
+++ b/src/abdp/scenario/runner.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from abdp.agents import Agent, AgentContext, AgentDecision
+from abdp.inspector.recorder import TraceRecorder
 from abdp.scenario.resolver import ActionResolver
 from abdp.scenario.run import ScenarioRun
 from abdp.scenario.step import ScenarioStep
@@ -26,11 +27,17 @@ class ScenarioRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
     carried by the current state, and delegating progression to an
     ``ActionResolver``. Iteration is bounded by ``max_steps`` and terminates
     early when no proposals remain to resolve.
+
+    When ``recorder`` is provided, ``run`` emits ``step.begin``,
+    ``decision.evaluate``, and ``step.end`` :class:`abdp.inspector.TraceEvent`
+    records into the inspector plane. Recording is metadata only and does
+    not influence canonical scenario output.
     """
 
     agents: tuple[Agent[S, P, A], ...]
     resolver: ActionResolver[S, P, A]
     max_steps: int
+    recorder: TraceRecorder | None = None
 
     def run(self, spec: ScenarioSpec[S, P, A]) -> ScenarioRun[S, P, A]:
         """Execute the scenario and return its full ``ScenarioRun`` trace."""
@@ -38,22 +45,25 @@ class ScenarioRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
         steps: list[ScenarioStep[S, P, A]] = []
 
         while state.step_index < self.max_steps:
-            decisions: tuple[AgentDecision[A], ...] = tuple(
-                agent.decide(
-                    AgentContext(
-                        scenario_key=spec.scenario_key,
-                        agent_id=agent.agent_id,
-                        step_index=state.step_index,
-                        seed=state.seed,
-                        state=state,
-                    )
-                )
-                for agent in self.agents
+            self._emit(
+                event_type="step.begin",
+                step_index=state.step_index,
+                attributes={"scenario_key": spec.scenario_key},
             )
+            decisions: tuple[AgentDecision[A], ...] = tuple(self._decide(agent, spec, state) for agent in self.agents)
             emissions: tuple[A, ...] = tuple(proposal for decision in decisions for proposal in decision.proposals)
             merged: tuple[A, ...] = state.pending_actions + emissions
 
             steps.append(ScenarioStep(state=state, decisions=decisions, proposals=merged))
+
+            self._emit(
+                event_type="step.end",
+                step_index=state.step_index,
+                attributes={
+                    "proposals": len(merged),
+                    "decisions": len(decisions),
+                },
+            )
 
             if not merged:
                 break
@@ -67,4 +77,44 @@ class ScenarioRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
             seed=spec.seed,
             steps=tuple(steps),
             final_state=state,
+        )
+
+    def _decide(
+        self,
+        agent: Agent[S, P, A],
+        spec: ScenarioSpec[S, P, A],
+        state: SimulationState[S, P, A],
+    ) -> AgentDecision[A]:
+        decision = agent.decide(
+            AgentContext(
+                scenario_key=spec.scenario_key,
+                agent_id=agent.agent_id,
+                step_index=state.step_index,
+                seed=state.seed,
+                state=state,
+            )
+        )
+        self._emit(
+            event_type="decision.evaluate",
+            step_index=state.step_index,
+            attributes={
+                "agent_id": agent.agent_id,
+                "proposals": len(decision.proposals),
+            },
+        )
+        return decision
+
+    def _emit(
+        self,
+        *,
+        event_type: str,
+        step_index: int,
+        attributes: dict[str, str | int | float | bool],
+    ) -> None:
+        if self.recorder is None:
+            return
+        self.recorder.record(
+            event_type=event_type,
+            step_index=step_index,
+            attributes=attributes,
         )

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -16,7 +16,10 @@ from abdp.inspector import (
 )
 
 
-def _populate(db_path: Path, *, seed: Seed = Seed(42), run_id: str = "run-x") -> None:
+_DEFAULT_SEED = Seed(42)
+
+
+def _populate(db_path: Path, *, seed: Seed = _DEFAULT_SEED, run_id: str = "run-x") -> None:
     store = SQLiteTraceStore(db_path)
     recorder = TraceRecorder(store=store, seed=seed, run_id=run_id)
     recorder.record(event_type="step.begin", step_index=0, attributes={"scenario_key": "demo"})

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -1,0 +1,299 @@
+"""Tests for ``abdp.cli.inspect`` subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from abdp.cli.__main__ import main
+from abdp.core import Seed
+from abdp.inspector import (
+    SQLiteTraceStore,
+    TraceRecorder,
+)
+
+
+def _populate(db_path: Path, *, seed: Seed = Seed(42), run_id: str = "run-x") -> None:
+    store = SQLiteTraceStore(db_path)
+    recorder = TraceRecorder(store=store, seed=seed, run_id=run_id)
+    recorder.record(event_type="step.begin", step_index=0, attributes={"scenario_key": "demo"})
+    recorder.record(
+        event_type="decision.evaluate",
+        step_index=0,
+        attributes={"agent_id": "agent-a", "proposals": 1},
+    )
+    recorder.record(event_type="step.end", step_index=0, attributes={"proposals": 1, "decisions": 1})
+    recorder.record(event_type="step.begin", step_index=1, attributes={"scenario_key": "demo"})
+    recorder.record(event_type="step.end", step_index=1, attributes={"proposals": 0, "decisions": 0})
+    store.close()
+
+
+def _decode_lines(blob: bytes) -> list[dict[str, object]]:
+    text = blob.decode("utf-8")
+    if not text:
+        return []
+    return [json.loads(line) for line in text.splitlines()]
+
+
+def test_inspect_emits_jsonl_for_all_events_in_run(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+
+    exit_code = main(["inspect", "run-x", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    rows = _decode_lines(captured.out)
+    assert [r["event_type"] for r in rows] == [
+        "step.begin",
+        "decision.evaluate",
+        "step.end",
+        "step.begin",
+        "step.end",
+    ]
+    assert [r["seq"] for r in rows] == [0, 1, 2, 3, 4]
+    for row in rows:
+        UUID(str(row["event_id"]))
+        assert row["run_id"] == "run-x"
+        assert row["parent_event_id"] is None
+
+
+def test_inspect_filters_by_step(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+
+    exit_code = main(["inspect", "run-x", "--db", str(db), "--step", "1"])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    rows = _decode_lines(captured.out)
+    assert [r["seq"] for r in rows] == [3, 4]
+    assert all(r["step_index"] == 1 for r in rows)
+
+
+def test_inspect_filters_by_event_type(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+
+    exit_code = main(["inspect", "run-x", "--db", str(db), "--event-type", "step.begin"])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    rows = _decode_lines(captured.out)
+    assert [r["seq"] for r in rows] == [0, 3]
+    assert all(r["event_type"] == "step.begin" for r in rows)
+
+
+def test_inspect_combined_filters(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+
+    exit_code = main(["inspect", "run-x", "--db", str(db), "--step", "0", "--event-type", "decision.evaluate"])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    rows = _decode_lines(captured.out)
+    assert len(rows) == 1
+    assert rows[0]["seq"] == 1
+    assert rows[0]["attributes"] == {"agent_id": "agent-a", "proposals": 1}
+
+
+def test_inspect_unknown_run_id_emits_no_lines_and_exits_zero(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+
+    exit_code = main(["inspect", "missing-run", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == b""
+
+
+def test_inspect_writes_to_output_file_byte_equal(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+    out_file = tmp_path / "trace.jsonl"
+
+    exit_code = main(["inspect", "run-x", "--db", str(db), "--output", str(out_file)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == b""
+
+    file_rows = _decode_lines(out_file.read_bytes())
+    assert [r["seq"] for r in file_rows] == [0, 1, 2, 3, 4]
+
+
+def test_inspect_output_matches_stdout_byte_for_byte(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+    out_file = tmp_path / "trace.jsonl"
+
+    file_exit = main(["inspect", "run-x", "--db", str(db), "--output", str(out_file)])
+    capsysbinary.readouterr()
+    stdout_exit = main(["inspect", "run-x", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+
+    assert file_exit == 0
+    assert stdout_exit == 0
+    assert out_file.read_bytes() == captured.out
+
+
+def test_inspect_missing_db_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    missing = tmp_path / "absent.db"
+    exit_code = main(["inspect", "run-x", "--db", str(missing)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+    assert captured.err.count(b"\n") == 1
+
+
+def test_inspect_corrupt_db_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    bad = tmp_path / "corrupt.db"
+    bad.write_bytes(b"not a sqlite database at all")
+    exit_code = main(["inspect", "run-x", "--db", str(bad)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_inspect_invalid_step_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["inspect", "run-x", "--db", "x.db", "--step", "not-int"])
+    assert exc_info.value.code == 2
+
+
+def test_inspect_negative_step_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+    exit_code = main(["inspect", "run-x", "--db", str(db), "--step", "-1"])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_inspect_missing_run_id_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["inspect", "--db", "x.db"])
+    assert exc_info.value.code == 2
+
+
+def test_inspect_missing_db_flag_exits_argparse_two() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["inspect", "run-x"])
+    assert exc_info.value.code == 2
+
+
+def test_inspect_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["inspect", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_inspect_output_to_missing_parent_directory_exits_two(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    _populate(db)
+    bad_output = tmp_path / "no" / "such" / "dir" / "out.jsonl"
+
+    exit_code = main(["inspect", "run-x", "--db", str(db), "--output", str(bad_output)])
+    captured = capsysbinary.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+    assert not bad_output.exists()
+
+
+def test_inspect_falls_back_to_text_write_when_stdout_has_no_buffer(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import io
+    import sys as _sys
+
+    db = tmp_path / "trace.db"
+    _populate(db)
+
+    text_only = io.StringIO()
+    monkeypatch.setattr(_sys, "stdout", text_only)
+    exit_code = main(["inspect", "run-x", "--db", str(db)])
+    capsys.readouterr()
+
+    assert exit_code == 0
+    assert text_only.getvalue() != ""
+    rows = _decode_lines(text_only.getvalue().encode("utf-8"))
+    assert [r["seq"] for r in rows] == [0, 1, 2, 3, 4]
+
+
+def test_inspect_jsonl_payload_round_trips_attributes_with_uuid_parent(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    store = SQLiteTraceStore(db)
+    recorder = TraceRecorder(store=store, seed=Seed(7), run_id="run-y")
+    parent = recorder.record(event_type="step.begin", step_index=0, attributes={"scenario_key": "demo"})
+    recorder.record(
+        event_type="decision.evaluate",
+        step_index=0,
+        attributes={"agent_id": "a1", "proposals": 2, "ratio": 0.5, "ok": True},
+        parent_event_id=parent.event_id,
+    )
+    store.close()
+
+    exit_code = main(["inspect", "run-y", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+    rows = _decode_lines(captured.out)
+
+    assert exit_code == 0
+    assert rows[0]["parent_event_id"] is None
+    assert rows[1]["parent_event_id"] == str(parent.event_id)
+    assert rows[1]["attributes"] == {
+        "agent_id": "a1",
+        "proposals": 2,
+        "ratio": 0.5,
+        "ok": True,
+    }

--- a/tests/inspector/conftest.py
+++ b/tests/inspector/conftest.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+
+from abdp.agents import AgentContext, AgentDecision
+from abdp.core import JsonValue, Seed
+from abdp.simulation import (
+    ParticipantState,
+    SegmentState,
+    SimulationState,
+)
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+_State = SimulationState[SegmentState, ParticipantState, _Action]
+
+
+@dataclass(frozen=True, slots=True)
+class _Spec:
+    scenario_key: str
+    seed: Seed
+    initial: _State
+
+    def build_initial_state(self) -> _State:
+        return self.initial
+
+
+@dataclass
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+@dataclass
+class _RecordingAgent:
+    agent_id: str
+    proposals_to_emit: tuple[_Action, ...]
+    seen_contexts: list[AgentContext[SegmentState, ParticipantState, _Action]] = dataclasses.field(default_factory=list)
+
+    def decide(
+        self,
+        context: AgentContext[SegmentState, ParticipantState, _Action],
+    ) -> AgentDecision[_Action]:
+        self.seen_contexts.append(context)
+        return _Decision(agent_id=self.agent_id, proposals=self.proposals_to_emit)
+
+
+@dataclass
+class _RecordingResolver:
+    received: list[tuple[int, tuple[_Action, ...]]] = dataclasses.field(default_factory=list)
+
+    def resolve(
+        self,
+        state: _State,
+        proposals: tuple[_Action, ...],
+    ) -> _State:
+        self.received.append((state.step_index, proposals))
+        return _make_state(
+            step_index=state.step_index + 1,
+            pending=(),
+            snapshot_suffix=state.step_index + 2,
+        )
+
+
+_DEFAULT_SEED: Seed = Seed(7)
+
+
+def _make_snapshot_ref(suffix: int = 1) -> SnapshotRef:
+    return SnapshotRef(
+        snapshot_id=UUID(int=suffix),
+        tier="bronze",
+        storage_key=f"snapshots/{suffix}",
+    )
+
+
+def _make_state(
+    *,
+    step_index: int = 0,
+    pending: tuple[_Action, ...] = (),
+    snapshot_suffix: int = 1,
+    seed: Seed = _DEFAULT_SEED,
+) -> _State:
+    return SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=seed,
+        snapshot_ref=_make_snapshot_ref(snapshot_suffix),
+        segments=(),
+        participants=(),
+        pending_actions=pending,
+    )
+
+
+def _make_action(suffix: str) -> _Action:
+    return _Action(
+        proposal_id=f"p-{suffix}",
+        actor_id=f"a-{suffix}",
+        action_key="noop",
+        payload=None,
+    )
+
+
+@pytest.fixture
+def make_action() -> Callable[[str], _Action]:
+    return _make_action
+
+
+@pytest.fixture
+def make_state() -> Callable[..., _State]:
+    return _make_state
+
+
+@pytest.fixture
+def make_spec() -> type[_Spec]:
+    return _Spec
+
+
+@pytest.fixture
+def make_recording_agent() -> type[_RecordingAgent]:
+    return _RecordingAgent
+
+
+@pytest.fixture
+def make_recording_resolver() -> type[_RecordingResolver]:
+    return _RecordingResolver
+
+
+@pytest.fixture
+def decision_cls() -> type[_Decision]:
+    return _Decision

--- a/tests/inspector/test_determinism.py
+++ b/tests/inspector/test_determinism.py
@@ -1,0 +1,155 @@
+"""Determinism tests: same ``(seed, scenario, run_id)`` -> byte-identical traces."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from abdp.core import Seed
+from abdp.inspector import (
+    MemoryTraceStore,
+    SQLiteTraceStore,
+    TraceEvent,
+    TraceRecorder,
+)
+from abdp.scenario import ScenarioRunner
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+
+_Runner = ScenarioRunner[SegmentState, ParticipantState, Any]
+
+_SEED = Seed(7)
+_RUN_ID = "run-deterministic"
+
+
+def _event_tuple(ev: TraceEvent) -> tuple[Any, ...]:
+    return (
+        ev.event_id,
+        ev.run_id,
+        ev.seq,
+        ev.step_index,
+        ev.event_type,
+        tuple(sorted(ev.attributes.items())),
+        ev.timestamp_ns,
+        ev.parent_event_id,
+    )
+
+
+def _execute_scenario(
+    *,
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+    store: MemoryTraceStore | SQLiteTraceStore,
+) -> None:
+    initial = make_state(step_index=0, pending=())
+    spec = make_spec(scenario_key="determinism", seed=_SEED, initial=initial)
+    agent = make_recording_agent(agent_id="a", proposals_to_emit=(make_action("x"),))
+    resolver = make_recording_resolver()
+    recorder = TraceRecorder(store=store, seed=_SEED, run_id=_RUN_ID)
+    runner: _Runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=3, recorder=recorder)
+    runner.run(spec)
+
+
+def test_two_runs_with_same_seed_produce_byte_identical_traces(
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    store_a = MemoryTraceStore()
+    store_b = MemoryTraceStore()
+    _execute_scenario(
+        make_action=make_action,
+        make_state=make_state,
+        make_spec=make_spec,
+        make_recording_agent=make_recording_agent,
+        make_recording_resolver=make_recording_resolver,
+        store=store_a,
+    )
+    _execute_scenario(
+        make_action=make_action,
+        make_state=make_state,
+        make_spec=make_spec,
+        make_recording_agent=make_recording_agent,
+        make_recording_resolver=make_recording_resolver,
+        store=store_b,
+    )
+
+    events_a = [_event_tuple(e) for e in store_a.query(run_id=_RUN_ID)]
+    events_b = [_event_tuple(e) for e in store_b.query(run_id=_RUN_ID)]
+    assert events_a == events_b
+    assert len(events_a) > 0
+
+
+def test_event_ids_only_depend_on_seed_run_id_seq() -> None:
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=_SEED, run_id=_RUN_ID)
+    a = recorder.record(event_type="step.begin", step_index=0, attributes={"x": 1})
+    b = recorder.record(event_type="step.end", step_index=99, attributes={"y": "z"})
+
+    store2 = MemoryTraceStore()
+    recorder2 = TraceRecorder(store=store2, seed=_SEED, run_id=_RUN_ID)
+    a2 = recorder2.record(event_type="other", step_index=42, attributes={"q": True})
+    b2 = recorder2.record(event_type="another", step_index=0, attributes={})
+
+    assert a.event_id == a2.event_id
+    assert b.event_id == b2.event_id
+
+
+def test_different_seeds_produce_different_event_ids() -> None:
+    store_a = MemoryTraceStore()
+    store_b = MemoryTraceStore()
+    rec_a = TraceRecorder(store=store_a, seed=Seed(1), run_id=_RUN_ID)
+    rec_b = TraceRecorder(store=store_b, seed=Seed(2), run_id=_RUN_ID)
+    e_a = rec_a.record(event_type="x", step_index=0, attributes={})
+    e_b = rec_b.record(event_type="x", step_index=0, attributes={})
+    assert e_a.event_id != e_b.event_id
+
+
+def test_different_run_ids_produce_different_event_ids() -> None:
+    store = MemoryTraceStore()
+    rec_a = TraceRecorder(store=store, seed=_SEED, run_id="run-a")
+    rec_b = TraceRecorder(store=store, seed=_SEED, run_id="run-b")
+    e_a = rec_a.record(event_type="x", step_index=0, attributes={})
+    e_b = rec_b.record(event_type="x", step_index=0, attributes={})
+    assert e_a.event_id != e_b.event_id
+
+
+def test_sqlite_store_round_trip_preserves_event_tuples(
+    tmp_path: Any,
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    db = tmp_path / "trace.db"
+    sqlite_store = SQLiteTraceStore(db)
+    _execute_scenario(
+        make_action=make_action,
+        make_state=make_state,
+        make_spec=make_spec,
+        make_recording_agent=make_recording_agent,
+        make_recording_resolver=make_recording_resolver,
+        store=sqlite_store,
+    )
+    sqlite_store.close()
+
+    mem_store = MemoryTraceStore()
+    _execute_scenario(
+        make_action=make_action,
+        make_state=make_state,
+        make_spec=make_spec,
+        make_recording_agent=make_recording_agent,
+        make_recording_resolver=make_recording_resolver,
+        store=mem_store,
+    )
+
+    reopened = SQLiteTraceStore(db)
+    sqlite_events = [_event_tuple(e) for e in reopened.query(run_id=_RUN_ID)]
+    reopened.close()
+    mem_events = [_event_tuple(e) for e in mem_store.query(run_id=_RUN_ID)]
+    assert sqlite_events == mem_events

--- a/tests/inspector/test_memory_store.py
+++ b/tests/inspector/test_memory_store.py
@@ -1,0 +1,137 @@
+"""Tests for ``abdp.inspector.MemoryTraceStore`` and ``TraceStore`` protocol."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from abdp.core.types import Seed
+from abdp.inspector import (
+    MemoryTraceStore,
+    TraceEvent,
+    TraceStore,
+    make_trace_event,
+)
+
+
+def _make(seq: int = 0, **overrides: Any) -> TraceEvent:
+    base: dict[str, Any] = {
+        "seed": Seed(0),
+        "run_id": "run-1",
+        "seq": seq,
+        "step_index": seq,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": seq,
+        "parent_event_id": None,
+    }
+    base.update(overrides)
+    return make_trace_event(**base)
+
+
+def test_memory_store_implements_protocol() -> None:
+    store = MemoryTraceStore()
+    assert isinstance(store, TraceStore)
+
+
+def test_memory_store_append_and_query_roundtrip() -> None:
+    store = MemoryTraceStore()
+    e0 = _make(seq=0)
+    e1 = _make(seq=1)
+    store.append(e0)
+    store.append(e1)
+    assert tuple(store.query(run_id="run-1")) == (e0, e1)
+
+
+def test_memory_store_query_returns_only_matching_run_id() -> None:
+    store = MemoryTraceStore()
+    e_a = _make(seq=0, run_id="run-a")
+    e_b = _make(seq=0, run_id="run-b")
+    store.append(e_a)
+    store.append(e_b)
+    assert tuple(store.query(run_id="run-a")) == (e_a,)
+    assert tuple(store.query(run_id="run-b")) == (e_b,)
+
+
+def test_memory_store_rejects_duplicate_event_id() -> None:
+    store = MemoryTraceStore()
+    e = _make(seq=0)
+    store.append(e)
+    with pytest.raises(ValueError, match="duplicate event_id"):
+        store.append(e)
+
+
+def test_memory_store_query_filters_by_step_index() -> None:
+    store = MemoryTraceStore()
+    e0 = _make(seq=0, step_index=0)
+    e1 = _make(seq=1, step_index=1)
+    e2 = _make(seq=2, step_index=1)
+    store.append(e0)
+    store.append(e1)
+    store.append(e2)
+    assert tuple(store.query(run_id="run-1", step_index=1)) == (e1, e2)
+
+
+def test_memory_store_query_filters_by_event_type() -> None:
+    store = MemoryTraceStore()
+    e0 = _make(seq=0, event_type="step.begin")
+    e1 = _make(seq=1, event_type="step.end")
+    store.append(e0)
+    store.append(e1)
+    assert tuple(store.query(run_id="run-1", event_type="step.end")) == (e1,)
+
+
+def test_memory_store_query_unknown_run_id_returns_empty() -> None:
+    store = MemoryTraceStore()
+    store.append(_make(seq=0))
+    assert tuple(store.query(run_id="missing")) == ()
+
+
+def test_memory_store_close_is_idempotent() -> None:
+    store = MemoryTraceStore()
+    store.close()
+    store.close()
+
+
+def test_memory_store_preserves_insertion_order() -> None:
+    store = MemoryTraceStore()
+    seqs = (3, 1, 2, 0)
+    events = tuple(_make(seq=s) for s in seqs)
+    for ev in events:
+        store.append(ev)
+    assert tuple(store.query(run_id="run-1")) == events
+
+
+def test_memory_store_append_rejects_non_trace_event() -> None:
+    store = MemoryTraceStore()
+    with pytest.raises(TypeError, match="TraceEvent"):
+        store.append("not an event")  # type: ignore[arg-type]
+
+
+def test_memory_store_query_unknown_filter_raises() -> None:
+    store = MemoryTraceStore()
+    store.append(_make(seq=0))
+    with pytest.raises(TypeError, match="filter"):
+        tuple(store.query(run_id="run-1", bogus="x"))
+
+
+def test_memory_store_runs_returns_distinct_run_ids() -> None:
+    store = MemoryTraceStore()
+    store.append(_make(seq=0, run_id="run-a"))
+    store.append(_make(seq=1, run_id="run-a"))
+    store.append(_make(seq=0, run_id="run-b"))
+    assert sorted(store.runs()) == ["run-a", "run-b"]
+
+
+def test_memory_store_event_returns_event_by_id() -> None:
+    store = MemoryTraceStore()
+    e = _make(seq=0)
+    store.append(e)
+    assert store.event(e.event_id) == e
+
+
+def test_memory_store_event_returns_none_for_unknown_id() -> None:
+    store = MemoryTraceStore()
+    assert store.event(UUID("00000000-0000-0000-0000-000000000099")) is None

--- a/tests/inspector/test_oracle_review_regressions.py
+++ b/tests/inspector/test_oracle_review_regressions.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import math
 import sqlite3
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 from uuid import UUID
 
 import pytest
@@ -203,6 +205,51 @@ def test_inspect_cli_returns_two_on_corrupt_attributes_json(
             0,
             "step.begin",
             "this-is-not-json",
+            0,
+            None,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    exit_code = main(["inspect", "run-x", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_trace_event_rejects_non_mapping_attributes() -> None:
+    with pytest.raises(TypeError):
+        TraceEvent(
+            event_id=UUID(int=1),
+            run_id="r",
+            seq=0,
+            step_index=0,
+            event_type="x",
+            attributes=cast("Mapping[str, object]", []),
+            timestamp_ns=0,
+            parent_event_id=None,
+        )
+
+
+def test_inspect_cli_returns_two_on_attributes_json_array(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    store = SQLiteTraceStore(db)
+    store.close()
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO trace_events VALUES (?,?,?,?,?,?,?,?)",
+        (
+            str(UUID(int=1)),
+            "run-x",
+            0,
+            0,
+            "step.begin",
+            json.dumps([1, 2, 3]),
             0,
             None,
         ),

--- a/tests/inspector/test_oracle_review_regressions.py
+++ b/tests/inspector/test_oracle_review_regressions.py
@@ -1,0 +1,248 @@
+"""Regression tests for Oracle review (PR #174) findings on issue #172."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from abdp.cli.__main__ import main
+from abdp.core import Seed
+from abdp.inspector import (
+    MemoryTraceStore,
+    SQLiteTraceStore,
+    TraceEvent,
+    TraceRecorder,
+    make_trace_event,
+)
+
+
+def _ev(seq: int = 0, *, run_id: str = "run-x") -> TraceEvent:
+    return make_trace_event(
+        seed=Seed(7),
+        run_id=run_id,
+        seq=seq,
+        step_index=0,
+        event_type="x",
+        attributes={},
+        timestamp_ns=seq,
+        parent_event_id=None,
+    )
+
+
+def test_trace_event_attributes_are_isolated_from_external_dict_mutation() -> None:
+    src: dict[str, object] = {"a": 1}
+    ev = make_trace_event(
+        seed=Seed(0),
+        run_id="r",
+        seq=0,
+        step_index=0,
+        event_type="x",
+        attributes=src,
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    src["a"] = 999
+    src["b"] = "added"
+    assert dict(ev.attributes) == {"a": 1}
+
+
+def test_trace_event_attributes_mapping_is_not_writable() -> None:
+    ev = make_trace_event(
+        seed=Seed(0),
+        run_id="r",
+        seq=0,
+        step_index=0,
+        event_type="x",
+        attributes={"a": 1},
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    with pytest.raises(TypeError):
+        ev.attributes["a"] = 2  # type: ignore[index]
+
+
+def test_trace_event_rejects_nan_attribute_value() -> None:
+    with pytest.raises(ValueError):
+        make_trace_event(
+            seed=Seed(0),
+            run_id="r",
+            seq=0,
+            step_index=0,
+            event_type="x",
+            attributes={"k": math.nan},
+            timestamp_ns=0,
+            parent_event_id=None,
+        )
+
+
+def test_trace_event_rejects_positive_infinity_attribute_value() -> None:
+    with pytest.raises(ValueError):
+        make_trace_event(
+            seed=Seed(0),
+            run_id="r",
+            seq=0,
+            step_index=0,
+            event_type="x",
+            attributes={"k": math.inf},
+            timestamp_ns=0,
+            parent_event_id=None,
+        )
+
+
+def test_trace_event_rejects_negative_infinity_attribute_value() -> None:
+    with pytest.raises(ValueError):
+        make_trace_event(
+            seed=Seed(0),
+            run_id="r",
+            seq=0,
+            step_index=0,
+            event_type="x",
+            attributes={"k": -math.inf},
+            timestamp_ns=0,
+            parent_event_id=None,
+        )
+
+
+def test_memory_store_rejects_duplicate_run_id_seq_pair() -> None:
+    store = MemoryTraceStore()
+    a = make_trace_event(
+        seed=Seed(1),
+        run_id="r",
+        seq=0,
+        step_index=0,
+        event_type="x",
+        attributes={},
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    b = make_trace_event(
+        seed=Seed(2),
+        run_id="r",
+        seq=0,
+        step_index=0,
+        event_type="y",
+        attributes={},
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    assert a.event_id != b.event_id
+    store.append(a)
+    with pytest.raises(ValueError):
+        store.append(b)
+
+
+def test_sqlite_store_duplicate_run_id_seq_message_mentions_run_id_seq(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(tmp_path / "t.db")
+    a = make_trace_event(
+        seed=Seed(1),
+        run_id="r",
+        seq=0,
+        step_index=0,
+        event_type="x",
+        attributes={},
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    b = make_trace_event(
+        seed=Seed(2),
+        run_id="r",
+        seq=0,
+        step_index=0,
+        event_type="y",
+        attributes={},
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    store.append(a)
+    with pytest.raises(ValueError) as exc:
+        store.append(b)
+    store.close()
+    assert "(run_id, seq)" in str(exc.value)
+
+
+class _FlakyStore:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.appended: list[TraceEvent] = []
+
+    def append(self, event: TraceEvent) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("simulated transient failure")
+        self.appended.append(event)
+
+
+def test_recorder_does_not_advance_seq_when_store_append_fails() -> None:
+    store = _FlakyStore()
+    recorder = TraceRecorder(store=store, seed=Seed(0), run_id="r")  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError):
+        recorder.record(event_type="x", step_index=0, attributes={})
+    ok = recorder.record(event_type="x", step_index=0, attributes={})
+    assert ok.seq == 0
+
+
+def test_inspect_cli_returns_two_on_corrupt_attributes_json(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    store = SQLiteTraceStore(db)
+    store.close()
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO trace_events VALUES (?,?,?,?,?,?,?,?)",
+        (
+            str(UUID(int=1)),
+            "run-x",
+            0,
+            0,
+            "step.begin",
+            "this-is-not-json",
+            0,
+            None,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    exit_code = main(["inspect", "run-x", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""
+
+
+def test_inspect_cli_returns_two_on_corrupt_event_id(
+    tmp_path: Path,
+    capsysbinary: pytest.CaptureFixture[bytes],
+) -> None:
+    db = tmp_path / "trace.db"
+    store = SQLiteTraceStore(db)
+    store.close()
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO trace_events VALUES (?,?,?,?,?,?,?,?)",
+        (
+            "not-a-uuid",
+            "run-x",
+            0,
+            0,
+            "step.begin",
+            json.dumps({}),
+            0,
+            None,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    exit_code = main(["inspect", "run-x", "--db", str(db)])
+    captured = capsysbinary.readouterr()
+    assert exit_code == 2
+    assert captured.out == b""
+    assert captured.err != b""

--- a/tests/inspector/test_oracle_review_regressions.py
+++ b/tests/inspector/test_oracle_review_regressions.py
@@ -37,7 +37,7 @@ def _ev(seq: int = 0, *, run_id: str = "run-x") -> TraceEvent:
 
 
 def test_trace_event_attributes_are_isolated_from_external_dict_mutation() -> None:
-    src: dict[str, object] = {"a": 1}
+    src: dict[str, str | int | float | bool] = {"a": 1}
     ev = make_trace_event(
         seed=Seed(0),
         run_id="r",
@@ -227,7 +227,7 @@ def test_trace_event_rejects_non_mapping_attributes() -> None:
             seq=0,
             step_index=0,
             event_type="x",
-            attributes=cast("Mapping[str, object]", []),
+            attributes=cast("Mapping[str, str | int | float | bool]", []),
             timestamp_ns=0,
             parent_event_id=None,
         )

--- a/tests/inspector/test_runner_emits.py
+++ b/tests/inspector/test_runner_emits.py
@@ -1,0 +1,135 @@
+"""Tests for ``ScenarioRunner`` -> ``TraceRecorder`` event emission."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from abdp.core import Seed
+from abdp.inspector import MemoryTraceStore, TraceRecorder
+from abdp.scenario import ScenarioRunner
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+
+_Runner = ScenarioRunner[SegmentState, ParticipantState, Any]
+
+
+def test_scenario_runner_does_not_require_recorder(
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    initial = make_state(step_index=0, pending=())
+    spec = make_spec(scenario_key="default", seed=Seed(7), initial=initial)
+    agent = make_recording_agent(agent_id="a", proposals_to_emit=(make_action("x"),))
+    resolver = make_recording_resolver()
+    runner: _Runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=2)
+
+    run = runner.run(spec)
+    assert run.scenario_key == "default"
+
+
+def test_scenario_runner_emits_step_begin_and_step_end_events(
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    initial = make_state(step_index=0, pending=())
+    spec = make_spec(scenario_key="emit", seed=Seed(7), initial=initial)
+    agent = make_recording_agent(agent_id="a", proposals_to_emit=(make_action("x"),))
+    resolver = make_recording_resolver()
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=Seed(7), run_id="run-emit")
+    runner: _Runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=1, recorder=recorder)
+
+    runner.run(spec)
+    events = tuple(store.query(run_id="run-emit"))
+    types = [e.event_type for e in events]
+    assert "step.begin" in types
+    assert "step.end" in types
+
+
+def test_scenario_runner_emits_decision_evaluate_per_agent(
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    initial = make_state(step_index=0, pending=())
+    spec = make_spec(scenario_key="dec", seed=Seed(7), initial=initial)
+    a1 = make_recording_agent(agent_id="agent-1", proposals_to_emit=(make_action("p1"),))
+    a2 = make_recording_agent(agent_id="agent-2", proposals_to_emit=(make_action("p2"),))
+    resolver = make_recording_resolver()
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=Seed(7), run_id="run-dec")
+    runner: _Runner = ScenarioRunner(agents=(a1, a2), resolver=resolver, max_steps=1, recorder=recorder)
+
+    runner.run(spec)
+    decisions = tuple(store.query(run_id="run-dec", event_type="decision.evaluate"))
+    assert len(decisions) == 2
+    agent_ids = [e.attributes["agent_id"] for e in decisions]
+    assert agent_ids == ["agent-1", "agent-2"]
+
+
+def test_scenario_runner_emits_events_in_seq_order(
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    initial = make_state(step_index=0, pending=())
+    spec = make_spec(scenario_key="seq", seed=Seed(7), initial=initial)
+    agent = make_recording_agent(agent_id="a", proposals_to_emit=(make_action("x"),))
+    resolver = make_recording_resolver()
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=Seed(7), run_id="run-seq")
+    runner: _Runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=2, recorder=recorder)
+
+    runner.run(spec)
+    events = tuple(store.query(run_id="run-seq"))
+    seqs = [e.seq for e in events]
+    assert seqs == sorted(seqs)
+    assert seqs == list(range(len(seqs)))
+
+
+def test_scenario_runner_with_recorder_records_step_indices(
+    make_action: Callable[[str], Any],
+    make_state: Callable[..., SimulationState[SegmentState, ParticipantState, Any]],
+    make_spec: type,
+    make_recording_agent: type,
+    make_recording_resolver: type,
+) -> None:
+    initial = make_state(step_index=0, pending=())
+    spec = make_spec(scenario_key="idx", seed=Seed(7), initial=initial)
+    agent = make_recording_agent(agent_id="a", proposals_to_emit=(make_action("x"),))
+    resolver = make_recording_resolver()
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=Seed(7), run_id="run-idx")
+    runner: _Runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=2, recorder=recorder)
+
+    runner.run(spec)
+    begins = tuple(store.query(run_id="run-idx", event_type="step.begin"))
+    assert [e.step_index for e in begins] == [0, 1]
+
+
+def test_trace_recorder_assigns_monotonic_seq() -> None:
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=Seed(0), run_id="r")
+    e1 = recorder.record(event_type="x", step_index=0, attributes={})
+    e2 = recorder.record(event_type="y", step_index=0, attributes={})
+    assert e1.seq == 0
+    assert e2.seq == 1
+
+
+def test_trace_recorder_uses_deterministic_timestamp() -> None:
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=Seed(0), run_id="r")
+    e = recorder.record(event_type="x", step_index=3, attributes={})
+    assert e.timestamp_ns == 0
+    e2 = recorder.record(event_type="y", step_index=3, attributes={})
+    assert e2.timestamp_ns == 1

--- a/tests/inspector/test_sqlite_store.py
+++ b/tests/inspector/test_sqlite_store.py
@@ -191,3 +191,12 @@ def test_sqlite_store_query_unknown_filter_raises(tmp_path: Path) -> None:
             tuple(store.query(run_id="run-1", bogus="x"))
     finally:
         store.close()
+
+
+def test_sqlite_store_append_rejects_non_trace_event(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        with pytest.raises(TypeError, match="TraceEvent"):
+            store.append("not an event")  # type: ignore[arg-type]
+    finally:
+        store.close()

--- a/tests/inspector/test_sqlite_store.py
+++ b/tests/inspector/test_sqlite_store.py
@@ -1,0 +1,193 @@
+"""Tests for ``abdp.inspector.SQLiteTraceStore``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from abdp.core.types import Seed
+from abdp.inspector import (
+    SQLiteTraceStore,
+    TraceEvent,
+    TraceStore,
+    make_trace_event,
+)
+
+
+def _make(seq: int = 0, **overrides: Any) -> TraceEvent:
+    base: dict[str, Any] = {
+        "seed": Seed(0),
+        "run_id": "run-1",
+        "seq": seq,
+        "step_index": seq,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": seq,
+        "parent_event_id": None,
+    }
+    base.update(overrides)
+    return make_trace_event(**base)
+
+
+def test_sqlite_store_implements_protocol(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(tmp_path / "t.db")
+    try:
+        assert isinstance(store, TraceStore)
+    finally:
+        store.close()
+
+
+def test_sqlite_store_in_memory_append_and_query(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        e0 = _make(seq=0)
+        e1 = _make(seq=1)
+        store.append(e0)
+        store.append(e1)
+        assert tuple(store.query(run_id="run-1")) == (e0, e1)
+    finally:
+        store.close()
+
+
+def test_sqlite_store_persists_across_reopen(tmp_path: Path) -> None:
+    db = tmp_path / "t.db"
+    store = SQLiteTraceStore(db)
+    e0 = _make(seq=0)
+    e1 = _make(seq=1, event_type="step.end")
+    store.append(e0)
+    store.append(e1)
+    store.close()
+
+    reopened = SQLiteTraceStore(db)
+    try:
+        assert tuple(reopened.query(run_id="run-1")) == (e0, e1)
+    finally:
+        reopened.close()
+
+
+def test_sqlite_store_round_trips_attributes(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        ev = _make(seq=0, attributes={"s": "v", "i": 1, "f": 1.5, "b": True})
+        store.append(ev)
+        (got,) = tuple(store.query(run_id="run-1"))
+        assert got == ev
+        assert got.attributes == {"s": "v", "i": 1, "f": 1.5, "b": True}
+    finally:
+        store.close()
+
+
+def test_sqlite_store_round_trips_parent_event_id(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        parent = _make(seq=0)
+        child = _make(seq=1, parent_event_id=parent.event_id)
+        store.append(parent)
+        store.append(child)
+        events = tuple(store.query(run_id="run-1"))
+        assert events == (parent, child)
+        assert events[1].parent_event_id == parent.event_id
+    finally:
+        store.close()
+
+
+def test_sqlite_store_rejects_duplicate_event_id(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        e = _make(seq=0)
+        store.append(e)
+        with pytest.raises(ValueError, match="duplicate event_id"):
+            store.append(e)
+    finally:
+        store.close()
+
+
+def test_sqlite_store_filters_by_step_index(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        e0 = _make(seq=0, step_index=0)
+        e1 = _make(seq=1, step_index=1)
+        store.append(e0)
+        store.append(e1)
+        assert tuple(store.query(run_id="run-1", step_index=1)) == (e1,)
+    finally:
+        store.close()
+
+
+def test_sqlite_store_filters_by_event_type(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        e0 = _make(seq=0, event_type="step.begin")
+        e1 = _make(seq=1, event_type="step.end")
+        store.append(e0)
+        store.append(e1)
+        assert tuple(store.query(run_id="run-1", event_type="step.end")) == (e1,)
+    finally:
+        store.close()
+
+
+def test_sqlite_store_close_is_idempotent(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(tmp_path / "t.db")
+    store.close()
+    store.close()
+
+
+def test_sqlite_store_append_after_close_raises(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    store.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        store.append(_make(seq=0))
+
+
+def test_sqlite_store_query_returns_seq_order(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        events = tuple(_make(seq=s) for s in (3, 1, 2, 0))
+        for ev in events:
+            store.append(ev)
+        got = tuple(store.query(run_id="run-1"))
+        assert [e.seq for e in got] == [0, 1, 2, 3]
+    finally:
+        store.close()
+
+
+def test_sqlite_store_runs_returns_distinct_run_ids(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        store.append(_make(seq=0, run_id="run-a"))
+        store.append(_make(seq=0, run_id="run-b"))
+        assert sorted(store.runs()) == ["run-a", "run-b"]
+    finally:
+        store.close()
+
+
+def test_sqlite_store_event_returns_event_by_id(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        e = _make(seq=0)
+        store.append(e)
+        assert store.event(e.event_id) == e
+    finally:
+        store.close()
+
+
+def test_sqlite_store_event_returns_none_for_unknown_id(tmp_path: Path) -> None:
+    from uuid import UUID
+
+    store = SQLiteTraceStore(":memory:")
+    try:
+        assert store.event(UUID("00000000-0000-0000-0000-000000000099")) is None
+    finally:
+        store.close()
+
+
+def test_sqlite_store_query_unknown_filter_raises(tmp_path: Path) -> None:
+    store = SQLiteTraceStore(":memory:")
+    try:
+        store.append(_make(seq=0))
+        with pytest.raises(TypeError, match="filter"):
+            tuple(store.query(run_id="run-1", bogus="x"))
+    finally:
+        store.close()

--- a/tests/inspector/test_trace_event.py
+++ b/tests/inspector/test_trace_event.py
@@ -114,12 +114,12 @@ def test_trace_event_rejects_empty_event_type() -> None:
 
 def test_trace_event_attributes_only_allow_primitive_values() -> None:
     with pytest.raises(TypeError, match="attribute"):
-        _event(attributes={"k": object()})  # type: ignore[dict-item]
+        _event(attributes={"k": object()})
 
 
 def test_trace_event_attributes_reject_non_str_keys() -> None:
     with pytest.raises(TypeError, match="attribute key"):
-        _event(attributes={1: "v"})  # type: ignore[dict-item]
+        _event(attributes={1: "v"})
 
 
 def test_trace_event_attributes_accept_str_int_float_bool() -> None:

--- a/tests/inspector/test_trace_event.py
+++ b/tests/inspector/test_trace_event.py
@@ -1,0 +1,247 @@
+"""Tests for ``abdp.inspector.TraceEvent`` and ``make_trace_event``.
+
+Locks the determinism contract:
+``event_id = deterministic_uuid(seed, _TRACE_NAMESPACE, f"{run_id}\\0{seq}")``
+so identity depends only on ``(seed, run_id, seq)`` while ``step_index``,
+``event_type``, ``attributes``, ``timestamp_ns``, and ``parent_event_id``
+are payload metadata that do not influence ``event_id``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from typing import Any, cast, get_type_hints
+from uuid import UUID
+
+import pytest
+
+from abdp.core.types import Seed
+from abdp.inspector import TraceEvent, make_trace_event
+
+
+def _event(**overrides: Any) -> TraceEvent:
+    base: dict[str, Any] = {
+        "event_id": UUID("00000000-0000-0000-0000-000000000001"),
+        "run_id": "run-1",
+        "seq": 0,
+        "step_index": 0,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": 0,
+        "parent_event_id": None,
+    }
+    base.update(overrides)
+    return TraceEvent(**base)
+
+
+def test_trace_event_is_frozen_dataclass() -> None:
+    assert dataclasses.is_dataclass(TraceEvent)
+    params = cast(Any, TraceEvent).__dataclass_params__
+    assert params.frozen is True
+
+
+def test_trace_event_uses_slots() -> None:
+    assert "__slots__" in vars(TraceEvent)
+
+
+def test_trace_event_field_order_and_types() -> None:
+    fields = dataclasses.fields(TraceEvent)
+    assert [f.name for f in fields] == [
+        "event_id",
+        "run_id",
+        "seq",
+        "step_index",
+        "event_type",
+        "attributes",
+        "timestamp_ns",
+        "parent_event_id",
+    ]
+    annotations = get_type_hints(TraceEvent)
+    assert annotations["event_id"] is UUID
+    assert annotations["run_id"] is str
+    assert annotations["seq"] is int
+    assert annotations["step_index"] is int
+    assert annotations["event_type"] is str
+    assert annotations["timestamp_ns"] is int
+    assert annotations["parent_event_id"] == UUID | None
+
+
+def test_trace_event_requires_all_fields() -> None:
+    for field in dataclasses.fields(TraceEvent):
+        assert field.default is dataclasses.MISSING
+        assert field.default_factory is dataclasses.MISSING
+
+
+def test_trace_event_is_immutable() -> None:
+    ev = _event()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(ev, "event_type", "other")  # noqa: B010
+
+
+def test_trace_event_equality_is_value_based() -> None:
+    a = _event()
+    b = _event()
+    c = _event(event_type="step.end")
+    assert a == b
+    assert a != c
+
+
+def test_trace_event_rejects_negative_seq() -> None:
+    with pytest.raises(ValueError, match="seq"):
+        _event(seq=-1)
+
+
+def test_trace_event_rejects_negative_step_index() -> None:
+    with pytest.raises(ValueError, match="step_index"):
+        _event(step_index=-1)
+
+
+def test_trace_event_rejects_negative_timestamp_ns() -> None:
+    with pytest.raises(ValueError, match="timestamp_ns"):
+        _event(timestamp_ns=-1)
+
+
+def test_trace_event_rejects_empty_run_id() -> None:
+    with pytest.raises(ValueError, match="run_id"):
+        _event(run_id="")
+
+
+def test_trace_event_rejects_empty_event_type() -> None:
+    with pytest.raises(ValueError, match="event_type"):
+        _event(event_type="")
+
+
+def test_trace_event_attributes_only_allow_primitive_values() -> None:
+    with pytest.raises(TypeError, match="attribute"):
+        _event(attributes={"k": object()})  # type: ignore[dict-item]
+
+
+def test_trace_event_attributes_accept_str_int_float_bool() -> None:
+    ev = _event(attributes={"s": "v", "i": 1, "f": 1.5, "b": True})
+    assert ev.attributes["s"] == "v"
+    assert ev.attributes["i"] == 1
+    assert ev.attributes["f"] == 1.5
+    assert ev.attributes["b"] is True
+
+
+def test_trace_event_attributes_are_a_mapping() -> None:
+    ev = _event(attributes={"k": "v"})
+    assert isinstance(ev.attributes, Mapping)
+
+
+def test_make_trace_event_returns_trace_event() -> None:
+    ev = make_trace_event(
+        seed=Seed(0),
+        run_id="run-1",
+        seq=0,
+        step_index=0,
+        event_type="step.begin",
+        attributes={},
+        timestamp_ns=0,
+        parent_event_id=None,
+    )
+    assert isinstance(ev, TraceEvent)
+    assert isinstance(ev.event_id, UUID)
+
+
+def test_make_trace_event_is_deterministic_for_same_inputs() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(7),
+        "run_id": "run-1",
+        "seq": 3,
+        "step_index": 1,
+        "event_type": "decision.evaluate",
+        "attributes": {"agent": "a"},
+        "timestamp_ns": 3,
+        "parent_event_id": None,
+    }
+    a = make_trace_event(**args)
+    b = make_trace_event(**args)
+    assert a.event_id == b.event_id
+
+
+def test_make_trace_event_id_changes_with_seq() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "run_id": "run-1",
+        "seq": 0,
+        "step_index": 0,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": 0,
+        "parent_event_id": None,
+    }
+    a = make_trace_event(**args)
+    b = make_trace_event(**{**args, "seq": 1})
+    assert a.event_id != b.event_id
+
+
+def test_make_trace_event_id_changes_with_run_id() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "run_id": "run-1",
+        "seq": 0,
+        "step_index": 0,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": 0,
+        "parent_event_id": None,
+    }
+    a = make_trace_event(**args)
+    b = make_trace_event(**{**args, "run_id": "run-2"})
+    assert a.event_id != b.event_id
+
+
+def test_make_trace_event_id_changes_with_seed() -> None:
+    args: dict[str, Any] = {
+        "run_id": "run-1",
+        "seq": 0,
+        "step_index": 0,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": 0,
+        "parent_event_id": None,
+    }
+    a = make_trace_event(seed=Seed(0), **args)
+    b = make_trace_event(seed=Seed(1), **args)
+    assert a.event_id != b.event_id
+
+
+def test_make_trace_event_id_does_not_depend_on_metadata() -> None:
+    args: dict[str, Any] = {
+        "seed": Seed(0),
+        "run_id": "run-1",
+        "seq": 0,
+        "step_index": 0,
+        "event_type": "step.begin",
+        "attributes": {},
+        "timestamp_ns": 0,
+        "parent_event_id": None,
+    }
+    a = make_trace_event(**args)
+    b = make_trace_event(
+        **{
+            **args,
+            "step_index": 99,
+            "event_type": "step.end",
+            "attributes": {"x": 1},
+            "timestamp_ns": 12345,
+            "parent_event_id": UUID("00000000-0000-0000-0000-0000000000aa"),
+        }
+    )
+    assert a.event_id == b.event_id
+
+
+def test_make_trace_event_pins_golden_vector() -> None:
+    ev = make_trace_event(
+        seed=Seed(42),
+        run_id="scenario-x",
+        seq=7,
+        step_index=2,
+        event_type="step.begin",
+        attributes={},
+        timestamp_ns=7,
+        parent_event_id=None,
+    )
+    assert ev.event_id == UUID("ec78f1ec-0d0d-5d4f-bd16-2f8c9c8e7c4f")

--- a/tests/inspector/test_trace_event.py
+++ b/tests/inspector/test_trace_event.py
@@ -117,6 +117,11 @@ def test_trace_event_attributes_only_allow_primitive_values() -> None:
         _event(attributes={"k": object()})  # type: ignore[dict-item]
 
 
+def test_trace_event_attributes_reject_non_str_keys() -> None:
+    with pytest.raises(TypeError, match="attribute key"):
+        _event(attributes={1: "v"})  # type: ignore[dict-item]
+
+
 def test_trace_event_attributes_accept_str_int_float_bool() -> None:
     ev = _event(attributes={"s": "v", "i": 1, "f": 1.5, "b": True})
     assert ev.attributes["s"] == "v"
@@ -244,4 +249,4 @@ def test_make_trace_event_pins_golden_vector() -> None:
         timestamp_ns=7,
         parent_event_id=None,
     )
-    assert ev.event_id == UUID("ec78f1ec-0d0d-5d4f-bd16-2f8c9c8e7c4f")
+    assert ev.event_id == UUID("05536901-00d4-56d2-bc07-b8e930292fe0")

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -15,7 +15,7 @@ README_PATHS: tuple[Path, ...] = (
     ADR_README_PATH,
 )
 
-MAX_DOCS_INDEX_LINES = 10
+MAX_DOCS_INDEX_LINES = 11
 MAX_SUBSECTION_README_LINES = 10
 MAX_EXAMPLES_INDEX_LINES = 80
 
@@ -26,7 +26,8 @@ EXPECTED_DOCS_INDEX_SNIPPETS = (
     "- [Models](models/README.md) — Conceptual model documentation for abdp.",
     "- [Examples](examples/README.md) — Worked examples and tutorials.",
     "- [ADRs](adr/README.md) — Architecture decision records and template.",
-    "- [CLI](cli.md) — Command-line usage reference for `abdp run` and `abdp report`.",
+    "- [CLI](cli.md) — Command-line usage reference for `abdp run`, `abdp report`, and `abdp inspect`.",
+    "- [Inspector](inspector.md) — In-process tracing layer and `abdp inspect` query CLI.",
 )
 
 EXPECTED_SUBSECTION_TITLES: tuple[tuple[Path, str], ...] = (

--- a/tests/scenario/test_scenario_runner.py
+++ b/tests/scenario/test_scenario_runner.py
@@ -19,7 +19,7 @@ def test_scenario_runner_is_a_frozen_slot_backed_dataclass_with_expected_fields(
     assert "__slots__" in ScenarioRunner.__dict__
 
     fields = {f.name: f.type for f in dataclasses.fields(ScenarioRunner)}
-    assert set(fields) == {"agents", "resolver", "max_steps"}
+    assert set(fields) == {"agents", "resolver", "max_steps", "recorder"}
     assert fields["max_steps"] is int
 
     hints = get_type_hints(ScenarioRunner)


### PR DESCRIPTION
## Summary

Implements **issue #172** — adds the `abdp.inspector` subsystem and the `abdp inspect` CLI subcommand, completing v0.4 of the roadmap.

This is the substrate the upcoming Self-Correction / ReviewLoopRunner (#173, v0.5) will build on.

## What's in

- `abdp.inspector` package
  - `TraceEvent` (frozen, slotted, fully typed, deterministic `event_id` over `(seed, run_id, seq)`).
  - `TraceStore` `Protocol` + ready-made `MemoryTraceStore` and `SQLiteTraceStore` implementations.
  - `TraceRecorder` (owns the per-run `seq` counter, deterministic `timestamp_ns = seq` — no wall clock).
- `ScenarioRunner` gains an optional `recorder: TraceRecorder | None = None` field; emits `step.begin`, `decision.evaluate` (per agent), `step.end` events when present. Default `None` keeps existing callers byte-identical.
- `abdp inspect <run_id> --db PATH [--step N] [--event-type TYPE] [--output FILE]` CLI subcommand emitting JSON Lines.
- `docs/inspector.md` user guide.
- `docs/adr/0001-two-plane-execution-model.md` ADR documenting the canonical-vs-inspector design (rejecting Options A/B/C from the Oracle pre-consult, picking Option D).

## TDD trail

| Cycle | Commit | Tests added |
| --- | --- | --- |
| RED1 / GREEN1 | `a7fdfa1` / `fe004f3` | `tests/inspector/test_trace_event.py` (22) |
| RED2 / GREEN2 | `098bd04` / `34fc351` | `tests/inspector/test_memory_store.py` (14), `test_sqlite_store.py` (16) |
| RED3 / GREEN3 | `ef965e8` / `2a30372` | `tests/inspector/test_runner_emits.py` (7) |
| RED4 / GREEN4 | `74850bb` / `d4f5bbd` | `tests/cli/test_inspect.py` (17) |
| RED5/GREEN5 | `cb09069` | `tests/inspector/test_determinism.py` (5) — GREEN was a no-op; the previous cycles already deliver determinism, this commit locks the contract in. |
| Docs | `823667a` | guide + ADR + CLI page updates |

## Verification

- ✅ 930 tests pass
- ✅ 100% line coverage maintained
- ✅ No public type changes to `ScenarioRun`, `SimulationState`, `EvidenceRecord`, `ClaimRecord`, `AuditLog`
- ✅ No `Any` without justification; no `# type: ignore`
- ✅ Determinism property test: same `(seed, run_id)` produces byte-identical event tuples across runs

## Design

Two-plane execution model — see [ADR 0001](docs/adr/0001-two-plane-execution-model.md):

- **Canonical plane** (`ScenarioRun` / `EvidenceRecord` / `AuditLog`): unchanged.
- **Inspector plane** (`abdp.inspector`): observational only; enabling/disabling never affects canonical bytes.

ReviewLoopRunner (#173) will record rejected attempts on the Inspector plane via `review.attempt` events, never polluting the canonical evidence store.

## Closes

Closes #172.