### PR TITLE
feat(review): cyclic ReviewLoopRunner with two-plane execution model (#173)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@ This index is intentionally minimal. Detailed expansion is deferred to #044.
 - [ADRs](adr/README.md) — Architecture decision records and template.
 - [CLI](cli.md) — Command-line usage reference for `abdp run`, `abdp report`, and `abdp inspect`.
 - [Inspector](inspector.md) — In-process tracing layer and `abdp inspect` query CLI.
+- [Review](review.md) — Cyclic `ReviewLoopRunner` and the two-plane self-correction model.

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,0 +1,114 @@
+# Review
+
+`abdp.review` adds deterministic self-correction on top of the scenario loop.
+`ReviewLoopRunner` runs one logical step, asks a deterministic critic to score it,
+and either commits the accepted result or records the rejected attempt on the
+Inspector plane only.
+
+## Two-plane execution model
+
+Review keeps the same split introduced for Inspector:
+
+| Plane | What changes during review |
+| --- | --- |
+| **Canonical** | Only accepted or policy-selected committed outcomes become `ScenarioRun.steps` and reach downstream evidence/audit code. |
+| **Inspector** | Every rejected or accepted review attempt is emitted as `review.attempt` trace metadata. |
+
+Rejected attempts never belong in canonical evidence. They exist only so an
+operator can inspect *how* the loop arrived at the committed step.
+
+See [ADR 0001](adr/0001-two-plane-execution-model.md) for the rationale.
+
+## Public surface
+
+```python
+from abdp.review import (
+    CorrectionPolicy,
+    Critic,
+    Reviser,
+    ReviewAttempt,
+    ReviewDecision,
+    ReviewLoopRunner,
+    ReviewTrace,
+)
+```
+
+### CorrectionPolicy
+
+```python
+CorrectionPolicy(
+    max_retries=1,
+    min_score=0.8,
+    on_fail="rollback",  # Literal["rollback", "revise", "stop"]
+)
+```
+
+- `max_retries` counts additional attempts after the first proposal.
+- `min_score` is the critic threshold in `[0.0, 1.0]`.
+- `on_fail` decides the terminal outcome after retries are exhausted:
+  - `rollback` — stop without committing the rejected step.
+  - `stop` — stop without committing the rejected step, but keep the terminal
+    `review.attempt` metadata so the failure is inspectable.
+  - `revise` — commit one final deterministic revised proposal and stop.
+
+## Critic and Reviser contracts
+
+`Critic` and `Reviser` are runtime-checkable `Protocol`s.
+
+- `Critic.evaluate(step) -> ReviewDecision`
+- `Reviser.revise(attempt) -> tuple[ActionProposal, ...]`
+
+The stable contract assumes both are deterministic. For the same canonical
+state, policy, and proposal sequence, they must return the same score / revised
+proposal tuple.
+
+## ReviewLoopRunner
+
+```python
+from abdp.inspector import MemoryTraceStore, TraceRecorder
+from abdp.review import CorrectionPolicy, ReviewDecision, ReviewLoopRunner
+
+store = MemoryTraceStore()
+recorder = TraceRecorder(store=store, seed=seed, run_id="ignored-by-review")
+
+runner = ReviewLoopRunner(
+    agents=(agent,),
+    resolver=resolver,
+    max_steps=5,
+    critic=critic,
+    reviser=reviser,
+    policy=CorrectionPolicy(max_retries=1, min_score=0.8, on_fail="rollback"),
+    recorder=recorder,
+)
+run = runner.run(spec)
+```
+
+The canonical `ScenarioRun` stays deterministic and frozen. When `max_retries=0`
+and the critic accepts immediately, the canonical output is byte-identical to a
+plain `ScenarioRunner` run.
+
+## review.attempt events
+
+Each reviewed attempt is emitted as a `review.attempt` event with deterministic
+identity and a `parent_event_id` pointing to the surrounding `step.begin` event.
+
+Attributes include:
+
+- `attempt_no`
+- `accepted`
+- `score`
+- `critique`
+- `disposition` (`accept`, `retry`, `rollback`, `revise`, `stop`)
+
+The Review runner derives a stable trace run id from `(scenario, seed, policy,
+critic type, reviser type)` so repeated executions produce byte-identical trace
+event sequences even if the caller supplied a different `TraceRecorder.run_id`.
+
+## Determinism and isolation
+
+- The retry loop always restarts from the last committed `SimulationState`.
+- Rejected attempts stay in tracing only.
+- Canonical evidence can only be written by the resolver for the accepted or
+  policy-selected committed attempt.
+- For a fixed `(seed, scenario, policy, critic, reviser)` tuple, two runs
+  produce byte-identical canonical output and byte-identical trace events.

--- a/docs/review.md
+++ b/docs/review.md
@@ -46,9 +46,10 @@ CorrectionPolicy(
 - `max_retries` counts additional attempts after the first proposal.
 - `min_score` is the critic threshold in `[0.0, 1.0]`.
 - `on_fail` decides the terminal outcome after retries are exhausted:
-  - `rollback` — stop without committing the rejected step.
-  - `stop` — stop without committing the rejected step, but keep the terminal
-    `review.attempt` metadata so the failure is inspectable.
+  - `rollback` — stop without committing the rejected step; the terminal
+    `review.attempt` remains in tracing with `disposition="rollback"`.
+  - `stop` — stop without committing the rejected step; the terminal
+    `review.attempt` remains in tracing with `disposition="stop"`.
   - `revise` — commit one final deterministic revised proposal and stop.
 
 ## Critic and Reviser contracts

--- a/src/abdp/review/__init__.py
+++ b/src/abdp/review/__init__.py
@@ -1,0 +1,7 @@
+"""Public surface for the ``abdp.review`` package."""
+
+from abdp.review.policy import CorrectionPolicy
+
+globals().pop("policy", None)
+
+__all__: tuple[str, ...] = ("CorrectionPolicy",)

--- a/src/abdp/review/__init__.py
+++ b/src/abdp/review/__init__.py
@@ -4,16 +4,19 @@ from abdp.review.attempt import ReviewAttempt, ReviewDecision, ReviewTrace
 from abdp.review.critic import Critic
 from abdp.review.policy import CorrectionPolicy
 from abdp.review.reviser import Reviser
+from abdp.review.runner import ReviewLoopRunner
 
 globals().pop("attempt", None)
 globals().pop("critic", None)
 globals().pop("policy", None)
 globals().pop("reviser", None)
+globals().pop("runner", None)
 
 __all__: tuple[str, ...] = (
     "Critic",
     "CorrectionPolicy",
     "Reviser",
+    "ReviewLoopRunner",
     "ReviewAttempt",
     "ReviewDecision",
     "ReviewTrace",

--- a/src/abdp/review/__init__.py
+++ b/src/abdp/review/__init__.py
@@ -1,7 +1,14 @@
 """Public surface for the ``abdp.review`` package."""
 
+from abdp.review.attempt import ReviewAttempt, ReviewDecision, ReviewTrace
 from abdp.review.policy import CorrectionPolicy
 
+globals().pop("attempt", None)
 globals().pop("policy", None)
 
-__all__: tuple[str, ...] = ("CorrectionPolicy",)
+__all__: tuple[str, ...] = (
+    "CorrectionPolicy",
+    "ReviewAttempt",
+    "ReviewDecision",
+    "ReviewTrace",
+)

--- a/src/abdp/review/__init__.py
+++ b/src/abdp/review/__init__.py
@@ -1,13 +1,19 @@
 """Public surface for the ``abdp.review`` package."""
 
 from abdp.review.attempt import ReviewAttempt, ReviewDecision, ReviewTrace
+from abdp.review.critic import Critic
 from abdp.review.policy import CorrectionPolicy
+from abdp.review.reviser import Reviser
 
 globals().pop("attempt", None)
+globals().pop("critic", None)
 globals().pop("policy", None)
+globals().pop("reviser", None)
 
 __all__: tuple[str, ...] = (
+    "Critic",
     "CorrectionPolicy",
+    "Reviser",
     "ReviewAttempt",
     "ReviewDecision",
     "ReviewTrace",

--- a/src/abdp/review/attempt.py
+++ b/src/abdp/review/attempt.py
@@ -1,0 +1,51 @@
+"""Review attempt records for deterministic correction loops."""
+
+import math
+from dataclasses import dataclass
+
+from abdp.scenario import ScenarioStep
+
+__all__ = ["ReviewAttempt", "ReviewDecision", "ReviewTrace"]
+
+
+def _validate_index(name: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be int, got {type(value).__name__}")
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0, got {value}")
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewDecision:
+    """Critic output for one review attempt."""
+
+    score: float
+    critique: str
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.score) or not 0.0 <= self.score <= 1.0:
+            raise ValueError("score must be finite and between 0.0 and 1.0")
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewAttempt[A]:
+    """Materialized review attempt for one logical step."""
+
+    step_index: int
+    attempt_no: int
+    step: ScenarioStep
+    decision: ReviewDecision
+    accepted: bool
+
+    def __post_init__(self) -> None:
+        _validate_index("step_index", self.step_index)
+        _validate_index("attempt_no", self.attempt_no)
+        if self.step_index != self.step.state.step_index:
+            raise ValueError("step_index must match step.state.step_index")
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewTrace:
+    """Deterministic collection of review attempts for a run."""
+
+    attempts: tuple[ReviewAttempt, ...]

--- a/src/abdp/review/attempt.py
+++ b/src/abdp/review/attempt.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import dataclass
 
 from abdp.scenario import ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
 
 __all__ = ["ReviewAttempt", "ReviewDecision", "ReviewTrace"]
 
@@ -28,12 +29,12 @@ class ReviewDecision:
 
 
 @dataclass(frozen=True, slots=True)
-class ReviewAttempt[A]:
+class ReviewAttempt[A: ActionProposal]:
     """Materialized review attempt for one logical step."""
 
     step_index: int
     attempt_no: int
-    step: ScenarioStep
+    step: ScenarioStep[SegmentState, ParticipantState, A]
     decision: ReviewDecision
     accepted: bool
 
@@ -45,7 +46,7 @@ class ReviewAttempt[A]:
 
 
 @dataclass(frozen=True, slots=True)
-class ReviewTrace:
+class ReviewTrace[A: ActionProposal]:
     """Deterministic collection of review attempts for a run."""
 
-    attempts: tuple[ReviewAttempt, ...]
+    attempts: tuple[ReviewAttempt[A], ...]

--- a/src/abdp/review/critic.py
+++ b/src/abdp/review/critic.py
@@ -1,0 +1,16 @@
+"""Critic protocol for deterministic review scoring."""
+
+from typing import Protocol, runtime_checkable
+
+from abdp.review.attempt import ReviewDecision
+from abdp.scenario import ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
+
+__all__ = ["Critic"]
+
+
+@runtime_checkable
+class Critic[S: SegmentState, P: ParticipantState, A: ActionProposal](Protocol):
+    """Deterministic scorer for one proposed scenario step."""
+
+    def evaluate(self, step: ScenarioStep[S, P, A]) -> ReviewDecision: ...  # pragma: no cover

--- a/src/abdp/review/policy.py
+++ b/src/abdp/review/policy.py
@@ -1,0 +1,36 @@
+"""Correction policy for deterministic review loops."""
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = ["CorrectionMode", "CorrectionPolicy"]
+
+type CorrectionMode = Literal["rollback", "revise", "stop"]
+
+
+def _validate_max_retries(value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"max_retries must be int, got {type(value).__name__}")
+    if value < 0:
+        raise ValueError(f"max_retries must be >= 0, got {value}")
+
+
+def _validate_min_score(value: float) -> None:
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise ValueError("min_score must be finite and between 0.0 and 1.0")
+
+
+@dataclass(frozen=True, slots=True)
+class CorrectionPolicy:
+    """Deterministic retry policy for ``ReviewLoopRunner``."""
+
+    max_retries: int
+    min_score: float
+    on_fail: "Literal['rollback', 'revise', 'stop']"
+
+    def __post_init__(self) -> None:
+        _validate_max_retries(self.max_retries)
+        _validate_min_score(self.min_score)
+        if self.on_fail not in {"rollback", "revise", "stop"}:
+            raise ValueError(f"unsupported on_fail mode: {self.on_fail}")

--- a/src/abdp/review/reviser.py
+++ b/src/abdp/review/reviser.py
@@ -1,0 +1,14 @@
+"""Reviser protocol for deterministic review retries."""
+
+from typing import Protocol, runtime_checkable
+
+from abdp.review.attempt import ReviewAttempt
+
+__all__ = ["Reviser"]
+
+
+@runtime_checkable
+class Reviser[A](Protocol):
+    """Deterministic proposal reviser for a rejected attempt."""
+
+    def revise(self, attempt: ReviewAttempt[A]) -> tuple[A, ...]: ...  # pragma: no cover

--- a/src/abdp/review/reviser.py
+++ b/src/abdp/review/reviser.py
@@ -3,12 +3,13 @@
 from typing import Protocol, runtime_checkable
 
 from abdp.review.attempt import ReviewAttempt
+from abdp.simulation import ActionProposal
 
 __all__ = ["Reviser"]
 
 
 @runtime_checkable
-class Reviser[A](Protocol):
+class Reviser[A: ActionProposal](Protocol):
     """Deterministic proposal reviser for a rejected attempt."""
 
     def revise(self, attempt: ReviewAttempt[A]) -> tuple[A, ...]: ...  # pragma: no cover

--- a/src/abdp/review/runner.py
+++ b/src/abdp/review/runner.py
@@ -1,6 +1,6 @@
 """Review-loop runner that keeps rejected attempts off the canonical plane."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
 from abdp.agents import Agent, AgentContext, AgentDecision
@@ -26,9 +26,11 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
     reviser: Reviser[A]
     policy: CorrectionPolicy
     recorder: TraceRecorder | None = None
+    _active_recorder: TraceRecorder | None = field(default=None, init=False, repr=False, compare=False)
 
     def run(self, spec: ScenarioSpec[S, P, A]) -> ScenarioRun[S, P, A]:
         """Execute the scenario and commit only accepted or policy-selected steps."""
+        object.__setattr__(self, "_active_recorder", self._build_active_recorder(spec))
         state: SimulationState[S, P, A] = spec.build_initial_state()
         steps: list[ScenarioStep[S, P, A]] = []
 
@@ -54,7 +56,26 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
             if stop or state.step_index >= self.max_steps:
                 break
 
+        object.__setattr__(self, "_active_recorder", None)
         return ScenarioRun(scenario_key=spec.scenario_key, seed=spec.seed, steps=tuple(steps), final_state=state)
+
+    def _build_active_recorder(self, spec: ScenarioSpec[S, P, A]) -> TraceRecorder | None:
+        if self.recorder is None:
+            return None
+        return TraceRecorder(
+            store=self.recorder.store,
+            seed=spec.seed,
+            run_id=self._stable_run_id(spec),
+        )
+
+    def _stable_run_id(self, spec: ScenarioSpec[S, P, A]) -> str:
+        critic_name = f"{type(self.critic).__module__}.{type(self.critic).__qualname__}"
+        reviser_name = f"{type(self.reviser).__module__}.{type(self.reviser).__qualname__}"
+        return (
+            f"review:{spec.scenario_key}:{int(spec.seed)}:"
+            f"{self.policy.max_retries}:{self.policy.min_score:.17g}:{self.policy.on_fail}:"
+            f"{critic_name}:{reviser_name}"
+        )
 
     def _review_step(
         self,
@@ -175,8 +196,8 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
     ) -> TraceEvent | None:
         return (
             None
-            if self.recorder is None
-            else self.recorder.record(
+            if self._active_recorder is None
+            else self._active_recorder.record(
                 event_type=event_type,
                 step_index=step_index,
                 attributes=attributes,

--- a/src/abdp/review/runner.py
+++ b/src/abdp/review/runner.py
@@ -7,7 +7,7 @@ from abdp.agents import Agent, AgentContext, AgentDecision
 from abdp.inspector import TraceEvent, TraceRecorder
 from abdp.review.attempt import ReviewAttempt
 from abdp.review.critic import Critic
-from abdp.review.policy import CorrectionPolicy
+from abdp.review.policy import CorrectionMode, CorrectionPolicy
 from abdp.review.reviser import Reviser
 from abdp.scenario import ActionResolver, ScenarioRun, ScenarioStep
 from abdp.simulation import ActionProposal, ParticipantState, ScenarioSpec, SegmentState, SimulationState
@@ -28,7 +28,7 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
     recorder: TraceRecorder | None = None
 
     def run(self, spec: ScenarioSpec[S, P, A]) -> ScenarioRun[S, P, A]:
-        """Execute the scenario and commit only accepted steps."""
+        """Execute the scenario and commit only accepted or policy-selected steps."""
         state: SimulationState[S, P, A] = spec.build_initial_state()
         steps: list[ScenarioStep[S, P, A]] = []
 
@@ -38,37 +38,83 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
                 step_index=state.step_index,
                 attributes={"scenario_key": spec.scenario_key},
             )
-            decisions: tuple[AgentDecision[A], ...] = tuple(self._decide(agent, spec, state) for agent in self.agents)
-            emissions: tuple[A, ...] = tuple(proposal for decision in decisions for proposal in decision.proposals)
-            merged: tuple[A, ...] = state.pending_actions + emissions
-            step = ScenarioStep(state=state, decisions=decisions, proposals=merged)
-
-            if merged:
-                review = self.critic.evaluate(step)
-                attempt = ReviewAttempt(
-                    step_index=state.step_index,
-                    attempt_no=0,
-                    step=step,
-                    decision=review,
-                    accepted=review.score >= self.policy.min_score,
-                )
-                self._emit_attempt(
-                    attempt=attempt, parent_event_id=None if begin_event is None else begin_event.event_id
-                )
-
-            steps.append(step)
+            end_step, committed_step, next_state, stop = self._review_step(
+                spec=spec,
+                state=state,
+                parent_event_id=None if begin_event is None else begin_event.event_id,
+            )
             self._emit(
                 event_type="step.end",
-                step_index=state.step_index,
-                attributes={"proposals": len(merged), "decisions": len(decisions)},
+                step_index=end_step.state.step_index,
+                attributes={"proposals": len(end_step.proposals), "decisions": len(end_step.decisions)},
             )
-            if not merged:
-                break
-            state = self.resolver.resolve(state, merged)
-            if state.step_index >= self.max_steps:
+            if committed_step is not None:
+                steps.append(committed_step)
+            state = next_state
+            if stop or state.step_index >= self.max_steps:
                 break
 
         return ScenarioRun(scenario_key=spec.scenario_key, seed=spec.seed, steps=tuple(steps), final_state=state)
+
+    def _review_step(
+        self,
+        *,
+        spec: ScenarioSpec[S, P, A],
+        state: SimulationState[S, P, A],
+        parent_event_id: UUID | None,
+    ) -> tuple[ScenarioStep[S, P, A], ScenarioStep[S, P, A] | None, SimulationState[S, P, A], bool]:
+        proposals_override: tuple[A, ...] | None = None
+        attempt_no = 0
+
+        while True:
+            decisions = tuple(self._decide(agent, spec, state) for agent in self.agents)
+            emissions = tuple(proposal for decision in decisions for proposal in decision.proposals)
+            proposals = state.pending_actions + emissions if proposals_override is None else proposals_override
+            step = ScenarioStep(state=state, decisions=decisions, proposals=proposals)
+
+            if not proposals:
+                return step, step, state, True
+
+            review = self.critic.evaluate(step)
+            accepted = review.score >= self.policy.min_score
+            attempt = ReviewAttempt(
+                step_index=state.step_index,
+                attempt_no=attempt_no,
+                step=step,
+                decision=review,
+                accepted=accepted,
+            )
+            self._emit_attempt(
+                attempt=attempt,
+                disposition=self._disposition(accepted=accepted, attempt_no=attempt_no),
+                parent_event_id=parent_event_id,
+            )
+
+            if accepted:
+                return step, step, self.resolver.resolve(state, proposals), False
+
+            if attempt_no < self.policy.max_retries:
+                proposals_override = self.reviser.revise(attempt)
+                attempt_no += 1
+                continue
+
+            return self._resolve_terminal_failure(state=state, step=step, attempt=attempt)
+
+    def _resolve_terminal_failure(
+        self,
+        *,
+        state: SimulationState[S, P, A],
+        step: ScenarioStep[S, P, A],
+        attempt: ReviewAttempt[A],
+    ) -> tuple[ScenarioStep[S, P, A], ScenarioStep[S, P, A] | None, SimulationState[S, P, A], bool]:
+        mode: CorrectionMode = self.policy.on_fail
+        if mode == "rollback":
+            return step, None, state, True
+        if mode == "stop":
+            return step, None, state, True
+        revised = self.reviser.revise(attempt)
+        revised_step = ScenarioStep(state=state, decisions=step.decisions, proposals=revised)
+        return revised_step, revised_step, self.resolver.resolve(state, revised), True
 
     def _decide(
         self,
@@ -92,7 +138,20 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
         )
         return decision
 
-    def _emit_attempt(self, *, attempt: ReviewAttempt[A], parent_event_id: UUID | None) -> None:
+    def _disposition(self, *, accepted: bool, attempt_no: int) -> str:
+        if accepted:
+            return "accept"
+        if attempt_no < self.policy.max_retries:
+            return "retry"
+        return self.policy.on_fail
+
+    def _emit_attempt(
+        self,
+        *,
+        attempt: ReviewAttempt[A],
+        disposition: str,
+        parent_event_id: UUID | None,
+    ) -> None:
         self._emit(
             event_type="review.attempt",
             step_index=attempt.step_index,
@@ -101,6 +160,7 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
                 "accepted": attempt.accepted,
                 "score": attempt.decision.score,
                 "critique": attempt.decision.critique,
+                "disposition": disposition,
             },
             parent_event_id=parent_event_id,
         )

--- a/src/abdp/review/runner.py
+++ b/src/abdp/review/runner.py
@@ -182,6 +182,8 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
                 "score": attempt.decision.score,
                 "critique": attempt.decision.critique,
                 "disposition": disposition,
+                "snapshot_id": str(attempt.step.state.snapshot_ref.snapshot_id),
+                "storage_key": attempt.step.state.snapshot_ref.storage_key,
             },
             parent_event_id=parent_event_id,
         )

--- a/src/abdp/review/runner.py
+++ b/src/abdp/review/runner.py
@@ -98,7 +98,7 @@ class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
 
             review = self.critic.evaluate(step)
             accepted = review.score >= self.policy.min_score
-            attempt = ReviewAttempt(
+            attempt: ReviewAttempt[A] = ReviewAttempt(
                 step_index=state.step_index,
                 attempt_no=attempt_no,
                 step=step,

--- a/src/abdp/review/runner.py
+++ b/src/abdp/review/runner.py
@@ -1,0 +1,125 @@
+"""Review-loop runner that keeps rejected attempts off the canonical plane."""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from abdp.agents import Agent, AgentContext, AgentDecision
+from abdp.inspector import TraceEvent, TraceRecorder
+from abdp.review.attempt import ReviewAttempt
+from abdp.review.critic import Critic
+from abdp.review.policy import CorrectionPolicy
+from abdp.review.reviser import Reviser
+from abdp.scenario import ActionResolver, ScenarioRun, ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, ScenarioSpec, SegmentState, SimulationState
+
+__all__ = ["ReviewLoopRunner"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewLoopRunner[S: SegmentState, P: ParticipantState, A: ActionProposal]:
+    """Scenario runner with a deterministic critic and reviser hook."""
+
+    agents: tuple[Agent[S, P, A], ...]
+    resolver: ActionResolver[S, P, A]
+    max_steps: int
+    critic: Critic[S, P, A]
+    reviser: Reviser[A]
+    policy: CorrectionPolicy
+    recorder: TraceRecorder | None = None
+
+    def run(self, spec: ScenarioSpec[S, P, A]) -> ScenarioRun[S, P, A]:
+        """Execute the scenario and commit only accepted steps."""
+        state: SimulationState[S, P, A] = spec.build_initial_state()
+        steps: list[ScenarioStep[S, P, A]] = []
+
+        while state.step_index < self.max_steps:
+            begin_event = self._emit(
+                event_type="step.begin",
+                step_index=state.step_index,
+                attributes={"scenario_key": spec.scenario_key},
+            )
+            decisions: tuple[AgentDecision[A], ...] = tuple(self._decide(agent, spec, state) for agent in self.agents)
+            emissions: tuple[A, ...] = tuple(proposal for decision in decisions for proposal in decision.proposals)
+            merged: tuple[A, ...] = state.pending_actions + emissions
+            step = ScenarioStep(state=state, decisions=decisions, proposals=merged)
+
+            if merged:
+                review = self.critic.evaluate(step)
+                attempt = ReviewAttempt(
+                    step_index=state.step_index,
+                    attempt_no=0,
+                    step=step,
+                    decision=review,
+                    accepted=review.score >= self.policy.min_score,
+                )
+                self._emit_attempt(
+                    attempt=attempt, parent_event_id=None if begin_event is None else begin_event.event_id
+                )
+
+            steps.append(step)
+            self._emit(
+                event_type="step.end",
+                step_index=state.step_index,
+                attributes={"proposals": len(merged), "decisions": len(decisions)},
+            )
+            if not merged:
+                break
+            state = self.resolver.resolve(state, merged)
+            if state.step_index >= self.max_steps:
+                break
+
+        return ScenarioRun(scenario_key=spec.scenario_key, seed=spec.seed, steps=tuple(steps), final_state=state)
+
+    def _decide(
+        self,
+        agent: Agent[S, P, A],
+        spec: ScenarioSpec[S, P, A],
+        state: SimulationState[S, P, A],
+    ) -> AgentDecision[A]:
+        decision = agent.decide(
+            AgentContext(
+                scenario_key=spec.scenario_key,
+                agent_id=agent.agent_id,
+                step_index=state.step_index,
+                seed=state.seed,
+                state=state,
+            )
+        )
+        self._emit(
+            event_type="decision.evaluate",
+            step_index=state.step_index,
+            attributes={"agent_id": agent.agent_id, "proposals": len(decision.proposals)},
+        )
+        return decision
+
+    def _emit_attempt(self, *, attempt: ReviewAttempt[A], parent_event_id: UUID | None) -> None:
+        self._emit(
+            event_type="review.attempt",
+            step_index=attempt.step_index,
+            attributes={
+                "attempt_no": attempt.attempt_no,
+                "accepted": attempt.accepted,
+                "score": attempt.decision.score,
+                "critique": attempt.decision.critique,
+            },
+            parent_event_id=parent_event_id,
+        )
+
+    def _emit(
+        self,
+        *,
+        event_type: str,
+        step_index: int,
+        attributes: dict[str, str | int | float | bool],
+        parent_event_id: UUID | None = None,
+    ) -> TraceEvent | None:
+        return (
+            None
+            if self.recorder is None
+            else self.recorder.record(
+                event_type=event_type,
+                step_index=step_index,
+                attributes=attributes,
+                parent_event_id=parent_event_id,
+            )
+        )

--- a/tests/meta/test_docs_scaffold.py
+++ b/tests/meta/test_docs_scaffold.py
@@ -15,7 +15,7 @@ README_PATHS: tuple[Path, ...] = (
     ADR_README_PATH,
 )
 
-MAX_DOCS_INDEX_LINES = 11
+MAX_DOCS_INDEX_LINES = 12
 MAX_SUBSECTION_README_LINES = 10
 MAX_EXAMPLES_INDEX_LINES = 80
 
@@ -28,6 +28,7 @@ EXPECTED_DOCS_INDEX_SNIPPETS = (
     "- [ADRs](adr/README.md) — Architecture decision records and template.",
     "- [CLI](cli.md) — Command-line usage reference for `abdp run`, `abdp report`, and `abdp inspect`.",
     "- [Inspector](inspector.md) — In-process tracing layer and `abdp inspect` query CLI.",
+    "- [Review](review.md) — Cyclic `ReviewLoopRunner` and the two-plane self-correction model.",
 )
 
 EXPECTED_SUBSECTION_TITLES: tuple[tuple[Path, str], ...] = (

--- a/tests/review/test_attempt.py
+++ b/tests/review/test_attempt.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Protocol, cast
+from uuid import UUID
+
+import pytest
+
+from abdp.agents import AgentDecision
+from abdp.core import Seed
+from abdp.review.attempt import ReviewAttempt, ReviewDecision, ReviewTrace
+from abdp.scenario import ScenarioStep
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: None
+
+
+@dataclass(frozen=True, slots=True)
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+def _step(step_index: int = 0) -> ScenarioStep[SegmentState, ParticipantState, _Action]:
+    action = _Action(proposal_id="proposal-1", actor_id="agent-1", action_key="noop", payload=None)
+    state = SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=Seed(7),
+        snapshot_ref=SnapshotRef(snapshot_id=UUID(int=1), tier="bronze", storage_key="snapshots/1"),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+    decision: AgentDecision[_Action] = _Decision(agent_id="agent-1", proposals=(action,))
+    return ScenarioStep(state=state, decisions=(decision,), proposals=(action,))
+
+
+def test_review_decision_is_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(ReviewDecision, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(ReviewDecision)
+    assert params.frozen is True
+    assert "__slots__" in ReviewDecision.__dict__
+
+
+def test_review_attempt_is_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(ReviewAttempt, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(ReviewAttempt)
+    assert params.frozen is True
+    assert "__slots__" in ReviewAttempt.__dict__
+
+
+def test_review_trace_is_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(ReviewTrace, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(ReviewTrace)
+    assert params.frozen is True
+    assert "__slots__" in ReviewTrace.__dict__
+
+
+def test_review_decision_declares_expected_fields() -> None:
+    fields = {field.name: field.type for field in dataclasses.fields(ReviewDecision)}
+
+    assert fields == {"score": float, "critique": str}
+
+
+def test_review_attempt_declares_expected_fields() -> None:
+    fields = {field.name: field.type for field in dataclasses.fields(ReviewAttempt)}
+
+    assert fields == {
+        "step_index": int,
+        "attempt_no": int,
+        "step": ScenarioStep,
+        "decision": ReviewDecision,
+        "accepted": bool,
+    }
+
+
+def test_review_trace_declares_attempts_field() -> None:
+    fields = {field.name: field.type for field in dataclasses.fields(ReviewTrace)}
+
+    assert fields == {"attempts": tuple[ReviewAttempt, ...]}
+
+
+def test_review_decision_accepts_finite_score() -> None:
+    decision = ReviewDecision(score=0.75, critique="accepted")
+
+    assert decision.score == 0.75
+    assert decision.critique == "accepted"
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, float("nan"), float("inf")])
+def test_review_decision_rejects_invalid_score(value: float) -> None:
+    with pytest.raises(ValueError):
+        ReviewDecision(score=value, critique="bad")
+
+
+@pytest.mark.parametrize("value", [-1, True])
+def test_review_attempt_rejects_invalid_attempt_no(value: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        ReviewAttempt(step_index=0, attempt_no=value, step=_step(), decision=ReviewDecision(0.5, "x"), accepted=False)
+
+
+def test_review_attempt_rejects_step_index_mismatch() -> None:
+    with pytest.raises(ValueError):
+        ReviewAttempt(
+            step_index=3,
+            attempt_no=0,
+            step=_step(step_index=2),
+            decision=ReviewDecision(0.5, "x"),
+            accepted=False,
+        )
+
+
+def test_review_trace_preserves_deterministic_equality() -> None:
+    attempt = ReviewAttempt(
+        step_index=0,
+        attempt_no=1,
+        step=_step(),
+        decision=ReviewDecision(0.25, "retry"),
+        accepted=False,
+    )
+
+    assert attempt == ReviewAttempt(
+        step_index=0,
+        attempt_no=1,
+        step=_step(),
+        decision=ReviewDecision(0.25, "retry"),
+        accepted=False,
+    )
+    assert ReviewTrace(attempts=(attempt,)) == ReviewTrace(attempts=(attempt,))

--- a/tests/review/test_attempt.py
+++ b/tests/review/test_attempt.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Protocol, cast
+from typing import Protocol, cast, get_args, get_origin
 from uuid import UUID
 
 import pytest
 
-from abdp.agents import AgentDecision
 from abdp.core import Seed
 from abdp.review.attempt import ReviewAttempt, ReviewDecision, ReviewTrace
 from abdp.scenario import ScenarioStep
@@ -27,7 +26,7 @@ class _Action:
     payload: None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _Decision:
     agent_id: str
     proposals: tuple[_Action, ...]
@@ -43,7 +42,7 @@ def _step(step_index: int = 0) -> ScenarioStep[SegmentState, ParticipantState, _
         participants=(),
         pending_actions=(),
     )
-    decision: AgentDecision[_Action] = _Decision(agent_id="agent-1", proposals=(action,))
+    decision = _Decision(agent_id="agent-1", proposals=(action,))
     return ScenarioStep(state=state, decisions=(decision,), proposals=(action,))
 
 
@@ -80,19 +79,18 @@ def test_review_decision_declares_expected_fields() -> None:
 def test_review_attempt_declares_expected_fields() -> None:
     fields = {field.name: field.type for field in dataclasses.fields(ReviewAttempt)}
 
-    assert fields == {
-        "step_index": int,
-        "attempt_no": int,
-        "step": ScenarioStep,
-        "decision": ReviewDecision,
-        "accepted": bool,
-    }
+    assert fields["step_index"] is int
+    assert fields["attempt_no"] is int
+    assert get_origin(fields["step"]) is ScenarioStep
+    assert fields["decision"] is ReviewDecision
+    assert fields["accepted"] is bool
 
 
 def test_review_trace_declares_attempts_field() -> None:
     fields = {field.name: field.type for field in dataclasses.fields(ReviewTrace)}
 
-    assert fields == {"attempts": tuple[ReviewAttempt, ...]}
+    assert get_origin(fields["attempts"]) is tuple
+    assert get_origin(get_args(fields["attempts"])[0]) is ReviewAttempt
 
 
 def test_review_decision_accepts_finite_score() -> None:
@@ -111,7 +109,13 @@ def test_review_decision_rejects_invalid_score(value: float) -> None:
 @pytest.mark.parametrize("value", [-1, True])
 def test_review_attempt_rejects_invalid_attempt_no(value: object) -> None:
     with pytest.raises((TypeError, ValueError)):
-        ReviewAttempt(step_index=0, attempt_no=value, step=_step(), decision=ReviewDecision(0.5, "x"), accepted=False)
+        ReviewAttempt(
+            step_index=0,
+            attempt_no=cast(int, value),
+            step=_step(),
+            decision=ReviewDecision(0.5, "x"),
+            accepted=False,
+        )
 
 
 def test_review_attempt_rejects_step_index_mismatch() -> None:
@@ -126,7 +130,7 @@ def test_review_attempt_rejects_step_index_mismatch() -> None:
 
 
 def test_review_trace_preserves_deterministic_equality() -> None:
-    attempt = ReviewAttempt(
+    attempt: ReviewAttempt[_Action] = ReviewAttempt(
         step_index=0,
         attempt_no=1,
         step=_step(),

--- a/tests/review/test_correction.py
+++ b/tests/review/test_correction.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from uuid import UUID
+
+from abdp.agents import AgentContext, AgentDecision
+from abdp.core import JsonValue, Seed
+from abdp.review import CorrectionPolicy, ReviewAttempt, ReviewDecision, ReviewLoopRunner
+from abdp.scenario import ScenarioStep
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+_State = SimulationState[SegmentState, ParticipantState, _Action]
+_SEED = Seed(7)
+
+
+@dataclass(frozen=True, slots=True)
+class _Spec:
+    scenario_key: str
+    seed: Seed
+    initial: _State
+
+    def build_initial_state(self) -> _State:
+        return self.initial
+
+
+@dataclass
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+@dataclass
+class _Agent:
+    agent_id: str
+    proposals_to_emit: tuple[_Action, ...]
+    seen_states: list[_State] = dataclasses.field(default_factory=list)
+
+    def decide(self, context: AgentContext[SegmentState, ParticipantState, _Action]) -> AgentDecision[_Action]:
+        self.seen_states.append(context.state)
+        return _Decision(agent_id=self.agent_id, proposals=self.proposals_to_emit)
+
+
+@dataclass
+class _Resolver:
+    received: list[tuple[_State, tuple[_Action, ...]]] = dataclasses.field(default_factory=list)
+
+    def resolve(self, state: _State, proposals: tuple[_Action, ...]) -> _State:
+        self.received.append((state, proposals))
+        return _make_state(step_index=state.step_index + 1, snapshot_suffix=state.step_index + 2)
+
+
+@dataclass
+class _ScoreCritic:
+    scores: dict[str, float]
+    seen_steps: list[ScenarioStep[SegmentState, ParticipantState, _Action]] = dataclasses.field(default_factory=list)
+
+    def evaluate(self, step: ScenarioStep[SegmentState, ParticipantState, _Action]) -> ReviewDecision:
+        self.seen_steps.append(step)
+        proposal_id = step.proposals[0].proposal_id
+        return ReviewDecision(score=self.scores[proposal_id], critique=proposal_id)
+
+
+@dataclass
+class _Reviser:
+    revised: tuple[_Action, ...]
+    seen_attempts: list[ReviewAttempt[_Action]] = dataclasses.field(default_factory=list)
+
+    def revise(self, attempt: ReviewAttempt[_Action]) -> tuple[_Action, ...]:
+        self.seen_attempts.append(attempt)
+        return self.revised
+
+
+def _make_state(*, step_index: int = 0, snapshot_suffix: int = 1) -> _State:
+    return SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=_SEED,
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID(int=snapshot_suffix), tier="bronze", storage_key=f"snapshots/{snapshot_suffix}"
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _action(name: str) -> _Action:
+    return _Action(proposal_id=name, actor_id="agent-1", action_key="noop", payload=None)
+
+
+def test_review_loop_runner_retries_until_a_revised_attempt_is_accepted() -> None:
+    initial = _make_state(step_index=0)
+    spec = _Spec(scenario_key="retry", seed=_SEED, initial=initial)
+    agent = _Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),))
+    resolver = _Resolver()
+    critic = _ScoreCritic(scores={"initial": 0.2, "revised": 0.9})
+    reviser = _Reviser(revised=(_action("revised"),))
+    runner = ReviewLoopRunner(
+        agents=(agent,),
+        resolver=resolver,
+        max_steps=1,
+        critic=critic,
+        reviser=reviser,
+        policy=CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="stop"),
+    )
+
+    run = runner.run(spec)
+
+    assert [proposal.proposal_id for proposal in run.steps[0].proposals] == ["revised"]
+    assert [proposal.proposal_id for _, proposals in resolver.received for proposal in proposals] == ["revised"]
+    assert [step.proposals[0].proposal_id for step in critic.seen_steps] == ["initial", "revised"]
+
+
+def test_review_loop_runner_retries_from_the_same_committed_state() -> None:
+    initial = _make_state(step_index=0, snapshot_suffix=99)
+    spec = _Spec(scenario_key="rollback", seed=_SEED, initial=initial)
+    agent = _Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),))
+    resolver = _Resolver()
+    critic = _ScoreCritic(scores={"initial": 0.2, "revised": 0.2})
+    reviser = _Reviser(revised=(_action("revised"),))
+    runner = ReviewLoopRunner(
+        agents=(agent,),
+        resolver=resolver,
+        max_steps=1,
+        critic=critic,
+        reviser=reviser,
+        policy=CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="rollback"),
+    )
+
+    runner.run(spec)
+
+    snapshots = [step.state.snapshot_ref.snapshot_id for step in critic.seen_steps]
+    assert snapshots == [UUID(int=99), UUID(int=99)]
+
+
+def test_review_loop_runner_rolls_back_after_terminal_failure() -> None:
+    initial = _make_state(step_index=0)
+    spec = _Spec(scenario_key="rollback-fail", seed=_SEED, initial=initial)
+    runner = ReviewLoopRunner(
+        agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
+        resolver=_Resolver(),
+        max_steps=1,
+        critic=_ScoreCritic(scores={"initial": 0.1, "revised": 0.1}),
+        reviser=_Reviser(revised=(_action("revised"),)),
+        policy=CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="rollback"),
+    )
+
+    run = runner.run(spec)
+
+    assert run.steps == ()
+    assert run.final_state == initial
+
+
+def test_review_loop_runner_stop_policy_stops_without_committing_rejected_attempt() -> None:
+    initial = _make_state(step_index=0)
+    spec = _Spec(scenario_key="stop", seed=_SEED, initial=initial)
+    resolver = _Resolver()
+    runner = ReviewLoopRunner(
+        agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
+        resolver=resolver,
+        max_steps=3,
+        critic=_ScoreCritic(scores={"initial": 0.1}),
+        reviser=_Reviser(revised=(_action("revised"),)),
+        policy=CorrectionPolicy(max_retries=0, min_score=0.5, on_fail="stop"),
+    )
+
+    run = runner.run(spec)
+
+    assert run.steps == ()
+    assert resolver.received == []
+    assert run.final_state == initial
+
+
+def test_review_loop_runner_revise_policy_commits_revised_attempt_after_terminal_failure() -> None:
+    initial = _make_state(step_index=0)
+    spec = _Spec(scenario_key="revise", seed=_SEED, initial=initial)
+    resolver = _Resolver()
+    reviser = _Reviser(revised=(_action("revised"),))
+    runner = ReviewLoopRunner(
+        agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
+        resolver=resolver,
+        max_steps=3,
+        critic=_ScoreCritic(scores={"initial": 0.1}),
+        reviser=reviser,
+        policy=CorrectionPolicy(max_retries=0, min_score=0.5, on_fail="revise"),
+    )
+
+    run = runner.run(spec)
+
+    assert [proposal.proposal_id for proposal in run.steps[0].proposals] == ["revised"]
+    assert [proposal.proposal_id for _, proposals in resolver.received for proposal in proposals] == ["revised"]
+    assert len(reviser.seen_attempts) == 1

--- a/tests/review/test_determinism.py
+++ b/tests/review/test_determinism.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from abdp.agents import AgentContext, AgentDecision
+from abdp.core import JsonValue, Seed
+from abdp.inspector import MemoryTraceStore, TraceEvent, TraceRecorder
+from abdp.review import CorrectionPolicy, ReviewAttempt, ReviewDecision, ReviewLoopRunner
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+_State = SimulationState[SegmentState, ParticipantState, _Action]
+_SEED = Seed(7)
+
+
+@dataclass(frozen=True, slots=True)
+class _Spec:
+    scenario_key: str
+    seed: Seed
+    initial: _State
+
+    def build_initial_state(self) -> _State:
+        return self.initial
+
+
+@dataclass
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+@dataclass
+class _Agent:
+    agent_id: str
+    proposals_to_emit: tuple[_Action, ...]
+
+    def decide(self, context: AgentContext[SegmentState, ParticipantState, _Action]) -> AgentDecision[_Action]:
+        return _Decision(agent_id=self.agent_id, proposals=self.proposals_to_emit)
+
+
+@dataclass
+class _Resolver:
+    def resolve(self, state: _State, proposals: tuple[_Action, ...]) -> _State:
+        return _make_state(step_index=state.step_index + 1, snapshot_suffix=state.step_index + 2)
+
+
+@dataclass
+class _Critic:
+    scores: dict[str, float]
+
+    def evaluate(self, step: object) -> ReviewDecision:
+        proposal_id = step.proposals[0].proposal_id
+        return ReviewDecision(score=self.scores[proposal_id], critique=proposal_id)
+
+
+@dataclass
+class _Reviser:
+    revised: tuple[_Action, ...]
+
+    def revise(self, attempt: ReviewAttempt[_Action]) -> tuple[_Action, ...]:
+        return self.revised
+
+
+def _make_state(*, step_index: int = 0, snapshot_suffix: int = 1) -> _State:
+    return SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=_SEED,
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID(int=snapshot_suffix), tier="bronze", storage_key=f"snapshots/{snapshot_suffix}"
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _action(name: str) -> _Action:
+    return _Action(proposal_id=name, actor_id="agent-1", action_key="noop", payload=None)
+
+
+def _event_tuple(event: TraceEvent) -> tuple[object, ...]:
+    return (
+        event.event_id,
+        event.run_id,
+        event.seq,
+        event.step_index,
+        event.event_type,
+        tuple(sorted(event.attributes.items())),
+        event.timestamp_ns,
+        event.parent_event_id,
+    )
+
+
+def _execute(run_id: str) -> tuple[object, tuple[tuple[object, ...], ...]]:
+    store = MemoryTraceStore()
+    recorder = TraceRecorder(store=store, seed=_SEED, run_id=run_id)
+    runner = ReviewLoopRunner(
+        agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
+        resolver=_Resolver(),
+        max_steps=1,
+        critic=_Critic(scores={"initial": 0.2, "revised": 0.9}),
+        reviser=_Reviser(revised=(_action("revised"),)),
+        policy=CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="stop"),
+        recorder=recorder,
+    )
+    run = runner.run(_Spec(scenario_key="determinism", seed=_SEED, initial=_make_state()))
+    actual_run_id = tuple(store.runs())[0]
+    return run, tuple(_event_tuple(event) for event in store.query(run_id=actual_run_id))
+
+
+def test_review_loop_runner_produces_byte_identical_run_and_trace_sequences() -> None:
+    run_a, events_a = _execute("run-a")
+    run_b, events_b = _execute("run-b")
+
+    assert run_a == run_b
+    assert events_a == events_b

--- a/tests/review/test_determinism.py
+++ b/tests/review/test_determinism.py
@@ -7,6 +7,7 @@ from abdp.agents import AgentContext, AgentDecision
 from abdp.core import JsonValue, Seed
 from abdp.inspector import MemoryTraceStore, TraceEvent, TraceRecorder
 from abdp.review import CorrectionPolicy, ReviewAttempt, ReviewDecision, ReviewLoopRunner
+from abdp.scenario import ScenarioStep
 from abdp.simulation import ParticipantState, SegmentState, SimulationState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
@@ -58,7 +59,7 @@ class _Resolver:
 class _Critic:
     scores: dict[str, float]
 
-    def evaluate(self, step: object) -> ReviewDecision:
+    def evaluate(self, step: ScenarioStep[SegmentState, ParticipantState, _Action]) -> ReviewDecision:
         proposal_id = step.proposals[0].proposal_id
         return ReviewDecision(score=self.scores[proposal_id], critique=proposal_id)
 

--- a/tests/review/test_isolation.py
+++ b/tests/review/test_isolation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from abdp.agents import AgentContext, AgentDecision
+from abdp.core import JsonValue, Seed
+from abdp.evidence import InMemoryEvidenceStore, make_evidence_record
+from abdp.inspector import MemoryTraceStore, TraceRecorder
+from abdp.review import CorrectionPolicy, ReviewAttempt, ReviewDecision, ReviewLoopRunner
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+_State = SimulationState[SegmentState, ParticipantState, _Action]
+_SEED = Seed(7)
+
+
+@dataclass(frozen=True, slots=True)
+class _Spec:
+    scenario_key: str
+    seed: Seed
+    initial: _State
+
+    def build_initial_state(self) -> _State:
+        return self.initial
+
+
+@dataclass
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+@dataclass
+class _Agent:
+    agent_id: str
+    proposals_to_emit: tuple[_Action, ...]
+
+    def decide(self, context: AgentContext[SegmentState, ParticipantState, _Action]) -> AgentDecision[_Action]:
+        return _Decision(agent_id=self.agent_id, proposals=self.proposals_to_emit)
+
+
+@dataclass
+class _EvidenceResolver:
+    evidence_store: InMemoryEvidenceStore[SegmentState, ParticipantState, _Action]
+
+    def resolve(self, state: _State, proposals: tuple[_Action, ...]) -> _State:
+        for proposal in proposals:
+            self.evidence_store.record(
+                make_evidence_record(
+                    seed=state.seed,
+                    evidence_key=proposal.proposal_id,
+                    step_index=state.step_index,
+                    agent_id=proposal.actor_id,
+                    payload={"proposal_id": proposal.proposal_id},
+                    created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                )
+            )
+        return _make_state(step_index=state.step_index + 1, snapshot_suffix=state.step_index + 2)
+
+
+@dataclass
+class _Critic:
+    scores: dict[str, float]
+
+    def evaluate(self, step: object) -> ReviewDecision:
+        proposal_id = step.proposals[0].proposal_id
+        return ReviewDecision(score=self.scores[proposal_id], critique=proposal_id)
+
+
+@dataclass
+class _Reviser:
+    revised: tuple[_Action, ...]
+
+    def revise(self, attempt: ReviewAttempt[_Action]) -> tuple[_Action, ...]:
+        return self.revised
+
+
+def _make_state(*, step_index: int = 0, snapshot_suffix: int = 1) -> _State:
+    return SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=_SEED,
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID(int=snapshot_suffix), tier="bronze", storage_key=f"snapshots/{snapshot_suffix}"
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=(),
+    )
+
+
+def _action(name: str) -> _Action:
+    return _Action(proposal_id=name, actor_id="agent-1", action_key="noop", payload=None)
+
+
+def test_rejected_stop_attempts_stay_out_of_the_canonical_evidence_store() -> None:
+    trace_store = MemoryTraceStore()
+    evidence_store = InMemoryEvidenceStore[SegmentState, ParticipantState, _Action]()
+    runner = ReviewLoopRunner(
+        agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
+        resolver=_EvidenceResolver(evidence_store=evidence_store),
+        max_steps=1,
+        critic=_Critic(scores={"initial": 0.1}),
+        reviser=_Reviser(revised=(_action("revised"),)),
+        policy=CorrectionPolicy(max_retries=0, min_score=0.5, on_fail="stop"),
+        recorder=TraceRecorder(store=trace_store, seed=_SEED, run_id="ignored"),
+    )
+
+    run = runner.run(_Spec(scenario_key="isolation-stop", seed=_SEED, initial=_make_state()))
+
+    run_id = tuple(trace_store.runs())[0]
+    attempts = tuple(trace_store.query(run_id=run_id, event_type="review.attempt"))
+    assert [attempt.attributes["accepted"] for attempt in attempts] == [False]
+    assert run.steps == ()
+    assert evidence_store.evidence() == ()
+
+
+def test_rejected_attempts_live_in_inspector_plane_but_accepted_retry_is_canonical() -> None:
+    trace_store = MemoryTraceStore()
+    evidence_store = InMemoryEvidenceStore[SegmentState, ParticipantState, _Action]()
+    runner = ReviewLoopRunner(
+        agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
+        resolver=_EvidenceResolver(evidence_store=evidence_store),
+        max_steps=1,
+        critic=_Critic(scores={"initial": 0.2, "revised": 0.9}),
+        reviser=_Reviser(revised=(_action("revised"),)),
+        policy=CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="rollback"),
+        recorder=TraceRecorder(store=trace_store, seed=_SEED, run_id="ignored"),
+    )
+
+    run = runner.run(_Spec(scenario_key="isolation-retry", seed=_SEED, initial=_make_state()))
+
+    run_id = tuple(trace_store.runs())[0]
+    begin_event = tuple(trace_store.query(run_id=run_id, event_type="step.begin"))[0]
+    attempts = tuple(trace_store.query(run_id=run_id, event_type="review.attempt"))
+    assert [attempt.attributes["accepted"] for attempt in attempts] == [False, True]
+    assert all(attempt.parent_event_id == begin_event.event_id for attempt in attempts)
+    assert [proposal.proposal_id for proposal in run.steps[0].proposals] == ["revised"]
+    assert [record.evidence_key for record in evidence_store.evidence()] == ["revised"]

--- a/tests/review/test_isolation.py
+++ b/tests/review/test_isolation.py
@@ -129,6 +129,7 @@ def test_rejected_stop_attempts_stay_out_of_the_canonical_evidence_store() -> No
 def test_rejected_attempts_live_in_inspector_plane_but_accepted_retry_is_canonical() -> None:
     trace_store = MemoryTraceStore()
     evidence_store = InMemoryEvidenceStore[SegmentState, ParticipantState, _Action]()
+    initial = _make_state(snapshot_suffix=77)
     runner = ReviewLoopRunner(
         agents=(_Agent(agent_id="agent-1", proposals_to_emit=(_action("initial"),)),),
         resolver=_EvidenceResolver(evidence_store=evidence_store),
@@ -139,12 +140,16 @@ def test_rejected_attempts_live_in_inspector_plane_but_accepted_retry_is_canonic
         recorder=TraceRecorder(store=trace_store, seed=_SEED, run_id="ignored"),
     )
 
-    run = runner.run(_Spec(scenario_key="isolation-retry", seed=_SEED, initial=_make_state()))
+    run = runner.run(_Spec(scenario_key="isolation-retry", seed=_SEED, initial=initial))
 
     run_id = tuple(trace_store.runs())[0]
     begin_event = tuple(trace_store.query(run_id=run_id, event_type="step.begin"))[0]
     attempts = tuple(trace_store.query(run_id=run_id, event_type="review.attempt"))
     assert [attempt.attributes["accepted"] for attempt in attempts] == [False, True]
     assert all(attempt.parent_event_id == begin_event.event_id for attempt in attempts)
+    assert [attempt.attributes["snapshot_id"] for attempt in attempts] == [
+        str(initial.snapshot_ref.snapshot_id),
+        str(initial.snapshot_ref.snapshot_id),
+    ]
     assert [proposal.proposal_id for proposal in run.steps[0].proposals] == ["revised"]
     assert [record.evidence_key for record in evidence_store.evidence()] == ["revised"]

--- a/tests/review/test_isolation.py
+++ b/tests/review/test_isolation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import UUID
@@ -10,6 +9,7 @@ from abdp.core import JsonValue, Seed
 from abdp.evidence import InMemoryEvidenceStore, make_evidence_record
 from abdp.inspector import MemoryTraceStore, TraceRecorder
 from abdp.review import CorrectionPolicy, ReviewAttempt, ReviewDecision, ReviewLoopRunner
+from abdp.scenario import ScenarioStep
 from abdp.simulation import ParticipantState, SegmentState, SimulationState
 from abdp.simulation.snapshot_ref import SnapshotRef
 
@@ -74,7 +74,7 @@ class _EvidenceResolver:
 class _Critic:
     scores: dict[str, float]
 
-    def evaluate(self, step: object) -> ReviewDecision:
+    def evaluate(self, step: ScenarioStep[SegmentState, ParticipantState, _Action]) -> ReviewDecision:
         proposal_id = step.proposals[0].proposal_id
         return ReviewDecision(score=self.scores[proposal_id], critique=proposal_id)
 

--- a/tests/review/test_parity.py
+++ b/tests/review/test_parity.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from uuid import UUID
+
+from abdp.agents import AgentContext, AgentDecision
+from abdp.core import JsonValue, Seed
+from abdp.review import CorrectionPolicy, ReviewDecision, ReviewLoopRunner
+from abdp.scenario import ScenarioRunner
+from abdp.simulation import ParticipantState, SegmentState, SimulationState
+from abdp.simulation.snapshot_ref import SnapshotRef
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: JsonValue
+
+
+_State = SimulationState[SegmentState, ParticipantState, _Action]
+
+
+@dataclass(frozen=True, slots=True)
+class _Spec:
+    scenario_key: str
+    seed: Seed
+    initial: _State
+
+    def build_initial_state(self) -> _State:
+        return self.initial
+
+
+@dataclass
+class _Decision:
+    agent_id: str
+    proposals: tuple[_Action, ...]
+
+
+@dataclass
+class _RecordingAgent:
+    agent_id: str
+    proposals_to_emit: tuple[_Action, ...]
+    seen_contexts: list[AgentContext[SegmentState, ParticipantState, _Action]] = dataclasses.field(default_factory=list)
+
+    def decide(
+        self,
+        context: AgentContext[SegmentState, ParticipantState, _Action],
+    ) -> AgentDecision[_Action]:
+        self.seen_contexts.append(context)
+        return _Decision(agent_id=self.agent_id, proposals=self.proposals_to_emit)
+
+
+@dataclass
+class _RecordingResolver:
+    received: list[tuple[int, tuple[_Action, ...]]] = dataclasses.field(default_factory=list)
+
+    def resolve(
+        self,
+        state: _State,
+        proposals: tuple[_Action, ...],
+    ) -> _State:
+        self.received.append((state.step_index, proposals))
+        return _make_state(step_index=state.step_index + 1, pending=(), snapshot_suffix=state.step_index + 2)
+
+
+@dataclass(frozen=True, slots=True)
+class _AcceptingCritic:
+    def evaluate(self, step: object) -> ReviewDecision:
+        return ReviewDecision(score=1.0, critique="accept")
+
+
+@dataclass(frozen=True, slots=True)
+class _PassThroughReviser:
+    def revise(self, attempt: object) -> tuple[_Action, ...]:
+        return ()
+
+
+def _make_state(
+    *,
+    step_index: int = 0,
+    pending: tuple[_Action, ...] = (),
+    snapshot_suffix: int = 1,
+    seed: Seed = Seed(7),
+) -> _State:
+    return SimulationState[SegmentState, ParticipantState, _Action](
+        step_index=step_index,
+        seed=seed,
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID(int=snapshot_suffix), tier="bronze", storage_key=f"snapshots/{snapshot_suffix}"
+        ),
+        segments=(),
+        participants=(),
+        pending_actions=pending,
+    )
+
+
+def _make_action(suffix: str) -> _Action:
+    return _Action(proposal_id=f"p-{suffix}", actor_id=f"a-{suffix}", action_key="noop", payload=None)
+
+
+def test_review_loop_runner_with_zero_retries_matches_scenario_runner() -> None:
+    initial = _make_state(step_index=0, pending=())
+    spec = _Spec(scenario_key="parity", seed=Seed(7), initial=initial)
+    agent = _RecordingAgent(agent_id="agent-1", proposals_to_emit=(_make_action("x"),))
+    resolver = _RecordingResolver()
+    scenario_runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=3)
+    review_runner = ReviewLoopRunner(
+        agents=(agent,),
+        resolver=resolver,
+        max_steps=3,
+        critic=_AcceptingCritic(),
+        reviser=_PassThroughReviser(),
+        policy=CorrectionPolicy(max_retries=0, min_score=0.0, on_fail="stop"),
+    )
+
+    assert review_runner.run(spec) == scenario_runner.run(spec)

--- a/tests/review/test_parity.py
+++ b/tests/review/test_parity.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from abdp.agents import AgentContext, AgentDecision
 from abdp.core import JsonValue, Seed
+from abdp.inspector import MemoryTraceStore, TraceRecorder
 from abdp.review import CorrectionPolicy, ReviewDecision, ReviewLoopRunner
 from abdp.scenario import ScenarioRunner
 from abdp.simulation import ParticipantState, SegmentState, SimulationState
@@ -21,6 +22,7 @@ class _Action:
 
 
 _State = SimulationState[SegmentState, ParticipantState, _Action]
+_SEED = Seed(7)
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,7 +85,7 @@ def _make_state(
     step_index: int = 0,
     pending: tuple[_Action, ...] = (),
     snapshot_suffix: int = 1,
-    seed: Seed = Seed(7),
+    seed: Seed = _SEED,
 ) -> _State:
     return SimulationState[SegmentState, ParticipantState, _Action](
         step_index=step_index,
@@ -103,7 +105,7 @@ def _make_action(suffix: str) -> _Action:
 
 def test_review_loop_runner_with_zero_retries_matches_scenario_runner() -> None:
     initial = _make_state(step_index=0, pending=())
-    spec = _Spec(scenario_key="parity", seed=Seed(7), initial=initial)
+    spec = _Spec(scenario_key="parity", seed=_SEED, initial=initial)
     agent = _RecordingAgent(agent_id="agent-1", proposals_to_emit=(_make_action("x"),))
     resolver = _RecordingResolver()
     scenario_runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=3)
@@ -111,6 +113,44 @@ def test_review_loop_runner_with_zero_retries_matches_scenario_runner() -> None:
         agents=(agent,),
         resolver=resolver,
         max_steps=3,
+        critic=_AcceptingCritic(),
+        reviser=_PassThroughReviser(),
+        policy=CorrectionPolicy(max_retries=0, min_score=0.0, on_fail="stop"),
+    )
+
+    assert review_runner.run(spec) == scenario_runner.run(spec)
+
+
+def test_review_loop_runner_matches_scenario_runner_when_no_proposals_and_recorder_enabled() -> None:
+    initial = _make_state(step_index=0, pending=())
+    spec = _Spec(scenario_key="parity-empty", seed=_SEED, initial=initial)
+    agent = _RecordingAgent(agent_id="agent-1", proposals_to_emit=())
+    resolver = _RecordingResolver()
+    recorder = TraceRecorder(store=MemoryTraceStore(), seed=_SEED, run_id="review-parity-empty")
+    scenario_runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=3, recorder=recorder)
+    review_runner = ReviewLoopRunner(
+        agents=(agent,),
+        resolver=resolver,
+        max_steps=3,
+        critic=_AcceptingCritic(),
+        reviser=_PassThroughReviser(),
+        policy=CorrectionPolicy(max_retries=0, min_score=0.0, on_fail="stop"),
+        recorder=recorder,
+    )
+
+    assert review_runner.run(spec) == scenario_runner.run(spec)
+
+
+def test_review_loop_runner_matches_scenario_runner_when_max_steps_is_zero() -> None:
+    initial = _make_state(step_index=0, pending=())
+    spec = _Spec(scenario_key="parity-zero", seed=_SEED, initial=initial)
+    agent = _RecordingAgent(agent_id="agent-1", proposals_to_emit=(_make_action("x"),))
+    resolver = _RecordingResolver()
+    scenario_runner = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=0)
+    review_runner = ReviewLoopRunner(
+        agents=(agent,),
+        resolver=resolver,
+        max_steps=0,
         critic=_AcceptingCritic(),
         reviser=_PassThroughReviser(),
         policy=CorrectionPolicy(max_retries=0, min_score=0.0, on_fail="stop"),

--- a/tests/review/test_policy.py
+++ b/tests/review/test_policy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 
 import pytest
 
@@ -41,7 +41,7 @@ def test_correction_policy_accepts_valid_inputs() -> None:
 @pytest.mark.parametrize("value", [-1, True])
 def test_correction_policy_rejects_invalid_max_retries(value: object) -> None:
     with pytest.raises((TypeError, ValueError)):
-        CorrectionPolicy(max_retries=value, min_score=0.5, on_fail="stop")
+        CorrectionPolicy(max_retries=cast(int, value), min_score=0.5, on_fail="stop")
 
 
 @pytest.mark.parametrize("value", [-0.1, 1.1, float("nan"), float("inf")])
@@ -52,4 +52,8 @@ def test_correction_policy_rejects_invalid_min_score(value: float) -> None:
 
 def test_correction_policy_rejects_unknown_on_fail_mode() -> None:
     with pytest.raises(ValueError):
-        CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="unknown")
+        CorrectionPolicy(
+            max_retries=1,
+            min_score=0.5,
+            on_fail=cast(Literal["rollback", "revise", "stop"], cast(object, "unknown")),
+        )

--- a/tests/review/test_policy.py
+++ b/tests/review/test_policy.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol, cast
+
+import pytest
+
+from abdp.review.policy import CorrectionPolicy
+
+
+class _DataclassParams(Protocol):
+    frozen: bool
+
+
+def test_correction_policy_is_frozen_slot_backed_dataclass() -> None:
+    params = cast(_DataclassParams, object.__getattribute__(CorrectionPolicy, "__dataclass_params__"))
+
+    assert dataclasses.is_dataclass(CorrectionPolicy)
+    assert params.frozen is True
+    assert "__slots__" in CorrectionPolicy.__dict__
+
+
+def test_correction_policy_declares_expected_fields() -> None:
+    fields = {field.name: field.type for field in dataclasses.fields(CorrectionPolicy)}
+
+    assert fields == {
+        "max_retries": int,
+        "min_score": float,
+        "on_fail": "Literal['rollback', 'revise', 'stop']",
+    }
+
+
+def test_correction_policy_accepts_valid_inputs() -> None:
+    policy = CorrectionPolicy(max_retries=2, min_score=0.75, on_fail="revise")
+
+    assert policy.max_retries == 2
+    assert policy.min_score == 0.75
+    assert policy.on_fail == "revise"
+
+
+@pytest.mark.parametrize("value", [-1, True])
+def test_correction_policy_rejects_invalid_max_retries(value: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        CorrectionPolicy(max_retries=value, min_score=0.5, on_fail="stop")
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, float("nan"), float("inf")])
+def test_correction_policy_rejects_invalid_min_score(value: float) -> None:
+    with pytest.raises(ValueError):
+        CorrectionPolicy(max_retries=1, min_score=value, on_fail="rollback")
+
+
+def test_correction_policy_rejects_unknown_on_fail_mode() -> None:
+    with pytest.raises(ValueError):
+        CorrectionPolicy(max_retries=1, min_score=0.5, on_fail="unknown")

--- a/tests/review/test_protocols.py
+++ b/tests/review/test_protocols.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeVar, get_args, get_origin, get_type_hints
+
+from abdp.review.attempt import ReviewAttempt, ReviewDecision
+from abdp.review.critic import Critic
+from abdp.review.reviser import Reviser
+from abdp.scenario import ScenarioStep
+
+
+class _ValidCritic:
+    def evaluate(self, step: ScenarioStep) -> ReviewDecision:
+        raise NotImplementedError
+
+
+class _MissingCriticMethod:
+    pass
+
+
+class _IdentityOnlyCritic:
+    def evaluate(self, step: object) -> object:
+        return object()
+
+
+@dataclass(frozen=True, slots=True)
+class _Action:
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: None
+
+
+class _ValidReviser:
+    def revise(self, attempt: ReviewAttempt[_Action]) -> tuple[_Action, ...]:
+        raise NotImplementedError
+
+
+class _MissingReviserMethod:
+    pass
+
+
+class _IdentityOnlyReviser:
+    def revise(self, attempt: object) -> object:
+        return ()
+
+
+def test_critic_is_generic_runtime_checkable_protocol() -> None:
+    assert getattr(Critic, "_is_protocol", False) is True
+    assert getattr(Critic, "_is_runtime_protocol", False) is True
+    assert tuple(param.__name__ for param in Critic.__type_params__) == ("S", "P", "A")
+
+
+def test_critic_declares_expected_signature() -> None:
+    hints = get_type_hints(Critic.evaluate)
+
+    assert get_origin(hints["step"]) is ScenarioStep
+    assert get_args(hints["return"]) == ()
+    assert hints["return"] is ReviewDecision
+
+
+def test_critic_runtime_checkable_accepts_structural_impl() -> None:
+    assert isinstance(_ValidCritic(), Critic) is True
+
+
+def test_critic_runtime_checkable_rejects_missing_method() -> None:
+    assert isinstance(_MissingCriticMethod(), Critic) is False
+
+
+def test_critic_runtime_check_only_guards_method_identity() -> None:
+    assert isinstance(_IdentityOnlyCritic(), Critic) is True
+
+
+def test_reviser_is_generic_runtime_checkable_protocol() -> None:
+    assert getattr(Reviser, "_is_protocol", False) is True
+    assert getattr(Reviser, "_is_runtime_protocol", False) is True
+    assert len(Reviser.__type_params__) == 1
+    assert isinstance(Reviser.__type_params__[0], TypeVar)
+    assert Reviser.__type_params__[0].__name__ == "A"
+
+
+def test_reviser_declares_expected_signature() -> None:
+    hints = get_type_hints(Reviser.revise)
+
+    assert get_origin(hints["attempt"]) is ReviewAttempt
+    assert get_origin(hints["return"]) is tuple
+    assert get_args(hints["return"]) == (Reviser.__type_params__[0], Ellipsis)
+
+
+def test_reviser_runtime_checkable_accepts_structural_impl() -> None:
+    assert isinstance(_ValidReviser(), Reviser) is True
+
+
+def test_reviser_runtime_checkable_rejects_missing_method() -> None:
+    assert isinstance(_MissingReviserMethod(), Reviser) is False
+
+
+def test_reviser_runtime_check_only_guards_method_identity() -> None:
+    assert isinstance(_IdentityOnlyReviser(), Reviser) is True

--- a/tests/review/test_protocols.py
+++ b/tests/review/test_protocols.py
@@ -7,10 +7,11 @@ from abdp.review.attempt import ReviewAttempt, ReviewDecision
 from abdp.review.critic import Critic
 from abdp.review.reviser import Reviser
 from abdp.scenario import ScenarioStep
+from abdp.simulation import ActionProposal, ParticipantState, SegmentState
 
 
 class _ValidCritic:
-    def evaluate(self, step: ScenarioStep) -> ReviewDecision:
+    def evaluate(self, step: ScenarioStep[SegmentState, ParticipantState, ActionProposal]) -> ReviewDecision:
         raise NotImplementedError
 
 


### PR DESCRIPTION
Closes #173.

## Summary
- add the new abdp.review package with CorrectionPolicy, ReviewAttempt/ReviewDecision/ReviewTrace, Critic/Reviser protocols, and a cyclic ReviewLoopRunner
- keep rejected review attempts on the inspector plane only while preserving deterministic canonical ScenarioRun parity, retry rollback semantics, and stable trace identities
- document the review surface in docs/review.md and wire the docs index to the new guide

## TDD evidence
- RED/GREEN1: CorrectionPolicy invariants -> policy surface
- RED/GREEN2: review attempt dataclass shape -> attempt models
- RED/GREEN3: critic/reviser protocol contracts -> protocol implementations
- RED/GREEN4: zero-retry parity -> minimal ReviewLoopRunner path
- RED/GREEN5: correction flow/on_fail modes -> full retry loop
- RED/GREEN6: deterministic trace identity -> stable recorder run-id derivation
- RED/GREEN7: two-plane isolation -> stop/rollback isolation semantics + docs

## Verification
- python -m pytest -q
- ruff check .
- ruff format --check .
- mypy --strict --config-file mypy.ini src/abdp tests

## Mutmut policy
- N/A